### PR TITLE
Reduce opacity in loading border glow gradient animation

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -95,11 +95,11 @@ body, .theme-surface {
   border-radius: inherit;
   background: linear-gradient(
     90deg,
-    rgba(34, 197, 94, 0.1) 0%,
-    rgba(34, 197, 94, 0.6) 25%,
-    rgba(74, 222, 128, 0.8) 50%,
-    rgba(34, 197, 94, 0.6) 75%,
-    rgba(34, 197, 94, 0.1) 100%
+    rgba(34, 197, 94, 0.08) 0%,
+    rgba(34, 197, 94, 0.4) 25%,
+    rgba(74, 222, 128, 0.55) 50%,
+    rgba(34, 197, 94, 0.4) 75%,
+    rgba(34, 197, 94, 0.08) 100%
   );
   background-size: 200% 100%;
   animation: loading-border-glow 1.5s ease-in-out infinite;


### PR DESCRIPTION
## Description
Adjusted the opacity values in the loading border glow gradient animation to create a more subtle visual effect. Reduced the maximum opacity from 0.6-0.8 to 0.4-0.55, and the minimum opacity from 0.1 to 0.08, resulting in a less intense glow animation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable)
- [x] Tested locally

## Test Plan
Verified the loading animation displays with the updated opacity values and appears more subtle than before.

https://claude.ai/code/session_017SrMsHd5kyFvEEiRDA6mrL