### PR TITLE
Fix __dirname crash in Electron ESM main process

package.json has "type": "module", so dist-electron/main.js runs as ESM
where __dirname is not available. Replace with the ESM equivalent:
fileURLToPath(import.meta.url) + path.dirname().

This was the root cause of the Electron app crash on startup
(including Chromebook/Crostini .deb installs).

https://claude.ai/code/session_01E6KDKY9vYFDJXzTCqhAqM3

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,10 @@
 import { app, BrowserWindow, shell } from 'electron';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
+
+// ESM does not provide __dirname — derive it from import.meta.url
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Fallback to software rendering when GPU is unavailable
 // (e.g. Chromebook/Crostini, VMs, headless Linux containers)


### PR DESCRIPTION
## Description
Brief description of the changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable)
- [ ] Tested locally

## Related Issues
Fixes #(issue number)
