### PR TITLE
Add dedicated Chromebook .deb release with --no-sandbox

Chromebook/Crostini requires --no-sandbox because Chrome's SUID sandbox
is not available inside the Linux container (which is already sandboxed).
Also adds --ozone-platform-hint=auto for Wayland/X11 auto-detection.

- New electron-builder.chromebook.json with executableArgs in .desktop file
- Separate output dir (release-chromebook/) to avoid conflicts
- Artifact named TubeTrend-<version>-Chromebook.deb
- CI builds Chromebook .deb on Linux runner alongside regular build
- Updated README with Chromebook install instructions

https://claude.ai/code/session_01E6KDKY9vYFDJXzTCqhAqM3

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -101,6 +101,21 @@ jobs:
             release/latest*.yml
           if-no-files-found: warn
 
+      - name: Build Chromebook .deb
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: npx electron-builder --config electron-builder.chromebook.json --linux --publish never -c.extraMetadata.version="${{ needs.prepare.outputs.build_version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Chromebook artifact
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@v6
+        with:
+          name: tubetrend-chromebook
+          path: release-chromebook/*.deb
+          if-no-files-found: warn
+
   release:
     needs: [prepare, build]
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ tubetrend/
 │   ├── main.ts                      # Main process: BrowserWindow, app lifecycle
 │   └── preload.ts                   # Preload script: contextBridge API exposure
 ├── electron-builder.json            # Electron packaging config (Win/Mac/Linux)
+├── electron-builder.chromebook.json # Chromebook .deb config (--no-sandbox, Ozone auto-detect)
 ├── build/                            # Build resources
 │   └── icon.png                     # App icon (512x512, generated via npm run electron:icon)
 ├── scripts/                          # Build/utility scripts
@@ -528,6 +529,7 @@ npm test
 - **External links** — Opened in system browser via `shell.openExternal()`, not in Electron window
 - **Dev mode** — `npm run electron:dev` sets `ELECTRON=true` which activates `vite-plugin-electron`; the plugin sets `VITE_DEV_SERVER_URL` env var; Electron loads the dev server URL in dev, `dist/index.html` in production
 - **Packaging** — `electron-builder` creates platform-specific installers (Windows NSIS/portable, macOS DMG, Linux AppImage) in `release/`. Config in `electron-builder.json` references `dist/**/*` + `dist-electron/**/*`.
+- **Chromebook release** — A separate `electron-builder.chromebook.json` builds a Chromebook-optimized `.deb` into `release-chromebook/`. It adds `--no-sandbox` (required for Crostini's container sandbox) and `--ozone-platform-hint=auto` (Wayland/X11 auto-detection) via `executableArgs` in the `.desktop` file. Artifact name: `TubeTrend-<version>-Chromebook.deb`.
 - **App icon** — Generated via `npm run electron:icon` (`scripts/generate-icon.mjs`), outputs `build/icon.png` (512x512)
 - **Requires internet** — YouTube Data API calls require internet; Tailwind CSS and fonts are bundled locally
 - **CI/CD** — `electron-release.yml` workflow builds for all platforms on version tags (`v*`), creates GitHub Release with `--generate-release-notes`. Uses `env: ELECTRON: 'true'` on the build step for cross-platform compatibility.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ For a quick preview without packaging:
 npm run electron:preview
 ```
 
+**Chromebook (ChromeOS / Crostini):** Download the `TubeTrend-*-Chromebook.deb` from [Releases](https://github.com/fo0/tubetrend/releases). This build includes `--no-sandbox` and Wayland auto-detection flags required for Crostini's Linux container. Install via:
+
+```bash
+sudo dpkg -i TubeTrend-*-Chromebook.deb
+```
+
 ### Option 4: Run from Source
 
 **Prerequisites:** Node.js v22+

--- a/electron-builder.chromebook.json
+++ b/electron-builder.chromebook.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
+  "appId": "com.tubetrend.app",
+  "productName": "TubeTrend",
+  "icon": "build/icon.png",
+  "directories": {
+    "output": "release-chromebook"
+  },
+  "files": [
+    "dist/**/*",
+    "dist-electron/**/*",
+    "package.json"
+  ],
+  "linux": {
+    "target": [
+      "deb"
+    ],
+    "category": "Utility",
+    "executableArgs": [
+      "--no-sandbox",
+      "--ozone-platform-hint=auto"
+    ]
+  },
+  "artifactName": "TubeTrend-${version}-Chromebook.${ext}"
+}


### PR DESCRIPTION
## Description
Brief description of the changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable)
- [ ] Tested locally

## Related Issues
Fixes #(issue number)
