### PR TITLE
chore(deps): merge 6 conflict-free Dependabot PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/android": "^8.1.0",
-        "@capacitor/core": "^8.1.0",
+        "@capacitor/android": "^8.3.0",
+        "@capacitor/core": "^8.3.0",
         "@fontsource/inter": "^5.2.8",
-        "i18next": "^26.0.1",
+        "i18next": "^26.0.3",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^1.7.0",
         "react": "^19.2.0",
@@ -22,17 +22,17 @@
       "devDependencies": {
         "@capacitor/cli": "^8.3.0",
         "@tailwindcss/vite": "^4.2.2",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.5.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.0.0",
-        "electron": "^41.1.0",
+        "electron": "^41.1.1",
         "electron-builder": "^26.8.1",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "vite": "^7.3.1",
-        "vite-plugin-electron": "^0.29.0"
+        "vite-plugin-electron": "^0.29.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -327,12 +327,12 @@
       }
     },
     "node_modules/@capacitor/android": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.1.0.tgz",
-      "integrity": "sha512-z0acTPxj5DCy/U2FU7w+GA93oC+wdyKnsOcRg5rutDmSYa8Do1tzYqApKgf+hnuTNPbtrCTHp0Zy1cLiK/4MEw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.0.tgz",
+      "integrity": "sha512-EQy6ByUuKayQBJmMm/e0byJiHavqsQHrvW23BuT2GNVQvenAvipqwaePiJHzrv2PZr7A0T0+se4kgDCeROj0mQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^8.1.0"
+        "@capacitor/core": "^8.3.0"
       }
     },
     "node_modules/@capacitor/cli": {
@@ -495,9 +495,9 @@
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.1.0.tgz",
-      "integrity": "sha512-UfMBMWc1v7J+14AhH03QmeNwV3HZx3qnOWhpwnHfzALEwAwlV/itQOQqcasMQYhOHWL0tiymc5ByaLTn7KKQxw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.0.tgz",
+      "integrity": "sha512-S4ajn4G/fS3VJj8salxqH/3LO5PPWv1VxGKQ27OCajnDcLJjEg9VXwgMPnlypgkIOqCJ2fmQLtk8GT+BlI9/rw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2661,9 +2661,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4224,9 +4224,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.0.tgz",
-      "integrity": "sha512-0XRFyxRqetmqtkkBvV++wGbHYJ7bD++f6EgJW8y9kX4pPRagwlmKDtzqXZhKiu0DIQppm3sXxzHWK9GYP91OKQ==",
+      "version": "41.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
+      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5224,9 +5224,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.1.tgz",
-      "integrity": "sha512-vtz5sXU4+nkCm8yEU+JJ6yYIx0mkg9e68W0G0PXpnOsmzLajNsW5o28DJMqbajxfsfq0gV3XdrBudsDQnwxfsQ==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
+      "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
       "funding": [
         {
           "type": "individual",
@@ -7872,9 +7872,9 @@
       }
     },
     "node_modules/vite-plugin-electron": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.29.0.tgz",
-      "integrity": "sha512-HP0DI9Shg41hzt55IKYVnbrChWXHX95QtsEQfM+szQBpWjVhVGMlqRjVco6ebfQjWNr+Ga+PeoBjMIl8zMaufw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.29.1.tgz",
+      "integrity": "sha512-AejNed5BgHFnuw8h5puTa61C6vdP4ydbsbo/uVjH1fTdHAlCDz1+o6pDQ/scQj1udDrGvH01+vTbzQh/vMnR9w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "build:extension": "vite build && node scripts/build-extension.mjs"
   },
   "dependencies": {
-    "@capacitor/android": "^8.1.0",
-    "@capacitor/core": "^8.1.0",
+    "@capacitor/android": "^8.3.0",
+    "@capacitor/core": "^8.3.0",
     "@fontsource/inter": "^5.2.8",
-    "i18next": "^26.0.1",
+    "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.7.0",
     "react": "^19.2.0",
@@ -53,16 +53,16 @@
   "devDependencies": {
     "@capacitor/cli": "^8.3.0",
     "@tailwindcss/vite": "^4.2.2",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.5.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.0",
-    "electron": "^41.1.0",
+    "electron": "^41.1.1",
     "electron-builder": "^26.8.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "vite": "^7.3.1",
-    "vite-plugin-electron": "^0.29.0"
+    "vite-plugin-electron": "^0.29.1"
   }
 }


### PR DESCRIPTION
## Summary
Closes #64

Squash-merges 6 safe, conflict-free Dependabot PRs into a single branch:

### npm patches (4)
- `@types/node` 25.5.0 → 25.5.2 (#60)
- `vite-plugin-electron` 0.29.0 → 0.29.1 (#61)
- `electron` 41.1.0 → 41.1.1 (#59)
- `i18next` 26.0.1 → 26.0.3 (#56)

### npm minors (2)
- `@capacitor/core` 8.1.0 → 8.3.0 (#62)
- `@capacitor/android` 8.1.0 → 8.3.0 (#55)

### GitHub Actions (3) — need separate merge
The following PRs modify `.github/workflows/` files and require the `workflow` token scope to push. They should be merged individually via the GitHub UI:
- `docker/metadata-action` v5 → v6 (#53)
- `android-actions/setup-android` v3 → v4 (#52)
- `docker/login-action` v3 → v4 (#51)

### Skipped (major version bumps — require individual review)
- `typescript` 5.9.3 → 6.0.2 (#54) — major: stricter type checking
- `vite` 7.3.1 → 8.0.3 (#57) — major: plugin API changes
- `@vitejs/plugin-react` 5.1.4 → 6.0.1 (#58) — major: requires Vite 8
- `react-i18next` 16.5.4 → 17.0.2 (#63) — major: potential API changes

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [ ] CI checks pass (pr-checks workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)