### PR TITLE
GitNexus Code Review Runde 2/3: subtle re-render & event-bus consistency

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,6 +17,7 @@ import type {FavoriteConfig} from '@/src/features/favorites/types';
 import type {VideoData} from '@/src/features/videos/types';
 import type {SearchType, TimeFrame} from '@/src/shared/types';
 import {STORAGE_KEYS} from '@/src/shared/constants';
+import {dispatchEvent} from '@/src/shared/lib/eventBus';
 
 const App: React.FC = () => {
   const { t } = useTranslation();
@@ -45,13 +46,14 @@ const App: React.FC = () => {
   const { sortMode, sortOrder, cacheTick, handleSortClick, sortFavorites } = useDashboardSort();
   const { hiddenTick } = useHighlights(favorites);
 
-  const { searchState, handleSearch, setSearchResult } = useSearch(apiKey, {
-    onApiKeyInvalid: () => {
-      setYoutubeApiKey('');
-      setApiKey(null);
-      setIsApiKeyModalOpen(true);
-    },
-  });
+  const onApiKeyInvalid = useCallback(() => {
+    setYoutubeApiKey('');
+    setApiKey(null);
+    setIsApiKeyModalOpen(true);
+  }, []);
+
+  const searchOptions = useMemo(() => ({ onApiKeyInvalid }), [onApiKeyInvalid]);
+  const { searchState, handleSearch, setSearchResult } = useSearch(apiKey, searchOptions);
 
   // Sorted favorites
   const sortedFavorites = useMemo(() => sortFavorites(favorites), [favorites, sortFavorites]);
@@ -138,12 +140,7 @@ const App: React.FC = () => {
     }
 
     loadFavorites();
-
-    try {
-      window.dispatchEvent(new CustomEvent('favorites-cache-updated', { detail: { id: '*' } }));
-    } catch {
-      // ignore
-    }
+    dispatchEvent('favorites-cache-updated', { id: '*' });
 
     window.alert(t('backup.importSuccess', { count }));
   }, [loadFavorites, t]);

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import type {ChannelSuggestion} from '@/src/shared/types';
 import {coerceTimeFrame, SearchType, TimeFrame} from '@/src/shared/types';
-import {MAX_RESULTS_OPTIONS, TIME_FRAMES} from '@/src/shared/constants';
+import {MAX_RESULTS_OPTIONS, STORAGE_KEYS, TIME_FRAMES} from '@/src/shared/constants';
 import {Hash, History, Link2, ListFilter, Loader2, Search, Star, X} from 'lucide-react';
 import {Youtube} from '@/src/shared/components/ui/BrandIcons';
 import {extractChannelIdentifier, searchChannels} from '@/src/features/youtube';
@@ -81,11 +81,11 @@ export const InputSection: React.FC<InputSectionProps> = ({
   // Load last selected timeframe and max results from localStorage once
   useEffect(() => {
     try {
-      const tf = localStorage.getItem('tt.search.timeframe');
+      const tf = localStorage.getItem(STORAGE_KEYS.SEARCH_TIMEFRAME);
       if (tf) {
         setTimeFrame(coerceTimeFrame(tf));
       }
-      const mr = localStorage.getItem('tt.search.maxResults');
+      const mr = localStorage.getItem(STORAGE_KEYS.SEARCH_MAX_RESULTS);
       if (mr) {
         const n = parseInt(mr, 10);
         if (!Number.isNaN(n)) {
@@ -122,8 +122,8 @@ export const InputSection: React.FC<InputSectionProps> = ({
   // Persist timeframe and maxResults on change
   useEffect(() => {
     try {
-      localStorage.setItem('tt.search.timeframe', timeFrame);
-      localStorage.setItem('tt.search.maxResults', String(maxResults));
+      localStorage.setItem(STORAGE_KEYS.SEARCH_TIMEFRAME, timeFrame);
+      localStorage.setItem(STORAGE_KEYS.SEARCH_MAX_RESULTS, String(maxResults));
     } catch (e) {
       // ignore storage errors
     }
@@ -132,7 +132,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
   // Load history from storage once
   useEffect(() => {
     try {
-      const raw = localStorage.getItem('tt.search.history');
+      const raw = localStorage.getItem(STORAGE_KEYS.SEARCH_HISTORY);
       if (raw) {
         const parsed = JSON.parse(raw);
         if (Array.isArray(parsed)) setHistory(parsed.filter((x) => typeof x === 'string'));
@@ -156,7 +156,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 
   const persistHistory = (next: string[]) => {
     try {
-      localStorage.setItem('tt.search.history', JSON.stringify(next));
+      localStorage.setItem(STORAGE_KEYS.SEARCH_HISTORY, JSON.stringify(next));
     } catch (e) {
       // ignore
     }


### PR DESCRIPTION
Closes #87
Part of #84

## Summary

Zweite Runde des 3-Runden GitNexus Code Reviews. Fokus auf subtile Issues und mögliche Regressionen aus Runde 1: Re-Render-Cascades und EventBus-Inkonsistenzen.

## Findings & Fixes

| # | Sev | Datei | Finding | Fix |
|---|-----|-------|---------|-----|
| 1 | P1 | `src/app/App.tsx` | `useSearch()` bekam pro Render ein neues `options`-Objekt — `useCallback` für `handleSearch` invalidierte daher pro Render, was via `handleAnalyzeFavorite` → `FavoriteRow` als unnötige Re-Renders durchschlug | `onApiKeyInvalid` in `useCallback`, `searchOptions` in `useMemo` |
| 2 | P1 | `src/app/App.tsx:142` | `handleDashboardImportFile` feuerte `favorites-cache-updated` per raw `window.dispatchEvent`, umging damit den typed `eventBus` — Subscriber via `useEventBus` wurden nie informiert | `dispatchEvent('favorites-cache-updated', { id: '*' })` aus `eventBus`-Helper |
| 3 | P1 | `src/shared/components/ui/InputSection.tsx` | 4× hardcoded localStorage-Key-Literale (`tt.search.timeframe`, `tt.search.maxResults`, `tt.search.history`) duplizierten `STORAGE_KEYS.SEARCH_*` aus zentraler Config | Konstanten aus `@/src/shared/constants` importieren |

## Open / Deferred (Runde 3)

- `useDashboard.ts:195` — hardcoded `'de'`-Locale in `localeCompare`
- `ApiQuotaIndicator.tsx` — hardcoded deutsche Labels (`'30 Min.'`, `'1 Std.'` etc.) und `'de-DE'` in `toLocaleString`
- `FavoriteRow.tsx:144-173` und `useDashboard.ts:52,139,219` — raw `window.addEventListener` statt `useEventBus`-Hook
- `searchService.ts` / `channelService.ts` — duplizierter ISO 8601 Duration Parser
- `searchService.ts:320` `Math.max(effectiveMax, 50)` — wirft fetched-aber-verworfene Videos weg
- bekannte CLAUDE.md-Refactoring-Notizen (FavoriteRow God-Component, Module-Level API-Key) — Out of Scope

## GitNexus

- Index re-analysiert: 1328 Symbols, 2122 Edges, 100 Processes
- `detect_changes`: 4 changed files (2 src + 2 tooling-managed CLAUDE.md/.gitignore), Risk \"high\" prozessbasiert, signaturerhaltend

## Test plan

- [x] `npx tsc --noEmit` grün
- [x] `npm run build` grün (375.24 kB)
- [ ] Manueller Smoke-Test: Dashboard-Import löst FavoriteRow-Cache-Refresh aus
- [ ] Manueller Smoke-Test: keine sichtbaren UI-Regressionen durch stabilere `handleSearch`-Identität

🤖 Generated with [Claude Code](https://claude.com/claude-code)