### PR TITLE
chore(deps): ignore eslint major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Prophylaktisch: ESLint 10 brach in den Schwester-Repos die Plugin-Chain (peer-dep `^8 || ^9` in eslint-config-next, neue ESLint-10-API entfernt `getFilename`). Auch wenn dieses Repo aktuell keinen direkten eslint nutzt — Ignore vereinheitlicht die dependabot-Configs fleet-weit.

---
_Generated by [Claude Code](https://claude.ai/code/session_019uYsxPAYctqm3sX1RGW1HX)_