### PR TITLE
chore(deps): revert dependabot to plain config (no groups)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,26 +6,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     ignore:
+      # eslint major: peer-dep conflicts (eslint-config-next still pins ^9)
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+      # electron major: needs manual migration
       - dependency-name: "electron"
         update-types: ["version-update:semver-major"]
-    groups:
-      minor-and-patch:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-      security:
-        applies-to: security-updates
-        patterns:
-          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    groups:
-      actions:
-        patterns:
-          - "*"


### PR DESCRIPTION
Revert dependabot config to the pre-grouping plain layout. Groups produced bad bundles, so we go back to one PR per dependency.

Kept: `eslint` and `electron` major-version ignores.

Removed: `minor-and-patch` group, `security` group, `actions` group.

---
_Generated by [Claude Code](https://claude.ai/code/session_015BNnJdRjKBVyo8pMf8xAAX)_