### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -1,5 +1,5 @@
 import {useCallback, useState} from 'react';
-import type {SearchType, TimeFrame} from '@/src/shared/types';
+import type {SearchType, TimeFrame, YouTubeVideoItem} from '@/src/shared/types';
 import {SearchType as ST} from '@/src/shared/types';
 import type {VideoData} from '@/src/features/videos/types';
 import {analyzeVideoStats} from '@/src/features/videos';
@@ -58,7 +58,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
       }));
 
       try {
-        let apiVideos: any[];
+        let apiVideos: YouTubeVideoItem[];
         let displayName: string;
         let channelId: string | undefined;
 

--- a/src/features/youtube/services/youtubeApiClient.ts
+++ b/src/features/youtube/services/youtubeApiClient.ts
@@ -38,7 +38,8 @@ export class YouTubeApiError extends Error {
 export async function fetchFromApi<T>(
   endpoint: Endpoint,
   params: Record<string, string>,
-  context?: QuotaCallContext
+  context?: QuotaCallContext,
+  signal?: AbortSignal
 ): Promise<T> {
   if (!API_KEY) {
     throw new YouTubeApiError('YouTube API Key fehlt.', 401);
@@ -49,7 +50,7 @@ export async function fetchFromApi<T>(
   Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
 
   const cost = API_COSTS[endpoint];
-  const response = await fetch(url.toString());
+  const response = await fetch(url.toString(), { signal });
   const data = await response.json();
 
   if (!response.ok) {

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import type {FavoriteConfig} from '@/src/features/favorites';
 import type {VideoData} from '@/src/features/videos';
 import {SearchType} from '@/src/shared/types';
-import type {TimeFrame} from '@/src/shared/types';
+import type {TimeFrame, YouTubeVideoItem} from '@/src/shared/types';
 import {favoritesService} from '@/src/features/favorites';
 import {analyzeVideoStats} from '@/src/features/videos';
 import {findChannelInfo, getChannelQueryType, getVideosFromChannel, searchVideosByKeyword} from '@/src/features/youtube';
@@ -233,7 +233,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
         if (cancelled) return;
       }
       try {
-        let apiVideos: any[];
+        let apiVideos: YouTubeVideoItem[];
         let displayName: string;
         let fetchedChannelId: string | undefined;
         let totalInTimeFrame: number;

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -13,7 +13,7 @@ import {useTranslation} from 'react-i18next';
 // - If VITE_DEFAULT_SEARCH is set, use that value.
 // - Else: in dev mode default to 'TEDx', in prod default to empty string.
 const DEFAULT_SEARCH_INPUT: string = (
-  (import.meta as any)?.env?.VITE_DEFAULT_SEARCH ?? (((import.meta as any)?.env?.DEV) ? 'TEDx' : '')
+  import.meta.env.VITE_DEFAULT_SEARCH ?? (import.meta.env.DEV ? 'TEDx' : '')
 );
 
 interface InputSectionProps {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_DEFAULT_SEARCH?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 interface BuildInfo {
   version: string;
   commitHash: string;


### PR DESCRIPTION
## Stack
Vite + React

## Gemergete Findings

| # | Datei | Kategorie | Fix | Impact |
|---|-------|-----------|-----|--------|
| 1 | `src/shared/components/ui/InputSection.tsx`, `src/vite-env.d.ts` | Correctness | `import.meta.env` direkt typisiert, `any`-Cast entfernt | mittel |
| 2 | `src/components/FavoriteRow.tsx`, `src/hooks/useSearch.ts` | Correctness | `any[]` durch `YouTubeVideoItem[]` ersetzt | mittel |
| 3 | `src/services/youtubeApiClient.ts` | Performance | `fetchFromApi` akzeptiert optionalen `AbortSignal` (Pass-Through, backward-compat) | mittel |

## Deferred dieses Sweeps
- Vollständiges AbortController-Wiring in `useSearch`/`FavoriteRow`-Cleanup-Handler — sprengt 3-Dateien-Budget.

Closes #120

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRi7oM71SkKx1qGujgBDbL)_