### PR TITLE
refactor: best-practice sweep round 2 (Vite + React)

### DIFF
--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -92,7 +92,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
           channelId,
         });
       } catch (err: any) {
-        console.error(err);
+        if (import.meta.env.DEV) console.error(err);
         const errorMessage = err?.message || 'Fehler bei der Analyse.';
 
         const isApiKeyInvalid =

--- a/src/features/youtube/services/youtubeApiClient.ts
+++ b/src/features/youtube/services/youtubeApiClient.ts
@@ -4,24 +4,22 @@ import {quotaService} from './quotaService';
 
 type Endpoint = keyof typeof API_COSTS;
 
-// Module-level API key storage
-let API_KEY = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEYS.API_KEY) || '' : '';
-
+// Single source of truth: localStorage. No module-level mirror to avoid drift
+// when the key is changed in another tab/window or by other code paths.
 export function setApiKey(key: string): void {
-  API_KEY = key;
-  if (typeof window !== 'undefined') {
-    if (key) {
-      localStorage.setItem(STORAGE_KEYS.API_KEY, key);
-    } else {
-      localStorage.removeItem(STORAGE_KEYS.API_KEY);
-      // Reset quota statistics when API key is deleted
-      quotaService.reset();
-    }
+  if (typeof window === 'undefined') return;
+  if (key) {
+    localStorage.setItem(STORAGE_KEYS.API_KEY, key);
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.API_KEY);
+    // Reset quota statistics when API key is deleted
+    quotaService.reset();
   }
 }
 
 export function getApiKey(): string {
-  return API_KEY;
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem(STORAGE_KEYS.API_KEY) || '';
 }
 
 export class YouTubeApiError extends Error {
@@ -41,12 +39,13 @@ export async function fetchFromApi<T>(
   context?: QuotaCallContext,
   signal?: AbortSignal
 ): Promise<T> {
-  if (!API_KEY) {
+  const apiKey = getApiKey();
+  if (!apiKey) {
     throw new YouTubeApiError('YouTube API Key fehlt.', 401);
   }
 
   const url = new URL(`https://www.googleapis.com/youtube/v3/${endpoint}`);
-  url.searchParams.append('key', API_KEY);
+  url.searchParams.append('key', apiKey);
   Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
 
   const cost = API_COSTS[endpoint];

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -175,6 +175,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
   useEffect(() => {
     let cancelled = false;
     let staggerTimeout: ReturnType<typeof setTimeout> | null = null;
+    let staggerReject: (() => void) | null = null;
 
     const load = async () => {
       setError(null);
@@ -226,7 +227,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
         await new Promise<void>((resolve, reject) => {
           staggerTimeout = setTimeout(resolve, staggerIndex * STAGGER_DELAY_MS);
           // Speichere reject-Funktion für sauberes Cleanup
-          (staggerTimeout as any).__reject = reject;
+          staggerReject = reject;
         }).catch(() => {
           // Timeout wurde abgebrochen - Ende-Event wird im Cleanup gesendet
         });
@@ -305,9 +306,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
       if (staggerTimeout) {
         clearTimeout(staggerTimeout);
         // Reject das Promise damit es nicht hängen bleibt
-        if ((staggerTimeout as any).__reject) {
-          (staggerTimeout as any).__reject();
-        }
+        staggerReject?.();
       }
       // Cleanup: Wenn Start-Event gesendet wurde aber noch kein End-Event, sende es jetzt
       if (dispatchedStartRef.current) {

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -210,7 +210,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
         setSuggestions(results);
         setShowSuggestions(true);
       } catch (err) {
-        console.error(err);
+        if (import.meta.env.DEV) console.error(err);
       } finally {
         setIsSearchingSuggestions(false);
       }


### PR DESCRIPTION
## Stack
Vite + React — Round 2

## Gemergete Findings

| Datei | Kategorie | Fix |
|-------|-----------|-----|
| `src/services/youtubeApiClient.ts` | Security | localStorage als Single Source — Modul-State entfernt |
| `InputSection.tsx`, `useSearch.ts` | Maintainability | `console.error` hinter `import.meta.env.DEV` gated |
| `FavoriteRow.tsx` | Maintainability | `setTimeout` mit typisiertem `ReturnType<typeof setTimeout>` statt `as any` |

## Deferred
- F3b AbortController-Wiring: end-to-end-Threading durch High-Level-Services >3 Dateien. Eigenes Ticket sinnvoll.

Closes #122

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRi7oM71SkKx1qGujgBDbL)_