### PR TITLE
refactor: best-practice sweep round 3 (Vite + React)

### DIFF
--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -75,8 +75,16 @@ export const InputSection: React.FC<InputSectionProps> = ({
   
   const wrapperRef = useRef<HTMLDivElement>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [justSaved, setJustSaved] = useState<boolean>(false);
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
+
+  // Clear save-feedback timer on unmount
+  useEffect(() => {
+    return () => {
+      if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
+    };
+  }, []);
 
   // Load last selected timeframe and max results from localStorage once
   useEffect(() => {
@@ -259,7 +267,8 @@ export const InputSection: React.FC<InputSectionProps> = ({
     favoritesService.add({ query, timeFrame, maxResults, searchType });
     // kurzes visuelles Feedback
     setJustSaved(true);
-    setTimeout(() => setJustSaved(false), 1500);
+    if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
+    justSavedTimerRef.current = setTimeout(() => setJustSaved(false), 1500);
     // Status aktualisieren
     try {
       const exists = favoritesService.exists(query, timeFrame, maxResults, searchType);

--- a/src/shared/components/ui/LanguageSwitcher.tsx
+++ b/src/shared/components/ui/LanguageSwitcher.tsx
@@ -41,7 +41,7 @@ function readExplicitLanguage(): ExplicitLang | null {
 
 function getSystemLanguage(): string {
   if (typeof navigator === 'undefined') return 'en';
-  const lang = navigator.language || (navigator as any).userLanguage || 'en';
+  const lang = navigator.language || 'en';
   const short = normalizeLangCode(lang);
   return (SUPPORTED as unknown as string[]).includes(short) ? short : 'en';
 }


### PR DESCRIPTION
## Stack
Vite + React 19 — Round 3

## Gemergte Findings

| # | Datei | Kategorie | Fix |
|---|-------|-----------|-----|
| 1 | `src/shared/components/ui/LanguageSwitcher.tsx` | Deprecation | `(navigator as any).userLanguage`-Fallback entfernt (IE-only) |
| 2 | `src/shared/components/ui/InputSection.tsx` | Correctness | Save-Feedback-Timer per Ref + Cleanup |

Closes #124

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJuWPE4MQBR9VLES1caAoy)_