### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/features/dashboard/services/dashboardBackupService.ts
+++ b/src/features/dashboard/services/dashboardBackupService.ts
@@ -69,6 +69,17 @@ export const dashboardBackupService = {
         return { ok: false, payload: parsed };
       }
 
+      // favoritesCache must be a plain object (Record<string, FavoriteCacheEntry>).
+      // Without this guard, importing a malformed backup writes `"undefined"` to
+      // localStorage via JSON.stringify(undefined) and corrupts the cache on next read.
+      if (
+        typeof parsed.data.favoritesCache !== 'object' ||
+        parsed.data.favoritesCache === null ||
+        Array.isArray(parsed.data.favoritesCache)
+      ) {
+        return { ok: false, payload: parsed };
+      }
+
       return { ok: true, payload: parsed as DashboardBackupPayload };
     } catch {
       return {

--- a/src/features/youtube/services/searchService.ts
+++ b/src/features/youtube/services/searchService.ts
@@ -52,7 +52,13 @@ export async function searchVideosByKeyword(
       break;
     }
 
-    const videoIds = searchData.items.map((item: any) => item.id.videoId);
+    // Search API can occasionally return items without `id.videoId` (e.g. if
+    // the response includes a non-video kind despite `type=video`). Filter
+    // falsy values to avoid pushing `undefined` into the IDs list, which
+    // would later corrupt the comma-joined `id` parameter to /videos.
+    const videoIds = searchData.items
+      .map((item: any) => item.id?.videoId)
+      .filter((id: unknown): id is string => typeof id === 'string' && id.length > 0);
     allVideoIds = [...allVideoIds, ...videoIds];
 
     nextPageToken = searchData.nextPageToken;

--- a/src/shared/components/ui/ApiKeyModal.tsx
+++ b/src/shared/components/ui/ApiKeyModal.tsx
@@ -82,7 +82,7 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
                       <a
                         href="https://console.cloud.google.com/marketplace/product/google/youtube.googleapis.com"
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener noreferrer"
                         className="text-indigo-500 dark:text-indigo-400 underline decoration-indigo-500/30 hover:text-indigo-400 inline-flex items-center gap-1"
                       >
                         {t('modal.apiKey.step1')}


### PR DESCRIPTION
## Summary

Drei kleine, äquivalenzerhaltende Best-Practice-Fixes (Security + Correctness). Verifikation grün: `tsc --noEmit` + `vite build`.

| # | Datei | Kategorie | Befund | Fix | Aufwand | Empfehlung | Status |
|---|-------|-----------|--------|-----|---------|------------|--------|
| 1 | `src/shared/components/ui/ApiKeyModal.tsx` | Security | Externer Link nur mit `rel="noreferrer"` (kein `noopener`) | `rel="noopener noreferrer"` | S | auto-fix | done |
| 2 | `src/features/dashboard/services/dashboardBackupService.ts` | Correctness | `parse()` validiert `favoritesCache` nicht — fehlerhafter Import schreibt `"undefined"` in localStorage | Typprüfung für Plain-Object ergänzt | S | auto-fix | done |
| 3 | `src/features/youtube/services/searchService.ts` | Correctness | Map auf `item.id.videoId` ohne Filter — `undefined` Werte zerstören späteren `.join(',')`-Batch-Call an /videos | Optional-Chain + `.filter(string)` | S | auto-fix | done |

## Test plan

- [x] `npx tsc --noEmit` — grün
- [x] `npm run build` — grün (Bundle-Delta vernachlässigbar: +0.04 KB gzip)
- [x] Manuelle Code-Review: alle drei Änderungen sind reine Äquivalenz/Defensiv-Härtung, keine Verhaltensänderung im Happy-Path.

Closes #130

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEoj7CwXeazgZfzRjhAQcP)_