### PR TITLE
ux: deferred S+M fixes — i18n keys + global focus-visible

### DIFF
--- a/index.css
+++ b/index.css
@@ -48,3 +48,23 @@ body, .theme-surface {
 .dark .fresh-green-border {
   box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.60);
 }
+
+/* ── Keyboard focus rings (WCAG 2.4.7) ───────────────────────────────────────
+   Show visible outlines only for keyboard navigation (not mouse clicks).
+   Uses :focus-visible to avoid the ring on mouse/touch interactions.
+   ─────────────────────────────────────────────────────────────────────────── */
+:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+button:focus-visible,
+[role="button"]:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 3px;
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -6,6 +6,7 @@
   },
   "actions": {
     "search": "Suchen",
+    "clearSearch": "Suche leeren",
     "resetApiKey": "API-Schlüssel löschen",
     "refreshAll": "Alle aktualisieren",
     "remove": "Entfernen",
@@ -13,6 +14,13 @@
     "analyze": "Analysieren",
     "importDashboard": "Importieren",
     "exportDashboard": "Exportieren"
+  },
+  "nav": {
+    "main": "Hauptnavigation"
+  },
+  "emptyState": {
+    "title": "Keine Ergebnisse",
+    "description": "Versuche andere Suchbegriffe oder Filter."
   },
   "labels": {
     "search": "Suche",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -6,6 +6,7 @@
   },
   "actions": {
     "search": "Search",
+    "clearSearch": "Clear search",
     "resetApiKey": "Delete API key",
     "refreshAll": "Refresh all",
     "remove": "Remove",
@@ -13,6 +14,13 @@
     "analyze": "Analyze",
     "importDashboard": "Import",
     "exportDashboard": "Export"
+  },
+  "nav": {
+    "main": "Main navigation"
+  },
+  "emptyState": {
+    "title": "No results",
+    "description": "Try different search terms or filters."
   },
   "labels": {
     "search": "Search",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -172,3 +172,23 @@ body, .theme-surface {
     transform: scale(0.98);
   }
 }
+
+/* ── Keyboard focus rings (WCAG 2.4.7) ───────────────────────────────────────
+   Show visible outlines only for keyboard navigation (not mouse clicks).
+   Uses :focus-visible to avoid the ring on mouse/touch interactions.
+   ─────────────────────────────────────────────────────────────────────────── */
+:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+button:focus-visible,
+[role="button"]:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 3px;
+}


### PR DESCRIPTION
## UX Deferred S+M Follow-up (2026-05-16)

| # | Finding | Effort | Datei(en) | Fix | Status |
|---|---------|--------|-----------|-----|--------|
| 1 | Fehlende i18n-Keys (`actions.clearSearch`, `nav.main`, `emptyState.title`, `emptyState.description`) | S | `src/i18n/locales/de.json`, `src/i18n/locales/en.json` | Keys in `actions`, neues `nav`-Objekt und neues `emptyState`-Objekt hinzugefügt, konsistent mit bestehendem Stil | implementiert |
| 2 | Globale `:focus-visible`-Ringe fehlen (WCAG 2.4.7) | M | `src/styles/index.css`, `index.css` | Globale `:focus-visible`-Regel + spezifische Regeln für interaktive Elemente (`button`, `[role="button"]`, `a`, `input`, `select`, `textarea`) mit blauem Outline (#3b82f6, 2px, offset 2px) ergänzt | implementiert |

## Commits
- `ux(microcopy): add missing i18n keys for clearSearch, nav, emptyState`
- `ux(visual): add global focus-visible ring (WCAG 2.4.7)`

## Übersprungene Findings
Keine — beide Findings vollständig implementiert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtoYy3Xy5NhPAq8iYBDbbk)_