### PR TITLE
ux: best-practice sweep 2026-05-17 (a11y fixes)

### DIFF
--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -82,6 +82,7 @@ export function Header({
             <>
               {apiKey && (
                 <button
+                  type="button"
                   onClick={onResetApiKey}
                   className="flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors
                              border-slate-300 text-slate-700 hover:bg-slate-100

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -268,7 +268,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
 
         const analyzed = await analyzeVideoStats(apiVideos, displayName, currentTimeFrame);
         const top6 = analyzed.sort((a, b) => b.trendingScore - a.trendingScore).slice(0, 6);
-        // Bestimme den höchsten Velocity‑Wert (Views pro Stunde) über alle analysierten Videos
+        // Bestimme den höchsten Velocity-Wert (Views pro Stunde) über alle analysierten Videos
         const topVelocityVph = analyzed.length > 0 
           ? analyzed.reduce((max, v) => {
               const vph = typeof v.viewsPerHour === 'number' && Number.isFinite(v.viewsPerHour) ? v.viewsPerHour : 0;
@@ -466,6 +466,8 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
               ref={tfButtonRef}
               type="button"
               onClick={() => { setShowTfMenu(v => !v); setShowMaxMenu(false); }}
+              aria-expanded={showTfMenu}
+              aria-haspopup="listbox"
               className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:bg-slate-200/70 dark:hover:bg-slate-700/70"
               title={t('favorites.changeTimeFrame')}
             >
@@ -496,6 +498,8 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
               ref={maxButtonRef}
               type="button"
               onClick={() => { setShowMaxMenu(v => !v); setShowTfMenu(false); }}
+              aria-expanded={showMaxMenu}
+              aria-haspopup="listbox"
               className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:bg-slate-200/70 dark:hover:bg-slate-700/70"
               title={t('favorites.changeMaxResults')}
             >
@@ -507,6 +511,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({ favorite, onRemove, on
                 title={t('favorites.overflowWarning', { total: totalInTimeFrame, shown: currentMax })}
               >
                 <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                <span className="sr-only">{t('favorites.overflowWarning', { total: totalInTimeFrame, shown: currentMax })}</span>
               </span>
             )}
             {showMaxMenu && (

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -46,10 +46,11 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                         target="_blank"
                         rel="noopener noreferrer"
                         className="relative w-24 h-14 shrink-0 rounded-md overflow-hidden bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 cursor-pointer"
+                        aria-label={video.title}
                       >
                         <img 
                           src={video.thumbnailUrl} 
-                          alt="" 
+                          alt={video.title} 
                           className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
                           loading="lazy"
                         />
@@ -98,6 +99,7 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                       rel="noopener noreferrer"
                       className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
                       title="Auf YouTube ansehen"
+                      aria-label={`${video.title} – auf YouTube ansehen`}
                     >
                       <ExternalLink className="w-4 h-4" />
                     </a>


### PR DESCRIPTION
Closes #139

## Summary

Five a11y findings fixed across 3 files, all severity S (≤15 LoC each):

- **VideoListTable**: Added `alt={video.title}` on thumbnail images and `aria-label` on both the thumbnail anchor and the icon-only YouTube link in the last column
- **FavoriteRow**: Added `aria-expanded` + `aria-haspopup="listbox"` to the timeframe and max-results popover trigger buttons; added `<span className="sr-only">` for the overflow-warning icon so screen-readers announce the warning text
- **Header**: Added missing `type="button"` to the Reset-API-Key settings button to prevent accidental form submission

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm run build` — ✓ built in 375ms (Vite+React)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VQjpBSdu2eJqx7QUxK6hMw)_