### PR TITLE
chore: Prettier follow-up (blame ignore + CI format:check)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier baseline reformat — see PR #143
+e5009c4933fc98d2743bfa4bfa1adee5192fcc43

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check Prettier formatting
+        run: npm run format:check
+
       - name: Run TypeScript type check
         run: npx tsc --noEmit
 


### PR DESCRIPTION
## Summary

Follow-up to the Prettier baseline rollout (#143):

- Add `.git-blame-ignore-revs` pointing at the reformat commit `e5009c4` so `git blame` skips the noise commit. Devs can opt in locally with `git config blame.ignoreRevsFile .git-blame-ignore-revs`.
- Add `npm run format:check` step to the `typecheck` job in `pr-checks.yml` (runs before `tsc --noEmit`). Enforces Prettier on every PR.

## Test plan

- [ ] `pr-checks.yml` typecheck job runs `format:check` successfully on this PR
- [ ] No YAML syntax breakage (validated locally)
- [ ] `.git-blame-ignore-revs` parses (one SHA, one comment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CNLeHa9BiJcK6UXdG9bt)_