### PR TITLE
feat: comfort sweep (Vite+React)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AlertCircle, Eye, List, Trophy } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { InputSection } from "@/src/shared/components/ui/InputSection";
@@ -8,6 +8,7 @@ import { EmptyState } from "@/src/shared/components/ui/EmptyState";
 import { useTranslation } from "react-i18next";
 import type { SearchType, TimeFrame } from "@/src/shared/types";
 import type { SearchState } from "@/src/features/search/hooks/useSearch";
+import { STORAGE_KEYS } from "@/src/shared/constants";
 
 interface AnalyserPageProps {
   searchState: SearchState;
@@ -29,8 +30,40 @@ interface AnalyserPageProps {
 export function AnalyserPage({ searchState, externalInputValues, onSearch }: AnalyserPageProps) {
   const { t } = useTranslation();
 
-  const [sortMode, setSortMode] = useState<"trend" | "views">("trend");
-  const [topN, setTopN] = useState<3 | 6>(6);
+  const [sortMode, setSortMode] = useState<"trend" | "views">(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.ANALYSER_SORT_MODE);
+      return stored === "views" ? "views" : "trend";
+    } catch {
+      return "trend";
+    }
+  });
+
+  const [topN, setTopN] = useState<3 | 6>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.ANALYSER_TOP_N);
+      return stored === "3" ? 3 : 6;
+    } catch {
+      return 6;
+    }
+  });
+
+  // Persist sortMode and topN changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ANALYSER_SORT_MODE, sortMode);
+    } catch {
+      // ignore storage errors
+    }
+  }, [sortMode]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ANALYSER_TOP_N, String(topN));
+    } catch {
+      // ignore storage errors
+    }
+  }, [topN]);
 
   const sortedVideos = useMemo(() => {
     if (!searchState.data) return [];

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -77,6 +77,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
   const [history, setHistory] = useState<string[]>([]);
   const [showHistory, setShowHistory] = useState(false);
 
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -88,6 +89,21 @@ export const InputSection: React.FC<InputSectionProps> = ({
     return () => {
       if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
     };
+  }, []);
+
+  // Global hotkey: press "/" to focus search input (when not already in an input/textarea)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
+        return;
+      }
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   // Load last selected timeframe and max results from localStorage once
@@ -350,6 +366,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
             </div>
 
             <input
+              ref={searchInputRef}
               type="text"
               id="searchInput"
               value={inputValue}
@@ -359,6 +376,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
               placeholder={t("input.searchPlaceholder")}
               disabled={isLoading}
               autoComplete="off"
+              title={t("input.searchPlaceholder") + " (Press / to focus)"}
             />
 
             {/* Loading Indicator or Clear Button */}

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Clock, ExternalLink } from "lucide-react";
+import { Check, Clock, Copy, ExternalLink } from "lucide-react";
 import { formatNumber } from "@/src/shared/lib/formatters";
 
 interface VideoListTableProps {
@@ -9,6 +9,15 @@ interface VideoListTableProps {
 }
 
 export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startIndex }) => {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const handleCopy = (video: VideoData) => {
+    navigator.clipboard.writeText(video.url).then(() => {
+      setCopiedId(video.id);
+      setTimeout(() => setCopiedId(null), 1500);
+    });
+  };
+
   const getScoreColor = (score: number) => {
     if (score >= 80) return "text-red-400 bg-red-400/10 border-red-400/20";
     if (score >= 50) return "text-amber-400 bg-amber-400/10 border-amber-400/20";
@@ -97,16 +106,31 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                     </span>
                   </td>
                   <td className="p-4 text-center">
-                    <a
-                      href={video.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
-                      title="Auf YouTube ansehen"
-                      aria-label={`${video.title} – auf YouTube ansehen`}
-                    >
-                      <ExternalLink className="w-4 h-4" />
-                    </a>
+                    <div className="flex items-center justify-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => handleCopy(video)}
+                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
+                        title="Copy video URL"
+                        aria-label={`Copy URL for ${video.title}`}
+                      >
+                        {copiedId === video.id ? (
+                          <Check className="w-4 h-4 text-green-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                      <a
+                        href={video.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
+                        title="Watch on YouTube"
+                        aria-label={`${video.title} – watch on YouTube`}
+                      >
+                        <ExternalLink className="w-4 h-4" />
+                      </a>
+                    </div>
                   </td>
                 </tr>
               );

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -17,6 +17,8 @@ export const STORAGE_KEYS = {
   SEARCH_HISTORY: "tt.search.history",
   LANGUAGE: "tt.lang.explicit",
   HIDDEN_HIGHLIGHTS: "tt.dashboard.hiddenHighlights.v1",
+  ANALYSER_SORT_MODE: "tt.analyser.sortMode",
+  ANALYSER_TOP_N: "tt.analyser.topN",
 } as const;
 
 export const CACHE_TTL = {


### PR DESCRIPTION
## Summary

- **Copy-to-clipboard button** added to every row in the video list table (`VideoListTable.tsx`) — one-click copy with a 1.5 s green check confirmation.
- **`/` keyboard shortcut** focuses the search input globally (`InputSection.tsx`) — follows the standard web convention (GitHub, YouTube), skips gracefully when cursor is already in an input.
- **Analyser preferences persisted** — sort mode (Trend/Views) and Top-N (3/6) are now saved to `localStorage` and restored on the next visit (`AnalyserPage.tsx`, `config.ts`).

| # | File(s) | Feature | Effort |
|---|---------|---------|--------|
| 1 | `VideoListTable.tsx` | Copy-to-clipboard for video URL | S |
| 2 | `InputSection.tsx` | `/` hotkey to focus search | S |
| 3 | `AnalyserPage.tsx`, `config.ts` | Persist sort mode + Top-N | S |

Closes #145

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_013aXy4qpHsqQM1MsxoiZXbp)_