### PR TITLE
refactor(types): narrow catch clauses + correct html lang

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -100,9 +100,9 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
           channelName: displayName,
           channelId,
         });
-      } catch (err: any) {
+      } catch (err: unknown) {
         if (import.meta.env.DEV) console.error(err);
-        const errorMessage = err?.message || "Fehler bei der Analyse.";
+        const errorMessage = err instanceof Error ? err.message : "Fehler bei der Analyse.";
 
         const isApiKeyInvalid =
           err instanceof YouTubeApiError && err.status === 403 && !err.isQuotaError;

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -316,8 +316,11 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
           channelTitle: displayName,
           channelId: fetchedChannelId,
         });
-      } catch (e: any) {
-        if (!cancelled) setError(e?.message || t("errors.favoriteLoad"));
+      } catch (e: unknown) {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : "";
+          setError(message || t("errors.favoriteLoad"));
+        }
       } finally {
         if (!cancelled) setLoading(false);
         // Globales Event: Ende des Refresh für diesen Favoriten (nur senden, wenn Start gesendet wurde)


### PR DESCRIPTION
Closes #147

## Summary
- Replace `catch (e: any)` with `catch (e: unknown)` + `instanceof Error` message extraction in `useSearch.ts` and `FavoriteRow.tsx`. Removes the two remaining implicit-`any` catches in the codebase and prevents reading arbitrary properties off non-Error throws.
- Change `<html lang="de">` to `lang="en"` to match i18n `fallbackLng`. The app supports 13 languages via browser detection; the hardcoded `"de"` misled assistive tech / SEO for non-DE users. i18next overrides this at runtime once it detects the user's locale.

## Equivalence
Error rendering is unchanged for `Error` instances. The codebase only throws `Error` (and the `YouTubeApiError extends Error` subclass), so `instanceof Error` covers every existing throw site. For the `useSearch` hook, the fallback German string (`"Fehler bei der Analyse."`) is preserved verbatim to keep this PR scoped — full i18n cleanup is captured as a follow-up in #147.

## Verification
- `npx tsc --noEmit` — green
- `npm run format:check` — green
- `npm run build` — green

## Hinweis
Best-practice sweep — narrow scope per Aufnahme rules (3 files, 8 LoC, equivalence-preserving). Larger items (German API error messages, `safeRead<any[]>`, `EventCallback<any>`) deferred to backlog.


---
_Generated by [Claude Code](https://claude.ai/code/session_01331zQtdA4aUfZDpVwJAogH)_