### PR TITLE
ux: best-practice sweep 2026-05-20 (a11y + microcopy)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -162,6 +162,7 @@
     "years_other": "vor {{count}} J."
   },
   "modal": {
+    "close": "Schließen",
     "apiKey": {
       "title": "YouTube API-Schlüssel",
       "description": "Gib deinen YouTube Data API-Schlüssel ein, um fortzufahren.",
@@ -195,6 +196,17 @@
     "tryAgain": "Erneut versuchen"
   },
   "loading": "Lädt…",
+  "loadingState": {
+    "fetchingYoutube": "Lade offizielle Daten…",
+    "analyzing": "Berechne Statistiken…"
+  },
+  "theme": {
+    "label": "Theme",
+    "system": "System",
+    "light": "Hell",
+    "dark": "Dunkel",
+    "clickToCycle": "klicken zum Wechseln"
+  },
   "empty": {
     "title": "YouTube-Kanäle analysieren",
     "desc": "Suche einen Kanal und erhalte Trend-Einblicke für verschiedene Zeiträume."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -162,6 +162,7 @@
     "years_other": "{{count}}y ago"
   },
   "modal": {
+    "close": "Close",
     "apiKey": {
       "title": "YouTube API key",
       "description": "Enter your YouTube Data API key to continue.",
@@ -195,6 +196,17 @@
     "tryAgain": "Try again"
   },
   "loading": "Loading…",
+  "loadingState": {
+    "fetchingYoutube": "Loading official data…",
+    "analyzing": "Calculating statistics…"
+  },
+  "theme": {
+    "label": "Theme",
+    "system": "System",
+    "light": "Light",
+    "dark": "Dark",
+    "clickToCycle": "click to cycle"
+  },
   "empty": {
     "title": "Analyze YouTube channels",
     "desc": "Search a channel and get trend insights for different time frames."

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -74,12 +74,16 @@ export function Header({
 
         <div className="flex items-center gap-4">
           {isLoading ? (
-            <div className="flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border bg-indigo-500/10 border-indigo-500/20 text-indigo-400 animate-pulse">
-              <Activity className="w-3 h-3 animate-spin" />
+            <div
+              className="flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border bg-indigo-500/10 border-indigo-500/20 text-indigo-400 animate-pulse"
+              role="status"
+              aria-live="polite"
+            >
+              <Activity className="w-3 h-3 animate-spin" aria-hidden="true" />
               <span>
                 {loadingStep === "fetching_youtube"
-                  ? "Lade offizielle Daten..."
-                  : "Berechne Statistiken..."}
+                  ? t("loadingState.fetchingYoutube")
+                  : t("loadingState.analyzing")}
               </span>
             </div>
           ) : (

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -23,6 +23,16 @@ export const HiddenHighlightsModal: React.FC<HiddenHighlightsModalProps> = ({
     }
   }, [isOpen]);
 
+  // Close on Escape (WCAG 2.1.2 — provide keyboard escape from modal)
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   const handleUnhide = (videoId: string) => {
     hiddenHighlightsService.show(videoId);
     setHiddenItems(hiddenHighlightsService.listChronological());
@@ -71,9 +81,9 @@ export const HiddenHighlightsModal: React.FC<HiddenHighlightsModalProps> = ({
             type="button"
             onClick={onClose}
             className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400 transition-colors"
-            aria-label={t("modal.apiKey.cancel")}
+            aria-label={t("modal.close")}
           >
-            <X className="w-5 h-5" />
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 
@@ -130,9 +140,10 @@ export const HiddenHighlightsModal: React.FC<HiddenHighlightsModalProps> = ({
                       type="button"
                       onClick={() => handleDelete(item.videoId)}
                       className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-red-500/30 text-red-400 dark:text-red-300 hover:bg-red-500/10 transition-colors"
-                      aria-label={t("modal.apiKey.cancel")}
+                      aria-label={t("dashboard.highlights.delete")}
+                      title={t("dashboard.highlights.delete")}
                     >
-                      <Trash2 className="w-3 h-3" />
+                      <Trash2 className="w-3 h-3" aria-hidden="true" />
                     </button>
                   </div>
                 </li>

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -377,6 +377,13 @@ export const InputSection: React.FC<InputSectionProps> = ({
               disabled={isLoading}
               autoComplete="off"
               title={t("input.searchPlaceholder") + " (Press / to focus)"}
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={
+                (showSuggestions && suggestions.length > 0) || (showHistory && history.length > 0)
+              }
+              aria-controls="search-listbox"
+              aria-haspopup="listbox"
             />
 
             {/* Loading Indicator or Clear Button */}
@@ -400,9 +407,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
             {/* Suggestions Dropdown */}
             {showSuggestions && suggestions.length > 0 && (
               <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in">
-                <ul>
+                <ul id="search-listbox" role="listbox">
                   {suggestions.map((sug) => (
-                    <li key={sug.id}>
+                    <li key={sug.id} role="option" aria-selected="false">
                       <button
                         type="button"
                         onClick={() => selectSuggestion(sug)}
@@ -433,9 +440,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
             {/* History Dropdown (shown only on focus when input is empty) */}
             {showHistory && history.length > 0 && (
               <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in">
-                <ul>
+                <ul id="search-listbox" role="listbox">
                   {history.map((item, idx) => (
-                    <li key={`${item}-${idx}`}>
+                    <li key={`${item}-${idx}`} role="option" aria-selected="false">
                       <button
                         type="button"
                         onClick={() => selectHistoryItem(item)}

--- a/src/shared/components/ui/ThemeToggle.tsx
+++ b/src/shared/components/ui/ThemeToggle.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Monitor, Moon, Sun } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { useTheme } from "@/src/providers/ThemeProvider";
 
 export const ThemeToggle: React.FC = () => {
   const { theme, resolvedTheme, setTheme } = useTheme();
+  const { t } = useTranslation();
 
   const nextTheme = () => {
     // cycle: system -> light -> dark -> system
@@ -14,8 +16,8 @@ export const ThemeToggle: React.FC = () => {
   };
 
   const title = (() => {
-    if (theme === "system") return `System (${resolvedTheme})`;
-    return theme === "dark" ? "Dunkel" : "Hell";
+    if (theme === "system") return `${t("theme.system")} (${t(`theme.${resolvedTheme}`)})`;
+    return theme === "dark" ? t("theme.dark") : t("theme.light");
   })();
 
   return (
@@ -25,8 +27,8 @@ export const ThemeToggle: React.FC = () => {
       className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors \
                  border-slate-300 text-slate-700 hover:bg-slate-100 \
                  dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
-      title={`Theme: ${title} (klicken zum Wechseln)`}
-      aria-label={`Theme: ${title}`}
+      title={`${t("theme.label")}: ${title} (${t("theme.clickToCycle")})`}
+      aria-label={`${t("theme.label")}: ${title}`}
     >
       {theme === "system" ? (
         <Monitor className="w-3 h-3" />


### PR DESCRIPTION
Closes #149

## Summary
Automated UX best-practice sweep — 5 prioritised fixes (a11y > microcopy).

- **a11y:** header loading badge is now an announced live region; modal closes on Escape; search field exposes proper combobox/listbox semantics.
- **microcopy / i18n:** hardcoded German strings in header loading text and `ThemeToggle` replaced with i18n keys; mislabeled icon-only buttons (close, delete) now use correct aria-labels.
- **i18n:** added `modal.close`, `loadingState.*`, `theme.*` to `en` + `de` (others fall back to `en`).

## Commits
- `ux(microcopy): add loadingState/theme/modal.close i18n keys (en+de)`
- `ux(a11y): mark header loading indicator as live region and i18n it`
- `ux(a11y): close modal on Escape and fix mislabeled icon-only buttons`
- `ux(a11y): annotate search input as combobox with listbox suggestions`
- `ux(microcopy): translate theme toggle title/aria-label via i18n keys`

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `npm run format:check` clean
- [ ] Manual: NVDA/VoiceOver announces "Loading official data" / "Calculating statistics" on search
- [ ] Manual: Escape closes Hidden Highlights modal
- [ ] Manual: search input announces as combobox + reachable suggestions via SR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NK66MhXmozBcmepTxGxogd)_