### PR TITLE
refine: ux sweep (Vite+React)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -35,7 +35,11 @@
     "keyword": "Schlagwort"
   },
   "history": {
-    "recent": "Zuletzt gesucht"
+    "recent": "Zuletzt gesucht",
+    "remove": "Aus Verlauf entfernen",
+    "removeAria": "\"{{item}}\" aus Suchverlauf entfernen",
+    "clearAll": "Alle löschen",
+    "clearAllConfirm": "Alle Einträge aus dem Suchverlauf löschen?"
   },
   "timeFrames": {
     "lastHour": "Letzte Stunde",
@@ -142,7 +146,19 @@
     },
     "highlightTopN": "Top {{n}} hervorheben",
     "topPerformance": "Top {{n}} Performance",
-    "moreVideos": "Weitere Videos"
+    "moreVideos": "Weitere Videos",
+    "table": {
+      "rank": "#",
+      "video": "Video",
+      "upload": "Hochgeladen",
+      "views": "Aufrufe",
+      "velocity": "Velocity",
+      "score": "Score",
+      "copyUrl": "Video-URL kopieren",
+      "copyUrlAria": "URL kopieren für {{title}}",
+      "watchOnYoutube": "Auf YouTube ansehen",
+      "watchOnYoutubeAria": "{{title}} – auf YouTube ansehen"
+    }
   },
   "timeAgo": {
     "justNow": "gerade eben",
@@ -233,7 +249,15 @@
     "sourceUnknown": "Sonstige",
     "timeJustNow": "gerade eben",
     "timeMinutesAgo": "vor {{count}} Min.",
-    "timeHoursAgo": "vor {{count}} Std."
+    "timeHoursAgo": "vor {{count}} Std.",
+    "window15m": "15 Min.",
+    "window30m": "30 Min.",
+    "window90m": "90 Min.",
+    "window1h": "1 Std.",
+    "window3h": "3 Std.",
+    "window6h": "6 Std.",
+    "window12h": "12 Std.",
+    "window24h": "24 Std."
   },
   "footer": {
     "buildInfo": "Build-Info",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -35,7 +35,11 @@
     "keyword": "Keyword"
   },
   "history": {
-    "recent": "Recently searched"
+    "recent": "Recently searched",
+    "remove": "Remove from history",
+    "removeAria": "Remove \"{{item}}\" from search history",
+    "clearAll": "Clear all",
+    "clearAllConfirm": "Clear all entries from search history?"
   },
   "timeFrames": {
     "lastHour": "Last hour",
@@ -142,7 +146,19 @@
     },
     "highlightTopN": "Highlight top {{n}}",
     "topPerformance": "Top {{n}} performance",
-    "moreVideos": "More videos"
+    "moreVideos": "More videos",
+    "table": {
+      "rank": "#",
+      "video": "Video",
+      "upload": "Upload",
+      "views": "Views",
+      "velocity": "Velocity",
+      "score": "Score",
+      "copyUrl": "Copy video URL",
+      "copyUrlAria": "Copy URL for {{title}}",
+      "watchOnYoutube": "Watch on YouTube",
+      "watchOnYoutubeAria": "{{title}} – watch on YouTube"
+    }
   },
   "timeAgo": {
     "justNow": "just now",
@@ -233,7 +249,15 @@
     "sourceUnknown": "Other",
     "timeJustNow": "just now",
     "timeMinutesAgo": "{{count}} min ago",
-    "timeHoursAgo": "{{count}} hrs ago"
+    "timeHoursAgo": "{{count}} hrs ago",
+    "window15m": "15 min",
+    "window30m": "30 min",
+    "window90m": "90 min",
+    "window1h": "1 hr",
+    "window3h": "3 hrs",
+    "window6h": "6 hrs",
+    "window12h": "12 hrs",
+    "window24h": "24 hrs"
   },
   "footer": {
     "buildInfo": "Build info",

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -5,11 +5,17 @@ import type { QuotaHistoryEntry } from "@/src/shared/types";
 import { useTranslation } from "react-i18next";
 import { formatNumber } from "@/src/shared/lib/formatters";
 
-// Determine optimal time window based on actual data
+// Determine optimal time window based on actual data.
+// Returns i18n key + half-window key so labels are translated at render time.
 const getOptimalTimeWindow = (
   history: QuotaHistoryEntry[],
-): { windowMs: number; label: string } => {
-  if (history.length === 0) return { windowMs: 24 * 60 * 60 * 1000, label: "24h" };
+): { windowMs: number; labelKey: string; halfLabelKey: string } => {
+  const fullDay = {
+    windowMs: 24 * 60 * 60 * 1000,
+    labelKey: "quota.window24h",
+    halfLabelKey: "quota.window12h",
+  };
+  if (history.length === 0) return fullDay;
 
   const now = Date.now();
   const oldestEntry = Math.min(...history.map((h) => h.timestamp));
@@ -17,23 +23,37 @@ const getOptimalTimeWindow = (
 
   // Choose time window based on data span with some buffer
   if (dataSpan < 30 * 60 * 1000) {
-    // Less than 30 min -> show last 30 minutes
-    return { windowMs: 30 * 60 * 1000, label: "30 Min." };
+    return {
+      windowMs: 30 * 60 * 1000,
+      labelKey: "quota.window30m",
+      halfLabelKey: "quota.window15m",
+    };
   } else if (dataSpan < 60 * 60 * 1000) {
-    // Less than 1 hour -> show last hour
-    return { windowMs: 60 * 60 * 1000, label: "1 Std." };
+    return {
+      windowMs: 60 * 60 * 1000,
+      labelKey: "quota.window1h",
+      halfLabelKey: "quota.window30m",
+    };
   } else if (dataSpan < 3 * 60 * 60 * 1000) {
-    // Less than 3 hours -> show last 3 hours
-    return { windowMs: 3 * 60 * 60 * 1000, label: "3 Std." };
+    return {
+      windowMs: 3 * 60 * 60 * 1000,
+      labelKey: "quota.window3h",
+      halfLabelKey: "quota.window90m",
+    };
   } else if (dataSpan < 6 * 60 * 60 * 1000) {
-    // Less than 6 hours -> show last 6 hours
-    return { windowMs: 6 * 60 * 60 * 1000, label: "6 Std." };
+    return {
+      windowMs: 6 * 60 * 60 * 1000,
+      labelKey: "quota.window6h",
+      halfLabelKey: "quota.window3h",
+    };
   } else if (dataSpan < 12 * 60 * 60 * 1000) {
-    // Less than 12 hours -> show last 12 hours
-    return { windowMs: 12 * 60 * 60 * 1000, label: "12 Std." };
+    return {
+      windowMs: 12 * 60 * 60 * 1000,
+      labelKey: "quota.window12h",
+      halfLabelKey: "quota.window6h",
+    };
   }
-  // Default: 24 hours
-  return { windowMs: 24 * 60 * 60 * 1000, label: "24 Std." };
+  return fullDay;
 };
 
 // Group history entries by time buckets for the timeline
@@ -401,7 +421,7 @@ export const ApiQuotaIndicator: React.FC = () => {
           {/* Timeline line chart - pure line chart showing usage over time */}
           <div className="px-3 py-3 border-b border-slate-700/50">
             <div className="text-[10px] text-slate-500 mb-2">
-              {t("quota.lastTimeWindow", { time: timeWindow.label })}
+              {t("quota.lastTimeWindow", { time: t(timeWindow.labelKey) })}
             </div>
             <div className="relative h-16">
               <svg className="w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
@@ -507,10 +527,8 @@ export const ApiQuotaIndicator: React.FC = () => {
             </div>
             {/* Time labels - dynamic based on time window */}
             <div className="flex justify-between mt-1 text-[9px] text-slate-600">
-              <span>-{timeWindow.label}</span>
-              <span>
-                -{timeWindow.label.replace(/(\d+)/, (m) => String(Math.round(parseInt(m) / 2)))}
-              </span>
+              <span>-{t(timeWindow.labelKey)}</span>
+              <span>-{t(timeWindow.halfLabelKey)}</span>
               <span>{t("quota.now")}</span>
             </div>
           </div>

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -2,7 +2,17 @@ import React, { useEffect, useRef, useState } from "react";
 import type { ChannelSuggestion } from "@/src/shared/types";
 import { coerceTimeFrame, SearchType, TimeFrame } from "@/src/shared/types";
 import { MAX_RESULTS_OPTIONS, STORAGE_KEYS, TIME_FRAMES } from "@/src/shared/constants";
-import { Hash, History, Link2, ListFilter, Loader2, Search, Star, X } from "lucide-react";
+import {
+  Hash,
+  History,
+  Link2,
+  ListFilter,
+  Loader2,
+  Search,
+  Star,
+  Trash2,
+  X,
+} from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { extractChannelIdentifier, searchChannels } from "@/src/features/youtube";
 import { favoritesService } from "@/src/features/favorites";
@@ -317,6 +327,35 @@ export const InputSection: React.FC<InputSectionProps> = ({
     // Do not trigger search automatically; user can submit
   };
 
+  const removeHistoryItem = (val: string) => {
+    setHistory((prev) => {
+      const updated = prev.filter((x) => x !== val);
+      persistHistory(updated);
+      if (updated.length === 0) setShowHistory(false);
+      return updated;
+    });
+  };
+
+  const clearAllHistory = () => {
+    if (!window.confirm(t("history.clearAllConfirm"))) return;
+    setHistory([]);
+    persistHistory([]);
+    setShowHistory(false);
+  };
+
+  // Escape closes any open dropdown (suggestions or history)
+  useEffect(() => {
+    if (!showSuggestions && !showHistory) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setShowSuggestions(false);
+        setShowHistory(false);
+      }
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [showSuggestions, showHistory]);
+
   // Synchronisiere Favoriten-Status, wenn Eingabe/Zeitfenster/MaxErgebnisse/SearchType sich ändern
   useEffect(() => {
     const strippedInput = stripSearchPrefix(inputValue || "");
@@ -442,14 +481,19 @@ export const InputSection: React.FC<InputSectionProps> = ({
               <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in">
                 <ul id="search-listbox" role="listbox">
                   {history.map((item, idx) => (
-                    <li key={`${item}-${idx}`} role="option" aria-selected="false">
+                    <li
+                      key={`${item}-${idx}`}
+                      role="option"
+                      aria-selected="false"
+                      className="group/item flex items-stretch hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                    >
                       <button
                         type="button"
                         onClick={() => selectHistoryItem(item)}
-                        className="w-full text-left px-4 py-3 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors flex items-center gap-3 group/item"
+                        className="flex-1 min-w-0 text-left px-4 py-3 flex items-center gap-3"
                       >
                         <div className="w-8 h-8 rounded-full overflow-hidden bg-slate-100 dark:bg-slate-950 shrink-0 border border-slate-200 dark:border-slate-700 flex items-center justify-center">
-                          <History className="w-4 h-4 text-slate-500" />
+                          <History className="w-4 h-4 text-slate-500" aria-hidden="true" />
                         </div>
                         <div className="min-w-0">
                           <p className="text-slate-700 dark:text-slate-200 font-medium truncate group-hover/item:text-indigo-500 dark:group-hover/item:text-indigo-400 transition-colors">
@@ -458,9 +502,32 @@ export const InputSection: React.FC<InputSectionProps> = ({
                           <p className="text-xs text-slate-500 truncate">{t("history.recent")}</p>
                         </div>
                       </button>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removeHistoryItem(item);
+                        }}
+                        className="px-3 flex items-center text-slate-400 hover:text-red-500 dark:hover:text-red-400 opacity-0 group-hover/item:opacity-100 focus:opacity-100 transition-opacity"
+                        title={t("history.remove")}
+                        aria-label={t("history.removeAria", { item })}
+                      >
+                        <X className="w-4 h-4" aria-hidden="true" />
+                      </button>
                     </li>
                   ))}
                 </ul>
+                <div className="border-t border-slate-200 dark:border-slate-700 px-3 py-2 bg-slate-50 dark:bg-slate-900/80 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={clearAllHistory}
+                    className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-md text-slate-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                    title={t("history.clearAll")}
+                  >
+                    <Trash2 className="w-3 h-3" aria-hidden="true" />
+                    <span>{t("history.clearAll")}</span>
+                  </button>
+                </div>
               </div>
             )}
           </div>

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import type { VideoData } from "@/src/features/videos";
 import { Check, Clock, Copy, ExternalLink } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { formatNumber } from "@/src/shared/lib/formatters";
 
 interface VideoListTableProps {
@@ -9,6 +10,7 @@ interface VideoListTableProps {
 }
 
 export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startIndex }) => {
+  const { t } = useTranslation();
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const handleCopy = (video: VideoData) => {
@@ -30,13 +32,27 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
         <table className="w-full text-left border-collapse">
           <thead>
             <tr className="bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800 text-xs uppercase tracking-wider text-slate-500 font-semibold">
-              <th className="p-4 w-16 text-center">#</th>
-              <th className="p-4">Video</th>
-              <th className="p-4 hidden sm:table-cell">Upload</th>
-              <th className="p-4 text-right">Views</th>
-              <th className="p-4 text-right hidden md:table-cell">Velocity</th>
-              <th className="p-4 text-center">Score</th>
-              <th className="p-4 w-16 text-center"></th>
+              <th scope="col" className="p-4 w-16 text-center">
+                {t("results.table.rank")}
+              </th>
+              <th scope="col" className="p-4">
+                {t("results.table.video")}
+              </th>
+              <th scope="col" className="p-4 hidden sm:table-cell">
+                {t("results.table.upload")}
+              </th>
+              <th scope="col" className="p-4 text-right">
+                {t("results.table.views")}
+              </th>
+              <th scope="col" className="p-4 text-right hidden md:table-cell">
+                {t("results.table.velocity")}
+              </th>
+              <th scope="col" className="p-4 text-center">
+                {t("results.table.score")}
+              </th>
+              <th scope="col" className="p-4 w-16 text-center">
+                <span className="sr-only">{t("results.table.copyUrl")}</span>
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200/50 dark:divide-slate-800/50 text-sm">
@@ -75,7 +91,8 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                           {video.title}
                         </a>
                         <div className="text-xs text-slate-500 mt-1 sm:hidden">
-                          {video.uploadTime} • {formatNumber(video.views)} Views
+                          {video.uploadTime} • {formatNumber(video.views)}{" "}
+                          {t("results.table.views")}
                         </div>
                       </div>
                     </div>
@@ -111,13 +128,13 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                         type="button"
                         onClick={() => handleCopy(video)}
                         className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
-                        title="Copy video URL"
-                        aria-label={`Copy URL for ${video.title}`}
+                        title={t("results.table.copyUrl")}
+                        aria-label={t("results.table.copyUrlAria", { title: video.title })}
                       >
                         {copiedId === video.id ? (
-                          <Check className="w-4 h-4 text-green-500" />
+                          <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
                         ) : (
-                          <Copy className="w-4 h-4" />
+                          <Copy className="w-4 h-4" aria-hidden="true" />
                         )}
                       </button>
                       <a
@@ -125,10 +142,10 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
-                        title="Watch on YouTube"
-                        aria-label={`${video.title} – watch on YouTube`}
+                        title={t("results.table.watchOnYoutube")}
+                        aria-label={t("results.table.watchOnYoutubeAria", { title: video.title })}
                       >
-                        <ExternalLink className="w-4 h-4" />
+                        <ExternalLink className="w-4 h-4" aria-hidden="true" />
                       </a>
                     </div>
                   </td>


### PR DESCRIPTION
## Summary

3 UX refinements on existing features. No new features, additive only, no new deps.

| # | Feature | Datei | UX-Lücke | Verbesserung | Aufwand |
|---|---------|-------|----------|--------------|---------|
| 1 | API Quota window labels | `ApiQuotaIndicator.tsx` + i18n | Hardcoded German strings in `getOptimalTimeWindow` leaked into EN UI | Replaced with `quota.window{15m,30m,90m,1h,3h,6h,12h,24h}` i18n keys | S |
| 2 | Video list table | `VideoListTable.tsx` + i18n | Headers + tooltips hardcoded English; missing `scope="col"`; action column had no SR header | i18n `results.table.*`, `scope="col"`, `sr-only` header, `aria-hidden` on decorative icons | S |
| 3 | Search history management | `InputSection.tsx` + i18n | History entries non-deletable; no bulk clear; Escape didn't close dropdowns | Per-entry remove + "Clear all" with confirm; Escape closes suggestions & history | S |

## Verification

- `npm ci` -> green
- `npx tsc --noEmit` -> green
- `npm run build` -> green (built in ~940ms)
- `npm test` -> not configured (per CLAUDE.md)
- ESLint -> no `eslint.config.js` present in repo (project uses Prettier only)

Closes #151


---
_Generated by [Claude Code](https://claude.ai/code/session_018afJFgYmSNuPvPDaLaMaaK)_