### PR TITLE
chore: quality & housekeeping sweep 2026-05-23

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -4,7 +4,7 @@ This repository is a Vite + React + TypeScript single-page app (`"type": "module
 
 Key entrypoints:
 
-- `index.html` — Vite HTML entry with Tailwind CDN and theme initialization
+- `index.html` — Vite HTML entry with inline FOUC-prevention theme script (Tailwind v4 ships through the `@tailwindcss/vite` plugin, not a CDN)
 - `src/main.tsx` — React bootstrap (renders App with providers)
 - `src/app/App.tsx` — main UI/state (search, dashboard, favorites)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   web:
     # Build a production image (multi-stage) and serve via Nginx

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,0 @@
-{
-  "name": "TubeTrend",
-  "description": "Eine KI-gestützte Analyse-App, die die neuesten Videos eines YouTube-Kanals findet und bewertet, um virale Trends und sehenswerte Inhalte zu identifizieren.",
-  "requestFramePermissions": []
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
       "@i18n/*": ["./src/i18n/*"]
     }
   },
-  "include": ["src/**/*", "*.tsx", "*.ts", "components/**/*", "services/**/*", "utils/**/*"],
+  "include": ["src/**/*", "*.tsx", "*.ts"],
   "exclude": ["node_modules", "dist", "electron", "chrome-extension"]
 }


### PR DESCRIPTION
## Summary

Quality & housekeeping sweep removing stale configuration and documentation noise. No production code touched, no version bumps.

Closes #155.

## Findings addressed (4 × S)

| #   | Commit    | Location                  | Change                                                                                                                                                  |
| --- | --------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| F1  | `b9d7f71` | `metadata.json`           | Delete unused 5-LoC AI Studio leftover. Stale "KI-gestützte" description contradicts CLAUDE.md (trend scoring is pure math).                            |
| F2  | `c6d239b` | `docker-compose.yml`      | Drop obsolete `version: "3.9"` top-level field. Compose Spec v2 warns on it.                                                                            |
| F3  | `a5a2f62` | `.junie/guidelines.md`    | Fix stale "Tailwind CDN" line — Tailwind v4 ships via `@tailwindcss/vite`, `index.html` only carries the FOUC-prevention script.                        |
| F4  | `3ac680a` | `tsconfig.json`           | Drop stale legacy `include` paths (`components/**/*`, `services/**/*`, `utils/**/*`) that don't exist after the `src/` reorg.                           |

## Test plan

- [x] `npm run format:check` — green
- [x] `npx tsc --noEmit` — green
- [x] `npm run build` — green, bundle size unchanged (382.07 kB / 113.66 kB gzip)
- [ ] PR CI: `pr-checks.yml` (typecheck / build / lint-noop / npm audit)

## Out of scope

- No dependency upgrades / version bumps
- No security advisories
- Refactoring backlog (#126, FavoriteRow split) untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfYsYP7sqPHPiN4kx9NRcU)_