### PR TITLE
feat(comfort-sweep): English API errors, i18n stat labels, i18n relative time

### DIFF
--- a/src/features/videos/services/trendAnalysisService.ts
+++ b/src/features/videos/services/trendAnalysisService.ts
@@ -47,7 +47,6 @@ export async function analyzeVideoStats(
       url: `https://www.youtube.com/watch?v=${video.id}`,
       thumbnailUrl,
       views,
-      uploadTime: formatUploadTime(publishedAt),
       publishedTimestamp: publishedAt,
       trendingScore: Math.max(0, Math.min(100, trendingScore)),
       reasoning,
@@ -96,28 +95,3 @@ function generateReasoning(
   return parts.join(", ");
 }
 
-function formatUploadTime(timestamp: number): string {
-  const now = Date.now();
-  const diffMs = now - timestamp;
-  const diffHours = diffMs / (1000 * 60 * 60);
-  const diffDays = diffHours / 24;
-
-  if (diffHours < 1) {
-    const mins = Math.round(diffMs / (1000 * 60));
-    return `${mins} min ago`;
-  }
-  if (diffHours < 24) {
-    const hours = Math.round(diffHours);
-    return `${hours}h ago`;
-  }
-  if (diffDays < 7) {
-    const days = Math.round(diffDays);
-    return `${days}d ago`;
-  }
-  if (diffDays < 30) {
-    const weeks = Math.round(diffDays / 7);
-    return `${weeks}w ago`;
-  }
-  const months = Math.round(diffDays / 30);
-  return `${months}mo ago`;
-}

--- a/src/features/videos/types.ts
+++ b/src/features/videos/types.ts
@@ -8,7 +8,6 @@ export interface VideoData {
   url: string;
   thumbnailUrl: string;
   views: number;
-  uploadTime: string;
   publishedTimestamp: number;
   trendingScore: number;
   reasoning: string;

--- a/src/features/youtube/services/youtubeApiClient.ts
+++ b/src/features/youtube/services/youtubeApiClient.ts
@@ -41,7 +41,7 @@ export async function fetchFromApi<T>(
 ): Promise<T> {
   const apiKey = getApiKey();
   if (!apiKey) {
-    throw new YouTubeApiError("YouTube API Key fehlt.", 401);
+    throw new YouTubeApiError("YouTube API key missing.", 401);
   }
 
   const url = new URL(`https://www.googleapis.com/youtube/v3/${endpoint}`);
@@ -58,12 +58,12 @@ export async function fetchFromApi<T>(
       const lower = msg.toLowerCase();
 
       if (lower.includes("api key not valid")) {
-        throw new YouTubeApiError("Der eingegebene API Key ist ungültig.", 403);
+        throw new YouTubeApiError("The provided API key is invalid.", 403);
       }
 
       if (lower.includes("quota")) {
         quotaService.markExhausted();
-        throw new YouTubeApiError("YouTube API Quota überschritten.", 403, true);
+        throw new YouTubeApiError("YouTube API quota exceeded.", 403, true);
       }
 
       // 4xx errors still cost quota
@@ -72,7 +72,7 @@ export async function fetchFromApi<T>(
       }
 
       throw new YouTubeApiError(
-        msg ? `YouTube API Fehler: ${msg}` : `YouTube API Fehler (${response.status})`,
+        msg ? `YouTube API error: ${msg}` : `YouTube API error (${response.status})`,
         response.status,
       );
     }
@@ -81,7 +81,7 @@ export async function fetchFromApi<T>(
       quotaService.track(cost, endpoint, context);
     }
 
-    throw new YouTubeApiError(`HTTP Fehler: ${response.status}`, response.status);
+    throw new YouTubeApiError(`HTTP error: ${response.status}`, response.status);
   }
 
   // Track successful request

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -26,6 +26,7 @@ import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { MAX_RESULTS_OPTIONS, STORAGE_KEYS, TIME_FRAMES } from "@/src/shared/constants";
 import { useTranslation } from "react-i18next";
 import { eventBus } from "@/src/shared/lib/eventBus";
+import { formatTimeAgo } from "@/src/shared/lib/formatters";
 
 interface FavoriteRowProps {
   favorite: FavoriteConfig;
@@ -122,26 +123,6 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
     return totalInTimeFrame > currentMax;
   }, [totalInTimeFrame, currentMax]);
 
-  const formatTimeAgo = (ts: number): string => {
-    const diffMs = Date.now() - ts;
-    if (diffMs < 0) return t("timeAgo.justNow");
-    const sec = Math.floor(diffMs / 1000);
-    if (sec < 10) return t("timeAgo.justNow");
-    if (sec < 60) return t("timeAgo.seconds", { count: sec });
-    const min = Math.floor(sec / 60);
-    if (min < 60) return t("timeAgo.minutes", { count: min });
-    const hrs = Math.floor(min / 60);
-    if (hrs < 24) return t("timeAgo.hours", { count: hrs });
-    const days = Math.floor(hrs / 24);
-    if (days < 7) return t("timeAgo.days", { count: days });
-    const weeks = Math.floor(days / 7);
-    if (weeks < 5) return t("timeAgo.weeks", { count: weeks });
-    const months = Math.floor(days / 30);
-    if (months < 12) return t("timeAgo.months", { count: months });
-    const years = Math.floor(days / 365);
-    return t("timeAgo.years", { count: years });
-  };
-
   // Live-Update für "vor X Min." Badge (aktualisiert alle 10 Sekunden)
   useEffect(() => {
     if (!lastFetchedAt || loading) {
@@ -149,10 +130,10 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
       return;
     }
     // Initiale Berechnung
-    setLiveTimeAgo(formatTimeAgo(lastFetchedAt));
+    setLiveTimeAgo(formatTimeAgo(lastFetchedAt, t));
     // Intervall für Live-Updates
     const interval = setInterval(() => {
-      setLiveTimeAgo(formatTimeAgo(lastFetchedAt));
+      setLiveTimeAgo(formatTimeAgo(lastFetchedAt, t));
     }, 10000); // alle 10 Sekunden aktualisieren
     return () => clearInterval(interval);
   }, [lastFetchedAt, loading]);

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -117,7 +117,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
         <div className="grid grid-cols-2 gap-2 mb-3">
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" /> Views
+              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" /> {t("results.table.views")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {formatNumber(video.views)}
@@ -125,7 +125,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
           </div>
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" /> Velocity
+              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" /> {t("results.table.velocity")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {video.viewsPerHour ? `~${formatNumber(video.viewsPerHour)}/h` : "N/A"}

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { VideoData } from "@/src/features/videos";
 import { Clock, Eye, EyeOff, Sparkles, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { formatNumber } from "@/src/shared/lib/formatters";
+import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
 interface HighlightVideoCardProps {
   video: VideoData;
@@ -58,7 +58,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
 
         <div className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm text-white text-xs font-bold px-2 py-1 rounded flex items-center gap-1 pointer-events-none">
           <Clock className="w-3 h-3 text-slate-300" />
-          {video.uploadTime}
+          {formatTimeAgo(video.publishedTimestamp, t)}
         </div>
 
         <div

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { VideoData } from "@/src/features/videos";
 import { Clock, Eye, TrendingUp, Zap } from "lucide-react";
 import { formatNumber } from "@/src/shared/lib/formatters";
+import { useTranslation } from "react-i18next";
 
 interface VideoCardProps {
   video: VideoData;
@@ -9,6 +10,8 @@ interface VideoCardProps {
 }
 
 export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
+  const { t } = useTranslation();
+
   // Determine color based on score
   const getScoreColor = (score: number) => {
     if (score >= 80)
@@ -42,7 +45,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           className={`absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-bold border backdrop-blur-md flex items-center gap-1 pointer-events-none ${getScoreColor(video.trendingScore)}`}
         >
           <TrendingUp className="w-3 h-3" />
-          Score: {video.trendingScore}
+          {t("results.table.score")}: {video.trendingScore}
         </div>
       </div>
 
@@ -66,7 +69,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
         <div className="grid grid-cols-2 gap-2 mb-3">
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" /> Views
+              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" /> {t("results.table.views")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {formatNumber(video.views)}
@@ -74,7 +77,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           </div>
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" /> Velocity
+              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" /> {t("results.table.velocity")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {video.viewsPerHour ? `~${formatNumber(video.viewsPerHour)}/h` : "N/A"}

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { VideoData } from "@/src/features/videos";
 import { Clock, Eye, TrendingUp, Zap } from "lucide-react";
-import { formatNumber } from "@/src/shared/lib/formatters";
+import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { useTranslation } from "react-i18next";
 
 interface VideoCardProps {
@@ -39,7 +39,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
         </a>
         <div className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm text-white text-xs font-bold px-2 py-1 rounded flex items-center gap-1 pointer-events-none">
           <Clock className="w-3 h-3 text-slate-300" />
-          {video.uploadTime}
+          {formatTimeAgo(video.publishedTimestamp, t)}
         </div>
         <div
           className={`absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-bold border backdrop-blur-md flex items-center gap-1 pointer-events-none ${getScoreColor(video.trendingScore)}`}

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import type { VideoData } from "@/src/features/videos";
 import { Check, Clock, Copy, ExternalLink } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { formatNumber } from "@/src/shared/lib/formatters";
+import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
 interface VideoListTableProps {
   videos: VideoData[];
@@ -91,7 +91,7 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                           {video.title}
                         </a>
                         <div className="text-xs text-slate-500 mt-1 sm:hidden">
-                          {video.uploadTime} • {formatNumber(video.views)}{" "}
+                          {formatTimeAgo(video.publishedTimestamp, t)} • {formatNumber(video.views)}{" "}
                           {t("results.table.views")}
                         </div>
                       </div>
@@ -100,7 +100,7 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                   <td className="p-4 text-slate-500 dark:text-slate-400 whitespace-nowrap hidden sm:table-cell">
                     <div className="flex items-center gap-1.5">
                       <Clock className="w-3.5 h-3.5 text-slate-400 dark:text-slate-600" />
-                      {video.uploadTime}
+                      {formatTimeAgo(video.publishedTimestamp, t)}
                     </div>
                   </td>
                   <td className="p-4 text-right font-mono text-slate-600 dark:text-slate-300">

--- a/src/shared/lib/formatters.ts
+++ b/src/shared/lib/formatters.ts
@@ -2,6 +2,7 @@
  * Formatting utilities
  */
 
+import type { TFunction } from "i18next";
 import { getLocale } from "./locale";
 
 /**
@@ -54,4 +55,31 @@ export function formatDuration(ms: number): string {
  */
 export function formatPercentage(value: number, decimals = 0): string {
   return `${value.toFixed(decimals)}%`;
+}
+
+/**
+ * Format a past timestamp as a localized relative time string.
+ * Uses the timeAgo.* i18n keys present in all supported locales.
+ *
+ * @param timestamp - Unix timestamp in milliseconds
+ * @param t         - i18next TFunction from useTranslation()
+ */
+export function formatTimeAgo(timestamp: number, t: TFunction): string {
+  const diffMs = Date.now() - timestamp;
+  if (diffMs < 0) return t("timeAgo.justNow");
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 10) return t("timeAgo.justNow");
+  if (sec < 60) return t("timeAgo.seconds", { count: sec });
+  const min = Math.floor(sec / 60);
+  if (min < 60) return t("timeAgo.minutes", { count: min });
+  const hrs = Math.floor(min / 60);
+  if (hrs < 24) return t("timeAgo.hours", { count: hrs });
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return t("timeAgo.days", { count: days });
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return t("timeAgo.weeks", { count: weeks });
+  const months = Math.floor(days / 30);
+  if (months < 12) return t("timeAgo.months", { count: months });
+  const years = Math.floor(days / 365);
+  return t("timeAgo.years", { count: years });
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **fix(youtube):** Replace 5 hardcoded German error strings in `youtubeApiClient.ts` with English equivalents (CLAUDE.md convention)
- **feat(i18n):** Route `"Score:"`, `"Views"`, `"Velocity"` stat labels in `VideoCard` / `HighlightVideoCard` through existing `results.table.*` translation keys
- **feat(i18n):** Remove static `uploadTime: string` field from `VideoData`; add shared `formatTimeAgo(ts, t)` to `formatters.ts`; all video card / table / FavoriteRow components now compute relative time at render using the full `timeAgo.*` i18n keys (13 locales)

Closes #157

## Test plan

- [ ] `npx tsc --noEmit` — passes (verified locally)
- [ ] `npm run build` — clean build, no size regression (verified locally)
- [ ] Smoke: switch app language to German → video cards show "vor X Std." / "vor X Tg." instead of "3h ago" / "3d ago"
- [ ] Smoke: trigger an invalid API key → browser console / error toast shows English message
- [ ] Smoke: quota exceeded scenario → English message shown

https://claude.ai/code/session_01TJh1RpZCYDFfNQ2ouAMVqv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJh1RpZCYDFfNQ2ouAMVqv)_