### PR TITLE
chore: quality & housekeeping sweep 2026-05-24

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,10 +4,9 @@ Review findings not immediately fixed. **Only work on these upon explicit reques
 
 ## Open
 
-| #   | Date | Category | Sev | Location | Finding | Status | Source |
-| --- | ---- | -------- | --- | -------- | ------- | ------ | ------ |
-
-_No open items._
+| #   | Date       | Category | Sev      | Location                                    | Finding                                                                                                                                                                                                                                                                                         | Status   | Source                                  |
+| --- | ---------- | -------- | -------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------- |
+| 13  | 2026-05-24 | Security | Moderate | `node_modules/brace-expansion` (transitive) | `npm audit` reports two moderate advisories on `brace-expansion` 4.0.0-5.0.5 (GHSA-f886-m6hf-6m8v zero-step DoS, GHSA-jxxr-4gwj-5jf2 numeric-range DoS). CI gate is `--audit-level=high` so it does not fail the build. Wait for dependabot or run `npm audit fix` once a dep bump is approved. | Deferred | quality & housekeeping sweep 2026-05-24 |
 
 ## Done
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,7 +6,7 @@ Session-spanning project knowledge. **Read at session start, update during work.
 
 ## Gotchas & Pitfalls
 
-- **Tailwind v4 migration (2026-02)** — Tailwind CSS was migrated from v3 (PostCSS plugin + tailwind.config.js) to v4 (@tailwindcss/vite plugin). The old tailwind.config.js was deleted. postcss.config.js remains but is empty. Dark mode now uses `@custom-variant dark` in CSS instead of `darkMode: 'class'` in config. (2026-04-03)
+- **Tailwind v4 migration (2026-02)** — Tailwind CSS was migrated from v3 (PostCSS plugin + tailwind.config.js) to v4 (@tailwindcss/vite plugin). Both `tailwind.config.js` and the empty `postcss.config.js` were deleted (postcss devDependency removed in PR #142). Dark mode now uses `@custom-variant dark` in CSS instead of `darkMode: 'class'` in config. (updated 2026-05-24)
 
 - **Lucide React 1.x breaking change** — Lucide React migrated from 0.x to 1.x. Some brand icons (YouTube, GitHub) were removed in v0.577+ and replaced with custom SVG components. Check for removed icons when updating. (2026-04-03)
 

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -117,7 +117,8 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
         <div className="grid grid-cols-2 gap-2 mb-3">
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" /> {t("results.table.views")}
+              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" />{" "}
+              {t("results.table.views")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {formatNumber(video.views)}
@@ -125,7 +126,8 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
           </div>
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" /> {t("results.table.velocity")}
+              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" />{" "}
+              {t("results.table.velocity")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {video.viewsPerHour ? `~${formatNumber(video.viewsPerHour)}/h` : "N/A"}

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -69,7 +69,8 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
         <div className="grid grid-cols-2 gap-2 mb-3">
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" /> {t("results.table.views")}
+              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" />{" "}
+              {t("results.table.views")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {formatNumber(video.views)}
@@ -77,7 +78,8 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           </div>
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" /> {t("results.table.velocity")}
+              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" />{" "}
+              {t("results.table.velocity")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {video.viewsPerHour ? `~${formatNumber(video.viewsPerHour)}/h` : "N/A"}


### PR DESCRIPTION
Closes #169.

## Summary

Three small commits, one finding each.

1. `style: prettier --write VideoCard + HighlightVideoCard` — unblocks the `format:check` job in `pr-checks.yml` (both files had unwrapped JSX expressions exceeding 100-char printWidth).
2. `docs(memory): correct stale postcss.config.js note` — MEMORY.md still claimed `postcss.config.js` was present but empty; it was actually deleted alongside the `postcss` devDependency in PR #142.
3. `docs(backlog): defer brace-expansion moderate audit advisories` — npm audit reports two moderate advisories on transitive `brace-expansion`. CI gate is `--audit-level=high` so the build is green, but the items belong on the backlog (BACKLOG #13) until a dependabot bump lands.

## Verification

- `npm run typecheck` — green
- `npm run format:check` — green (was failing on main)
- `npm run build` — green (~1.0s)
- `npm audit --audit-level=high` — green (1 moderate advisory remains, below the CI gate; tracked in BACKLOG #13)

## Out of scope

- No dependency bumps (per sweep policy).
- Bot PRs untouched (#165, #166, #167, #168).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm audit --audit-level=high`


---
_Generated by [Claude Code](https://claude.ai/code/session_01GuAS6VTws8kXk7G5ib94sq)_