### PR TITLE
feat: comfort sweep — copy button, clear-all favorites, R hotkey

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import { AnalyserPage } from "./routes/AnalyserPage";
 import { useTranslation } from "react-i18next";
 import { setApiKey as setYoutubeApiKey } from "@/src/features/youtube";
 import { dashboardBackupService } from "@/src/features/dashboard";
+import { favoritesService } from "@/src/features/favorites";
 import {
   useDashboardSort,
   useFavorites,
@@ -152,6 +153,13 @@ const App: React.FC = () => {
     [loadFavorites, t],
   );
 
+  const handleClearAllFavorites = useCallback(() => {
+    const count = favorites.length;
+    if (!window.confirm(t("favorites.clearAllConfirm", { count }))) return;
+    favoritesService.clearAll();
+    loadFavorites();
+  }, [favorites.length, loadFavorites, t]);
+
   const handleAnalyzeFavorite = useCallback(
     (
       favorite: FavoriteConfig,
@@ -213,6 +221,7 @@ const App: React.FC = () => {
             onExport={handleDashboardExport}
             onImportFile={handleDashboardImportFile}
             onOpenHiddenModal={() => setIsHiddenHighlightsModalOpen(true)}
+            onClearAllFavorites={handleClearAllFavorites}
           />
         ) : (
           <AnalyserPage

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -60,6 +60,24 @@ const App: React.FC = () => {
   // Sorted favorites
   const sortedFavorites = useMemo(() => sortFavorites(favorites), [favorites, sortFavorites]);
 
+  // Global hotkey: press "r" on dashboard to refresh all favorites
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "r" && e.key !== "R") return;
+      // Skip when focus is inside an input, textarea, or contentEditable element
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
+        return;
+      }
+      if (activePage !== "dashboard") return;
+      if (favorites.length === 0) return;
+      e.preventDefault();
+      refreshAll();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [activePage, favorites.length, refreshAll]);
+
   // Initial API key check
   useEffect(() => {
     if (!apiKey) {

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef } from "react";
-import { Activity, Download, EyeOff, RefreshCw, Upload } from "lucide-react";
+import { Activity, Download, EyeOff, RefreshCw, Trash2, Upload } from "lucide-react";
 import { FavoriteRow } from "@/src/shared/components/ui/FavoriteRow";
 import { FavoriteAvatar } from "@/src/shared/components/ui/FavoriteAvatar";
 import { HighlightVideoCard } from "@/src/shared/components/ui/HighlightVideoCard";
@@ -36,6 +36,7 @@ interface DashboardPageProps {
   onExport: () => void;
   onImportFile: (file: File) => Promise<void>;
   onOpenHiddenModal: () => void;
+  onClearAllFavorites: () => void;
 }
 
 export function DashboardPage({
@@ -54,6 +55,7 @@ export function DashboardPage({
   onExport,
   onImportFile,
   onOpenHiddenModal,
+  onClearAllFavorites,
 }: DashboardPageProps) {
   const { t } = useTranslation();
   const importRef = useRef<HTMLInputElement | null>(null);
@@ -169,6 +171,18 @@ export function DashboardPage({
                 >
                   <RefreshCw className="w-3 h-3" /> {t("actions.refreshAll")}
                 </button>
+                {favorites.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={onClearAllFavorites}
+                    className="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-md border transition-colors
+                             border-red-300/60 text-red-600 hover:bg-red-50
+                             dark:border-red-700/40 dark:text-red-400 dark:hover:bg-red-900/20"
+                    title={t("favorites.clearAll")}
+                  >
+                    <Trash2 className="w-3 h-3" /> {t("favorites.clearAll")}
+                  </button>
+                )}
                 {hiddenHighlightsCount > 0 && (
                   <button
                     type="button"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -97,7 +97,9 @@
     },
     "refresh": "Kanal aktualisieren",
     "remove": "Favorit entfernen",
-    "analyze": "Im Analyser öffnen (nutzt Cache-Daten)"
+    "analyze": "Im Analyser öffnen (nutzt Cache-Daten)",
+    "clearAll": "Alle Favoriten löschen",
+    "clearAllConfirm": "Alle {{count}} Favoriten entfernen? Das kann nicht rückgängig gemacht werden."
   },
   "dashboard": {
     "noFavorites": "Noch keine Favoriten. Lege im Analyser eine Suche als Favorit an.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -8,7 +8,7 @@
     "search": "Suchen",
     "clearSearch": "Suche leeren",
     "resetApiKey": "API-Schlüssel löschen",
-    "refreshAll": "Alle aktualisieren",
+    "refreshAll": "Alle aktualisieren (R)",
     "remove": "Entfernen",
     "refresh": "Aktualisieren",
     "analyze": "Analysieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -8,7 +8,7 @@
     "search": "Search",
     "clearSearch": "Clear search",
     "resetApiKey": "Delete API key",
-    "refreshAll": "Refresh all",
+    "refreshAll": "Refresh all (R)",
     "remove": "Remove",
     "refresh": "Refresh",
     "analyze": "Analyze",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -97,7 +97,9 @@
     },
     "refresh": "Refresh channel",
     "remove": "Remove favorite",
-    "analyze": "Open in Analyzer (uses cached data)"
+    "analyze": "Open in Analyzer (uses cached data)",
+    "clearAll": "Clear all favorites",
+    "clearAllConfirm": "Remove all {{count}} favorites? This cannot be undone."
   },
   "dashboard": {
     "noFavorites": "No favorites yet. Create a favorite from the analyzer.",

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Clock, Eye, TrendingUp, Zap } from "lucide-react";
+import { Check, Clock, Copy, Eye, TrendingUp, Zap } from "lucide-react";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { useTranslation } from "react-i18next";
 
@@ -11,6 +11,24 @@ interface VideoCardProps {
 
 export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
   const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigator.clipboard.writeText(video.url).then(() => {
+      setCopied(true);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => setCopied(false), 1500);
+    });
+  };
 
   // Determine color based on score
   const getScoreColor = (score: number) => {
@@ -87,7 +105,22 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           </div>
         </div>
 
-        {/* Analyse-Bereich entfernt */}
+        {/* Actions */}
+        <div className="mt-auto pt-2 flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700"
+            title={t("results.table.copyUrl")}
+            aria-label={t("results.table.copyUrlAria", { title: video.title })}
+          >
+            {copied ? (
+              <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
+            ) : (
+              <Copy className="w-3.5 h-3.5" aria-hidden="true" />
+            )}
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Three isolated S-size UX comfort improvements — no new dependencies, all patterns mirror existing codebase conventions.

| # | Feature | Files changed |
|---|---------|---------------|
| 1 | **Copy-URL button on VideoCard** — mirrors the copy pattern already in `VideoListTable` into the top-N thumbnail cards | `VideoCard.tsx` |
| 2 | **Clear all favorites** — bulk-remove with `window.confirm` (count-interpolated), mirrors `clearAllHistory` from `InputSection` | `DashboardPage.tsx`, `App.tsx`, `en.json`, `de.json` |
| 3 | **Keyboard shortcut `R` = Refresh all** — mirrors the existing `/` hotkey for search focus; skips when focus is in input/textarea/contentEditable; hint appended to button label | `App.tsx`, `en.json`, `de.json` |

## Test plan

- [ ] Open Analyser, search a channel — top-N cards now show a copy icon bottom-right; click copies the URL, icon briefly turns green check
- [ ] Dashboard with favorites: "Clear all favorites" button appears in highlights toolbar; clicking shows confirm with count, confirming removes all
- [ ] Dashboard with favorites: press `R` (no input focused) → all rows begin refreshing; pressing `R` while inside the search input does nothing
- [ ] TypeScript: `npx tsc --noEmit` — 0 errors
- [ ] Build: `npm run build` — green

Closes #172

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJX8iWjWvV3je87qQ2zqB9)_