### PR TITLE
refine: UX sweep – engagement rate, keyboard hints, clipboard fix

### DIFF
--- a/src/features/videos/services/trendAnalysisService.ts
+++ b/src/features/videos/services/trendAnalysisService.ts
@@ -53,6 +53,7 @@ export function analyzeVideoStats(
       trendingScore: Math.max(0, Math.min(100, trendingScore)),
       reasoning,
       viewsPerHour: Math.round(viewsPerHour * 10) / 10,
+      engagementRate: Math.round(engagementRate * 100) / 100,
     };
   });
 }

--- a/src/features/videos/types.ts
+++ b/src/features/videos/types.ts
@@ -12,6 +12,8 @@ export interface VideoData {
   trendingScore: number;
   reasoning: string;
   viewsPerHour?: number;
+  /** Engagement rate as percentage: (likes + comments) / views * 100 */
+  engagementRate?: number;
 }
 
 export interface SearchState {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -158,6 +158,7 @@
       "views": "Aufrufe",
       "velocity": "Velocity",
       "score": "Score",
+      "engagement": "Engage",
       "copyUrl": "Video-URL kopieren",
       "copyUrlAria": "URL kopieren für {{title}}",
       "watchOnYoutube": "Auf YouTube ansehen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -264,6 +264,11 @@
     "window12h": "12 Std.",
     "window24h": "24 Std."
   },
+  "keyboard": {
+    "label": "Tastaturkuerzel",
+    "focusSearch": "Suche fokussieren",
+    "refreshAll": "Alle Favoriten aktualisieren"
+  },
   "scroll": {
     "toTop": "Nach oben scrollen",
     "toBottom": "Nach unten scrollen"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -264,6 +264,11 @@
     "window12h": "12 hrs",
     "window24h": "24 hrs"
   },
+  "keyboard": {
+    "label": "Keyboard shortcuts",
+    "focusSearch": "Focus search",
+    "refreshAll": "Refresh all favorites"
+  },
   "scroll": {
     "toTop": "Scroll to top",
     "toBottom": "Scroll to bottom"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -158,6 +158,7 @@
       "views": "Views",
       "velocity": "Velocity",
       "score": "Score",
+      "engagement": "Engage",
       "copyUrl": "Copy video URL",
       "copyUrlAria": "Copy URL for {{title}}",
       "watchOnYoutube": "Watch on YouTube",

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -1,4 +1,5 @@
-import { Activity, BarChart3, LayoutDashboard, Settings } from "lucide-react";
+import { Activity, BarChart3, Keyboard, LayoutDashboard, Settings } from "lucide-react";
+import { useRef, useState, useEffect } from "react";
 import { ThemeToggle } from "@/src/shared/components/ui/ThemeToggle";
 import { LanguageSwitcher } from "@/src/shared/components/ui/LanguageSwitcher";
 import { ApiQuotaIndicator } from "@/src/shared/components/ui/ApiQuotaIndicator";
@@ -73,6 +74,7 @@ export function Header({
         </div>
 
         <div className="flex items-center gap-4">
+          <KeyboardShortcutsHint activePage={activePage} />
           {isLoading ? (
             <div
               className="flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border bg-indigo-500/10 border-indigo-500/20 text-indigo-400 animate-pulse"
@@ -112,5 +114,76 @@ export function Header({
         </div>
       </div>
     </header>
+  );
+}
+
+/** Small popover showing available keyboard shortcuts. Hidden on mobile. */
+function KeyboardShortcutsHint({ activePage }: { activePage: PageType }) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [isOpen]);
+
+  return (
+    <div className="relative hidden md:block" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors border border-transparent hover:border-slate-200 dark:hover:border-slate-700"
+        title={t("keyboard.label")}
+        aria-label={t("keyboard.label")}
+        aria-expanded={isOpen}
+      >
+        <Keyboard className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-2 w-56 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl z-50 p-3 animate-fade-in">
+          <div className="text-xs font-semibold text-slate-600 dark:text-slate-300 mb-2">
+            {t("keyboard.label")}
+          </div>
+          <div className="space-y-2 text-xs">
+            <div className="flex items-center justify-between">
+              <span className="text-slate-500 dark:text-slate-400">
+                {t("keyboard.focusSearch")}
+              </span>
+              <kbd className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 font-mono text-slate-600 dark:text-slate-300">
+                /
+              </kbd>
+            </div>
+            {activePage === "dashboard" && (
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500 dark:text-slate-400">
+                  {t("keyboard.refreshAll")}
+                </span>
+                <kbd className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 font-mono text-slate-600 dark:text-slate-300">
+                  R
+                </kbd>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, Eye, TrendingUp, Zap } from "lucide-react";
+import { Check, Clock, Copy, Eye, Heart, TrendingUp, Zap } from "lucide-react";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { useTranslation } from "react-i18next";
 
@@ -89,7 +89,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
         </div>
 
         {/* Stats Grid */}
-        <div className="grid grid-cols-2 gap-2 mb-3">
+        <div className="grid grid-cols-3 gap-2 mb-3">
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
               <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" />{" "}
@@ -106,6 +106,15 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
               {video.viewsPerHour ? `~${formatNumber(video.viewsPerHour)}/h` : "N/A"}
+            </span>
+          </div>
+          <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
+            <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
+              <Heart className="w-3 h-3 text-pink-500 dark:text-pink-400" />{" "}
+              {t("results.table.engagement")}
+            </div>
+            <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
+              {video.engagementRate != null ? `${video.engagementRate}%` : "N/A"}
             </span>
           </div>
         </div>

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -22,11 +22,16 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
   }, []);
 
   const handleCopy = (video: VideoData) => {
-    navigator.clipboard.writeText(video.url).then(() => {
-      setCopiedId(video.id);
-      if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
-      resetCopiedTimerRef.current = setTimeout(() => setCopiedId(null), 1500);
-    });
+    navigator.clipboard.writeText(video.url).then(
+      () => {
+        setCopiedId(video.id);
+        if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
+        resetCopiedTimerRef.current = setTimeout(() => setCopiedId(null), 1500);
+      },
+      () => {
+        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+      },
+    );
   };
 
   const getScoreColor = (score: number) => {

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, ExternalLink } from "lucide-react";
+import { Check, Clock, Copy, ExternalLink, Heart } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
@@ -55,6 +55,9 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
               </th>
               <th scope="col" className="p-4 text-right hidden md:table-cell">
                 {t("results.table.velocity")}
+              </th>
+              <th scope="col" className="p-4 text-right hidden lg:table-cell">
+                {t("results.table.engagement")}
               </th>
               <th scope="col" className="p-4 text-center">
                 {t("results.table.score")}
@@ -119,6 +122,16 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                     {video.viewsPerHour ? (
                       <span className="flex items-center justify-end gap-1 text-yellow-600/80 dark:text-yellow-500/80">
                         {formatNumber(video.viewsPerHour)}/h
+                      </span>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td className="p-4 text-right font-mono text-slate-500 dark:text-slate-400 hidden lg:table-cell">
+                    {video.engagementRate != null ? (
+                      <span className="flex items-center justify-end gap-1 text-pink-600/80 dark:text-pink-500/80">
+                        <Heart className="w-3 h-3" />
+                        {video.engagementRate}%
                       </span>
                     ) : (
                       "-"


### PR DESCRIPTION
## Summary

Three targeted UX refinements to improve data transparency, feature discoverability, and error robustness.

- **Engagement rate in Analyser** — Surface the engagement % (likes + comments / views) in VideoCard (3-col stats grid) and VideoListTable (new column on lg+). Makes the 30%-weighted trend score component visible to users.
- **Keyboard shortcuts hint** — Header popover (keyboard icon, hidden on mobile) listing available shortcuts (/ to focus search, R to refresh on Dashboard). Context-aware.
- **Clipboard error handling** — Add rejection handler to VideoListTable.handleCopy(), matching the existing pattern in VideoCard. Prevents unhandled promise rejection on HTTP/iframe contexts.

Closes #178

## Verification

- `npm run typecheck` — pass
- `npm run build` — pass  
- `npm run format:check` — pass

## Files changed (6)

| File | Change |
|---|---|
| `src/features/videos/types.ts` | Add `engagementRate` field to `VideoData` |
| `src/features/videos/services/trendAnalysisService.ts` | Compute and return engagement rate |
| `src/shared/components/ui/VideoCard.tsx` | 3-column stats grid with engagement |
| `src/shared/components/ui/VideoListTable.tsx` | Engagement column + clipboard fix |
| `src/shared/components/layout/Header.tsx` | `KeyboardShortcutsHint` component |
| `src/i18n/locales/{en,de}.json` | New i18n keys |


---
_Generated by [Claude Code](https://claude.ai/code/session_01NgyN6Cpj2naXQTL8yyb123)_