### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -16,7 +16,7 @@ export const HiddenHighlightsModal: React.FC<HiddenHighlightsModalProps> = ({
   const { t } = useTranslation();
   const [hiddenItems, setHiddenItems] = React.useState<HiddenHighlight[]>([]);
 
-  // Lade die Liste beim Öffnen des Modals
+  // Load the list when the modal opens
   React.useEffect(() => {
     if (isOpen) {
       setHiddenItems(hiddenHighlightsService.listChronological());
@@ -39,7 +39,8 @@ export const HiddenHighlightsModal: React.FC<HiddenHighlightsModalProps> = ({
   };
 
   const handleDelete = (videoId: string) => {
-    hiddenHighlightsService.show(videoId); // Entfernt den Eintrag aus der Liste
+    // show() removes the entry from the hidden list (un-hiding it)
+    hiddenHighlightsService.show(videoId);
     setHiddenItems(hiddenHighlightsService.listChronological());
   };
 

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -23,6 +23,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
   const handleCopy = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
+    // Accessing .writeText on it throws synchronously, which the promise
+    // rejection handler below would not catch — so guard the property first.
+    if (!navigator.clipboard) return;
     navigator.clipboard.writeText(video.url).then(
       () => {
         setCopied(true);

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -22,6 +22,10 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
   }, []);
 
   const handleCopy = (video: VideoData) => {
+    // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
+    // Accessing .writeText on it throws synchronously, which the promise
+    // rejection handler below would not catch — so guard the property first.
+    if (!navigator.clipboard) return;
     navigator.clipboard.writeText(video.url).then(
       () => {
         setCopiedId(video.id);


### PR DESCRIPTION
Best-practice sweep fuer das Vite + React (TypeScript) Frontend. Zwei verhaltens-aequivalente auto-fixes, je ein Commit. Weitere Findings deferred (siehe Issue).

## Findings (fixed)
| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | `src/shared/components/ui/VideoCard.tsx`, `src/shared/components/ui/VideoListTable.tsx` | Correctness | `navigator.clipboard.writeText` ohne Guard -> synchroner TypeError in unsicherem Kontext (HTTP/iframe), vom Promise-Reject-Handler nicht abgefangen. | Early-Guard `if (!navigator.clipboard) return;`. Verhaltens-aequivalent (Fehlerpfad bleibt stilles No-op). | S | merge-ready |
| 2 | `src/shared/components/ui/HiddenHighlightsModal.tsx` | Maintainability | Deutsche Kommentare entgegen Convention; `handleDelete`-Kommentar zudem irrefuehrend. | Kommentare nach Englisch uebersetzt, `handleDelete`-Kommentar korrigiert. | S | merge-ready |

## Deferred (Details im Issue)
- `HiddenHighlightsModal`: Unhide == Delete (identische Logik) -> Verhaltensaenderung noetig (Produkt-Entscheidung).
- `FloatingScrollButton`: scroll-Listener re-attach pro Frame (`lastScrollY` als Dep) -> ueber auto-fix-Schwelle.
- `useEventBus` / `useEventListener` / `useLocalStorage`: tote Exports -> API-Reduktion, riskant.
- `FavoriteRow.tsx`: ~30 deutsche Kommentare -> mit geplantem God-Component-Split buendeln (L).

## Out of Scope
- ESLint nicht im Stack (nur `tsc` + Prettier). Tests nicht konfiguriert. `brace-expansion`-Advisory = Dependabot (BACKLOG #13).

## Verifikation
`npm ci` OK | `tsc --noEmit` 0 Fehler | `vite build` OK | Prettier OK (beruehrte Dateien). ESLint + Tests nicht im Stack.

Closes #182

https://claude.ai/code/session_01RKNuKx2LBZLHMhQ62ffgim

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKNuKx2LBZLHMhQ62ffgim)_