### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useEventListener } from "@/src/shared/hooks";
 import { ApiKeyModal } from "@/src/shared/components/ui/ApiKeyModal";
 import { HiddenHighlightsModal } from "@/src/shared/components/ui/HiddenHighlightsModal";
 import { Header, Footer, type PageType } from "@/src/shared/components/layout";
@@ -62,8 +63,8 @@ const App: React.FC = () => {
   const sortedFavorites = useMemo(() => sortFavorites(favorites), [favorites, sortFavorites]);
 
   // Global hotkey: press "r" on dashboard to refresh all favorites
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
       if (e.key !== "r" && e.key !== "R") return;
       // Skip when focus is inside an input, textarea, or contentEditable element
       const target = e.target as HTMLElement;
@@ -74,10 +75,10 @@ const App: React.FC = () => {
       if (favorites.length === 0) return;
       e.preventDefault();
       refreshAll();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [activePage, favorites.length, refreshAll]);
+    },
+    [activePage, favorites.length, refreshAll],
+  );
+  useEventListener("keydown", handleKeyDown, document);
 
   // Initial API key check
   useEffect(() => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,7 @@ import type { VideoData } from "@/src/features/videos/types";
 import type { SearchType, TimeFrame } from "@/src/shared/types";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 import { dispatchEvent } from "@/src/shared/lib/eventBus";
+import { safeWrite } from "@/src/shared/lib/storage";
 
 const App: React.FC = () => {
   const { t } = useTranslation();
@@ -153,11 +154,8 @@ const App: React.FC = () => {
       if (!ok) return;
 
       try {
-        localStorage.setItem(STORAGE_KEYS.FAVORITES, JSON.stringify(parsed.payload.data.favorites));
-        localStorage.setItem(
-          STORAGE_KEYS.FAVORITES_CACHE,
-          JSON.stringify(parsed.payload.data.favoritesCache),
-        );
+        safeWrite(STORAGE_KEYS.FAVORITES, parsed.payload.data.favorites);
+        safeWrite(STORAGE_KEYS.FAVORITES_CACHE, parsed.payload.data.favoritesCache);
       } catch {
         window.alert(t("backup.importFailedStorage"));
         return;

--- a/src/features/youtube/services/quotaService.ts
+++ b/src/features/youtube/services/quotaService.ts
@@ -1,4 +1,4 @@
-import { safeRead, safeWrite } from "@/src/shared/lib/storage";
+import { safeRead, safeRemove, safeWrite } from "@/src/shared/lib/storage";
 import { dispatchEvent } from "@/src/shared/lib/eventBus";
 import { getTodayDateString } from "@/src/shared/lib/dateUtils";
 import { API_COSTS, DEFAULT_DAILY_QUOTA, STORAGE_KEYS } from "@/src/shared/constants";
@@ -94,8 +94,7 @@ export const quotaService = {
   },
 
   reset(): void {
-    if (typeof window === "undefined") return;
-    localStorage.removeItem(STORAGE_KEYS.QUOTA_TRACKING);
+    safeRemove(STORAGE_KEYS.QUOTA_TRACKING);
     // Dispatch event to update UI with empty data
     dispatchEvent("quota-updated", {
       used: 0,

--- a/src/shared/components/ui/FloatingScrollButton.tsx
+++ b/src/shared/components/ui/FloatingScrollButton.tsx
@@ -13,7 +13,10 @@ export function FloatingScrollButton() {
   const { t } = useTranslation();
   const [scrollDirection, setScrollDirection] = useState<"up" | "down">("down");
   const [isVisible, setIsVisible] = useState(false);
-  const [lastScrollY, setLastScrollY] = useState(0);
+  // Use a ref instead of state so the scroll handler can read the latest value
+  // without being listed in the useEffect dep array (which caused the listener
+  // to be removed and re-added on every scroll event).
+  const lastScrollYRef = useRef(0);
   const [isNearButton, setIsNearButton] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -73,17 +76,17 @@ export function FloatingScrollButton() {
             setIsVisible(true);
           } else {
             // In the middle: show based on last scroll direction
-            if (currentScrollY > lastScrollY) {
+            if (currentScrollY > lastScrollYRef.current) {
               // Scrolling down -> show "go to bottom"
               setScrollDirection("down");
-            } else if (currentScrollY < lastScrollY) {
+            } else if (currentScrollY < lastScrollYRef.current) {
               // Scrolling up -> show "go to top"
               setScrollDirection("up");
             }
             setIsVisible(true);
           }
 
-          setLastScrollY(currentScrollY);
+          lastScrollYRef.current = currentScrollY;
           ticking = false;
         });
         ticking = true;
@@ -95,7 +98,7 @@ export function FloatingScrollButton() {
 
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [lastScrollY]);
+  }, []);
 
   const handleClick = useCallback(() => {
     if (scrollDirection === "up") {

--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseLocalStorageOptions<T> {
   serialize?: (value: T) => string;
@@ -15,6 +15,10 @@ export function useLocalStorage<T>(
 ): [T, (value: T | ((prev: T) => T)) => void, () => void] {
   const serialize = options?.serialize ?? JSON.stringify;
   const deserialize = options?.deserialize ?? JSON.parse;
+
+  // Stable ref for initialValue to avoid re-creating the remove callback when
+  // the caller passes a new object/array reference on each render.
+  const initialValueRef = useRef(initialValue);
 
   const [storedValue, setStoredValue] = useState<T>(() => {
     if (typeof window === "undefined") return initialValue;
@@ -44,11 +48,11 @@ export function useLocalStorage<T>(
   const remove = useCallback(() => {
     try {
       localStorage.removeItem(key);
-      setStoredValue(initialValue);
+      setStoredValue(initialValueRef.current);
     } catch {
       // Ignore
     }
-  }, [key, initialValue]);
+  }, [key]);
 
   // Listen for storage changes from other tabs
   useEffect(() => {


### PR DESCRIPTION
Five small correctness/consistency fixes across the Vite + React codebase. All changes are behaviour-equivalent; no feature changes.

| Datei | Kategorie | Befund | Aufwand | Empfehlung |
|---|---|---|---|---|
| `src/shared/hooks/useLocalStorage.ts` | Correctness | `remove` callback had `initialValue` in dep array — unstable reference for object/array values caused unnecessary callback recreations | S | auto-fix |
| `src/shared/components/ui/FloatingScrollButton.tsx` | Correctness | `lastScrollY` state in scroll-effect dep array → listener removed+added on every scroll event | S | auto-fix |
| `src/app/App.tsx` | Correctness | Direct `localStorage.setItem(key, JSON.stringify(...))` in import handler instead of project-standard `safeWrite` | S | auto-fix |
| `src/app/App.tsx` | Maintainability | Raw `document.addEventListener('keydown', ...)` in useEffect instead of shared `useEventListener` hook | S | auto-fix |
| `src/features/youtube/services/quotaService.ts` | Correctness | Direct `localStorage.removeItem` in `reset()` instead of `safeRemove` (inconsistent with safeRead/safeWrite usage in same file) | S | auto-fix |

Closes #187


---
_Generated by [Claude Code](https://claude.ai/code/session_01EzbpCYyaVmg1K7YNuG1m4u)_