### PR TITLE
refactor: best-practice sweep (Vite + React + Electron)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -212,8 +212,8 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
               </h3>
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-3">
-              {topVideos.map((video, index) => (
-                <VideoCard key={video.id} video={video} rank={index + 1} />
+              {topVideos.map((video) => (
+                <VideoCard key={video.id} video={video} />
               ))}
             </div>
           </div>

--- a/src/shared/components/ui/EmptyState.tsx
+++ b/src/shared/components/ui/EmptyState.tsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { useTranslation } from "react-i18next";
 
-export const EmptyState: React.FC = () => {
+export function EmptyState() {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center px-4">

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -652,13 +652,13 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
 
       {!loading && !error && videos && (
         <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-3">
-          {videos.map((video, idx) => {
+          {videos.map((video) => {
             const isFresh =
               typeof video?.publishedTimestamp === "number" &&
               Date.now() - video.publishedTimestamp < 24 * 60 * 60 * 1000;
             return (
               <div key={video.id} className={isFresh ? "fresh-green-border rounded-xl" : ""}>
-                <VideoCard video={video} rank={idx + 1} />
+                <VideoCard video={video} />
               </div>
             );
           })}

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useEffect, useState } from "react";
 import { Clock, Eye, Trash2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { hiddenHighlightsService, type HiddenHighlight } from "@/src/features/dashboard";
@@ -9,22 +9,19 @@ interface HiddenHighlightsModalProps {
   onClose: () => void;
 }
 
-export const HiddenHighlightsModal: React.FC<HiddenHighlightsModalProps> = ({
-  isOpen,
-  onClose,
-}) => {
+export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModalProps) {
   const { t } = useTranslation();
-  const [hiddenItems, setHiddenItems] = React.useState<HiddenHighlight[]>([]);
+  const [hiddenItems, setHiddenItems] = useState<HiddenHighlight[]>([]);
 
   // Load the list when the modal opens
-  React.useEffect(() => {
+  useEffect(() => {
     if (isOpen) {
       setHiddenItems(hiddenHighlightsService.listChronological());
     }
   }, [isOpen]);
 
   // Close on Escape (WCAG 2.1.2 — provide keyboard escape from modal)
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();

--- a/src/shared/components/ui/ThemeToggle.tsx
+++ b/src/shared/components/ui/ThemeToggle.tsx
@@ -1,9 +1,8 @@
-import React from "react";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@/src/providers/ThemeProvider";
 
-export const ThemeToggle: React.FC = () => {
+export function ThemeToggle() {
   const { theme, resolvedTheme, setTheme } = useTheme();
   const { t } = useTranslation();
 

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 
 interface VideoCardProps {
   video: VideoData;
-  rank: number;
 }
 
 export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {

--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { useEventListener } from "./useEventListener";
 
 interface UseLocalStorageOptions<T> {
   serialize?: (value: T) => string;
@@ -55,20 +56,15 @@ export function useLocalStorage<T>(
   }, [key]);
 
   // Listen for storage changes from other tabs
-  useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === key && e.newValue !== null) {
-        try {
-          setStoredValue(deserialize(e.newValue));
-        } catch {
-          // Ignore parse errors
-        }
+  useEventListener("storage", (e: StorageEvent) => {
+    if (e.key === key && e.newValue !== null) {
+      try {
+        setStoredValue(deserialize(e.newValue));
+      } catch {
+        // Ignore parse errors
       }
-    };
-
-    window.addEventListener("storage", handleStorageChange);
-    return () => window.removeEventListener("storage", handleStorageChange);
-  }, [key, deserialize]);
+    }
+  });
 
   return [storedValue, setValue, remove];
 }


### PR DESCRIPTION
## Summary

- **VideoCard**: Remove unused `rank` prop from interface and all callers; clean up the now-redundant `idx`/`index` loop variables (3 files, behavior-equivalent)
- **useLocalStorage**: Replace raw `window.addEventListener("storage", …)` with the existing `useEventListener` hook for consistency (1 file)
- **HiddenHighlightsModal / ThemeToggle / EmptyState**: Drop redundant `import React from "react"` namespace imports and convert `React.FC` to plain function declarations — `jsx:react-jsx` handles the transform without the namespace (3 files)

All 5 commits are pure behavior-equivalent refactors. No logic changes.

## Verification

- `npx tsc --noEmit`: green (0 errors)
- `npx vite build`: green (builds to `dist/` successfully)
- ESLint: no lint script configured — skipped
- Tests: no test framework configured — skipped

Closes #189

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhprVN9LWS5zkTpUftmnL4)_