### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/features/dashboard/services/dashboardBackupService.ts
+++ b/src/features/dashboard/services/dashboardBackupService.ts
@@ -18,10 +18,9 @@ export interface DashboardBackupPayload {
   };
 }
 
-export interface ParseResult {
-  ok: boolean;
-  payload: DashboardBackupPayload;
-}
+export type ParseResult =
+  | { ok: true; payload: DashboardBackupPayload }
+  | { ok: false; payload?: never };
 
 export const dashboardBackupService = {
   createBackup(options: {
@@ -62,11 +61,11 @@ export const dashboardBackupService = {
         typeof parsed.version !== "number" ||
         typeof parsed.data !== "object"
       ) {
-        return { ok: false, payload: parsed };
+        return { ok: false };
       }
 
       if (!Array.isArray(parsed.data.favorites)) {
-        return { ok: false, payload: parsed };
+        return { ok: false };
       }
 
       // favoritesCache must be a plain object (Record<string, FavoriteCacheEntry>).
@@ -77,23 +76,12 @@ export const dashboardBackupService = {
         parsed.data.favoritesCache === null ||
         Array.isArray(parsed.data.favoritesCache)
       ) {
-        return { ok: false, payload: parsed };
+        return { ok: false };
       }
 
       return { ok: true, payload: parsed as DashboardBackupPayload };
     } catch {
-      return {
-        ok: false,
-        payload: {
-          version: 0,
-          createdAt: 0,
-          data: {
-            favorites: [],
-            favoritesCache: {},
-            dashboard: { sortMode: "alpha", sortOrder: "asc" },
-          },
-        },
-      };
+      return { ok: false };
     }
   },
 };

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { STORAGE_KEYS } from "@shared/constants";
 
 type Theme = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";
@@ -11,8 +12,6 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-const STORAGE_KEY = "tt.theme";
-
 function getSystemTheme(): ResolvedTheme {
   if (typeof window === "undefined") return "dark";
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -20,7 +19,7 @@ function getSystemTheme(): ResolvedTheme {
 
 function getStoredTheme(): Theme {
   if (typeof window === "undefined") return "system";
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = localStorage.getItem(STORAGE_KEYS.THEME);
   if (stored === "light" || stored === "dark" || stored === "system") {
     return stored;
   }
@@ -37,7 +36,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
     if (typeof window !== "undefined") {
-      localStorage.setItem(STORAGE_KEY, newTheme);
+      localStorage.setItem(STORAGE_KEYS.THEME, newTheme);
     }
   };
 

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -5,6 +5,7 @@ import type { QuotaHistoryEntry } from "@/src/shared/types";
 import { useTranslation } from "react-i18next";
 import { formatNumber } from "@/src/shared/lib/formatters";
 import { eventBus } from "@/src/shared/lib/eventBus";
+import { STORAGE_KEYS } from "@/src/shared/constants";
 
 // Determine optimal time window based on actual data.
 // Returns i18n key + half-window key so labels are translated at render time.
@@ -217,12 +218,16 @@ export const ApiQuotaIndicator: React.FC = () => {
     // Typed event bus for in-app quota updates
     const offQuota = eventBus.on("quota-updated", handleQuotaUpdate);
 
-    // Native storage event for cross-tab sync (not in EventMap, so raw listener)
-    window.addEventListener("storage", handleQuotaUpdate);
+    // Native storage event for cross-tab quota sync — filter to the quota key only
+    // so unrelated localStorage writes do not trigger unnecessary re-renders.
+    const handleStorageEvent = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEYS.QUOTA_TRACKING) handleQuotaUpdate();
+    };
+    window.addEventListener("storage", handleStorageEvent);
 
     return () => {
       offQuota();
-      window.removeEventListener("storage", handleQuotaUpdate);
+      window.removeEventListener("storage", handleStorageEvent);
     };
   }, []);
 

--- a/src/shared/components/ui/FavoriteAvatar.tsx
+++ b/src/shared/components/ui/FavoriteAvatar.tsx
@@ -69,7 +69,6 @@ export const FavoriteAvatar: React.FC<FavoriteAvatarProps> = ({
   size = "md",
 }) => {
   const cache = favoritesService.getCache(favorite.id);
-  const channelId = cache?.meta?.channelId;
   const channelTitle = cache?.meta?.channelTitle || favorite.query;
 
   const isKeyword = favorite.searchType === SearchType.KEYWORD;
@@ -77,14 +76,9 @@ export const FavoriteAvatar: React.FC<FavoriteAvatarProps> = ({
   const initials = useMemo(() => getInitials(channelTitle), [channelTitle]);
   const bgColor = useMemo(() => getAvatarColor(favorite.query), [favorite.query]);
 
-  // YouTube channel avatar URL (if we have channelId)
-  // Note: This requires a separate API call to get the actual thumbnail
-  // For now, we use initials as fallback
-  const avatarUrl = useMemo(() => {
-    // YouTube doesn't provide direct avatar URLs via channel ID alone
-    // We would need to fetch channel details - for now use initials
-    return null;
-  }, [channelId]);
+  // Avatar URL placeholder: direct YouTube avatar URLs require an additional
+  // API call (not yet implemented). Initials are used as fallback for now.
+  const avatarUrl = null;
 
   const sizeClasses = size === "sm" ? "w-7 h-7 text-xs" : "w-9 h-9 text-sm";
 

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -136,7 +136,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
       setLiveTimeAgo(formatTimeAgo(lastFetchedAt, t));
     }, 10000); // alle 10 Sekunden aktualisieren
     return () => clearInterval(interval);
-  }, [lastFetchedAt, loading]);
+  }, [lastFetchedAt, loading, t]);
 
   // Reagiere auf externe Cache-Updates via typed event bus
   // (z.B. wenn ein anderer Prozess den Cache aktualisiert)

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -19,6 +19,7 @@ export const STORAGE_KEYS = {
   HIDDEN_HIGHLIGHTS: "tt.dashboard.hiddenHighlights.v1",
   ANALYSER_SORT_MODE: "tt.analyser.sortMode",
   ANALYSER_TOP_N: "tt.analyser.topN",
+  THEME: "tt.theme",
 } as const;
 
 export const CACHE_TTL = {


### PR DESCRIPTION
Five small, behavior-equivalent correctness and maintainability improvements identified during a best-practice sweep of the Vite 8 + React 19 + TS 6 stack.

## Merged Findings

| Datei | Kategorie | Befund | Fix | Aufwand | Empfehlung |
|---|---|---|---|---|---|
| `FavoriteRow.tsx` | Correctness | Missing `t` in `useEffect` dep array → stale i18n closure in interval | Add `t` to dep array | S | auto-fix |
| `ThemeProvider.tsx` + `config.ts` | Maintainability | Hardcoded `"tt.theme"` storage key not in central `STORAGE_KEYS` | Add `STORAGE_KEYS.THEME`; use it in ThemeProvider | S | auto-fix |
| `dashboardBackupService.ts` | Correctness | `ParseResult.payload` non-nullable even when `ok: false`; error paths returned raw parsed objects | Replace interface with discriminated union | S | auto-fix |
| `ApiQuotaIndicator.tsx` | Correctness | Unfiltered `storage` event fires on every localStorage write, not just quota changes | Filter by `STORAGE_KEYS.QUOTA_TRACKING` | S | auto-fix |
| `FavoriteAvatar.tsx` | Maintainability | `useMemo(() => null, [channelId])` — always-null memo is dead code | Replace with `const avatarUrl = null` | S | auto-fix |

All commits pass `npm run typecheck` (tsc --noEmit) and `npm run build`.

Closes #191

https://claude.ai/code/session_01ASZre7Tvy6vXwpjAsNz5bd

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASZre7Tvy6vXwpjAsNz5bd)_