### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -239,6 +239,7 @@ const App: React.FC = () => {
             onImportFile={handleDashboardImportFile}
             onOpenHiddenModal={() => setIsHiddenHighlightsModalOpen(true)}
             onClearAllFavorites={handleClearAllFavorites}
+            onOpenAnalyser={() => setActivePage("analyser")}
           />
         ) : (
           <AnalyserPage

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -234,7 +234,11 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
       )}
 
       {/* Empty State */}
-      {!searchState.data && !searchState.isLoading && <EmptyState />}
+      {!searchState.data && !searchState.isLoading && (
+        <EmptyState
+          variant={searchState.step === "idle" && !searchState.error ? "welcome" : "no-results"}
+        />
+      )}
     </>
   );
 }

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef } from "react";
-import { Activity, Download, EyeOff, RefreshCw, Trash2, Upload } from "lucide-react";
+import { Activity, BarChart3, Download, EyeOff, RefreshCw, Trash2, Upload } from "lucide-react";
 import { FavoriteRow } from "@/src/shared/components/ui/FavoriteRow";
 import { FavoriteAvatar } from "@/src/shared/components/ui/FavoriteAvatar";
 import { HighlightVideoCard } from "@/src/shared/components/ui/HighlightVideoCard";
@@ -37,6 +37,7 @@ interface DashboardPageProps {
   onImportFile: (file: File) => Promise<void>;
   onOpenHiddenModal: () => void;
   onClearAllFavorites: () => void;
+  onOpenAnalyser: () => void;
 }
 
 export function DashboardPage({
@@ -56,6 +57,7 @@ export function DashboardPage({
   onImportFile,
   onOpenHiddenModal,
   onClearAllFavorites,
+  onOpenAnalyser,
 }: DashboardPageProps) {
   const { t } = useTranslation();
   const importRef = useRef<HTMLInputElement | null>(null);
@@ -341,8 +343,16 @@ export function DashboardPage({
 
       {/* Favorites list */}
       {favorites.length === 0 ? (
-        <div className="bg-slate-50 border border-slate-200 text-slate-600 dark:bg-slate-900/50 dark:border-slate-800 rounded-xl p-6 text-center dark:text-slate-400">
-          {t("dashboard.noFavorites")}
+        <div className="bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-800 rounded-xl p-8 text-center flex flex-col items-center gap-4">
+          <p className="text-slate-600 dark:text-slate-400">{t("dashboard.noFavorites")}</p>
+          <button
+            type="button"
+            onClick={onOpenAnalyser}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition-colors shadow-sm shadow-indigo-900/20"
+          >
+            <BarChart3 className="w-4 h-4" />
+            {t("dashboard.openAnalyser")}
+          </button>
         </div>
       ) : (
         <div className="space-y-10">

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -105,6 +105,7 @@
   },
   "dashboard": {
     "noFavorites": "Noch keine Favoriten. Lege im Analyser eine Suche als Favorit an.",
+    "openAnalyser": "Analyser öffnen",
     "highlights": {
       "title": "Highlights",
       "subtitle": "Top-Videos aus allen Favoriten (klickbar)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -105,6 +105,7 @@
   },
   "dashboard": {
     "noFavorites": "No favorites yet. Create a favorite from the analyzer.",
+    "openAnalyser": "Open Analyser",
     "highlights": {
       "title": "Highlights",
       "subtitle": "Top videos across all favorites (click to open)",

--- a/src/shared/components/ui/EmptyState.tsx
+++ b/src/shared/components/ui/EmptyState.tsx
@@ -1,17 +1,38 @@
+import { AlertCircle } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { useTranslation } from "react-i18next";
 
-export function EmptyState() {
+interface EmptyStateProps {
+  /** "welcome" = initial state before any search; "no-results" = search returned nothing */
+  variant?: "welcome" | "no-results";
+}
+
+export function EmptyState({ variant = "welcome" }: EmptyStateProps) {
   const { t } = useTranslation();
+
+  if (variant === "no-results") {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center px-4">
+        <div className="w-24 h-24 bg-slate-100 dark:bg-slate-800 rounded-full flex items-center justify-center mb-6 shadow-xl border border-slate-200 dark:border-slate-700">
+          <AlertCircle className="w-12 h-12 text-slate-400 dark:text-slate-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-slate-700 dark:text-slate-200 mb-2">
+          {t("emptyState.title")}
+        </h2>
+        <p className="text-slate-500 dark:text-slate-400 max-w-md">{t("emptyState.description")}</p>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center px-4">
       <div className="w-24 h-24 bg-slate-100 dark:bg-slate-800 rounded-full flex items-center justify-center mb-6 shadow-xl border border-slate-200 dark:border-slate-700 animate-pulse">
         <Youtube className="w-12 h-12 text-red-500" />
       </div>
       <h2 className="text-2xl font-bold text-slate-700 dark:text-slate-200 mb-2">
-        {t("emptyState.title")}
+        {t("empty.title")}
       </h2>
-      <p className="text-slate-500 dark:text-slate-400 max-w-md">{t("emptyState.description")}</p>
+      <p className="text-slate-500 dark:text-slate-400 max-w-md">{t("empty.desc")}</p>
     </div>
   );
 }

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Clock, Eye, EyeOff, Sparkles, Zap } from "lucide-react";
+import { Check, Clock, Copy, Eye, EyeOff, Sparkles, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
@@ -30,6 +30,31 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
   onHide,
 }) => {
   const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const resetCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(video.url).then(
+      () => {
+        setCopied(true);
+        if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
+        resetCopiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
+      },
+      () => {
+        // Clipboard API unavailable
+      },
+    );
+  };
+
   // Frische Videos (jünger als 24h) mit grünem Rand hervorheben
   const isFresh =
     typeof video?.publishedTimestamp === "number" &&
@@ -133,6 +158,23 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
               {video.viewsPerHour ? `~${formatNumber(video.viewsPerHour)}/h` : "N/A"}
             </span>
           </div>
+        </div>
+
+        {/* Copy URL action */}
+        <div className="mt-auto pt-2 flex items-center justify-end">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700"
+            title={t("results.table.copyUrl")}
+            aria-label={t("results.table.copyUrlAria", { title: video.title })}
+          >
+            {copied ? (
+              <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
+            ) : (
+              <Copy className="w-3.5 h-3.5" aria-hidden="true" />
+            )}
+          </button>
         </div>
       </div>
       {isRefreshing && (


### PR DESCRIPTION
## Summary

- **HighlightVideoCard**: adds a copy-URL button (same pattern as `VideoCard` + `VideoListTable`) so users can copy a highlight video URL directly from the dashboard with one click.
- **Dashboard empty state**: adds an "Open Analyser" CTA button below the "no favorites yet" text, reducing friction for new users who need to discover the Analyser.
- **Analyser EmptyState**: introduces a `variant` prop (`welcome` | `no-results`); the initial load now shows the inviting "Analyze YouTube channels" heading (already translated but unused), while a failed/empty search shows the generic "No results" copy with an `AlertCircle` icon.

## Verification

- `tsc --noEmit`: green
- `npm run build`: green (390 kB JS, 342 ms)
- No ESLint config present in repo — not a regression from this PR.

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand | Empfehlung |
|---|---|---|---|---|---|---|
| 1 | `HighlightVideoCard.tsx` | Komfort | Copy-URL-Button | Dashboard-Highlights konsistent mit anderen Video-Ansichten | S | auto-build |
| 2 | `DashboardPage.tsx` + i18n | Komfort | CTA "Open Analyser" | Leerer Dashboard-Zustand wird handlungsorientiert | S | auto-build |
| 3 | `EmptyState.tsx` + `AnalyserPage.tsx` | Qualitat | Welcome- vs No-Results-State | Irrefuhrender "Keine Ergebnisse"-Text beim ersten App-Start behoben | S | auto-build |

Closes #199

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01WafBUNNx6rAkViuf6XHqLG)_