### PR TITLE
ux: best-practice sweep (Vite + React)

### DIFF
--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -403,8 +403,10 @@ export const ApiQuotaIndicator: React.FC = () => {
             <button
               onClick={() => setIsOpen(false)}
               className="text-slate-400 hover:text-slate-200 transition-colors"
+              aria-label={t("modal.close")}
+              type="button"
             >
-              <X className="w-4 h-4" />
+              <X className="w-4 h-4" aria-hidden="true" />
             </button>
           </div>
 

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -483,6 +483,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
               }}
               aria-expanded={showTfMenu}
               aria-haspopup="listbox"
+              aria-label={t("favorites.changeTimeFrame")}
               className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:bg-slate-200/70 dark:hover:bg-slate-700/70"
               title={t("favorites.changeTimeFrame")}
             >
@@ -518,6 +519,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
               }}
               aria-expanded={showMaxMenu}
               aria-haspopup="listbox"
+              aria-label={t("favorites.changeMaxResults")}
               className="px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:bg-slate-200/70 dark:hover:bg-slate-700/70"
               title={t("favorites.changeMaxResults")}
             >

--- a/src/shared/components/ui/LanguageSwitcher.tsx
+++ b/src/shared/components/ui/LanguageSwitcher.tsx
@@ -97,7 +97,7 @@ export const LanguageSwitcher: React.FC = () => {
       </label>
       <div className="relative">
         <select
-          aria-label="Language"
+          aria-label={t("language.label")}
           className="px-3 py-1.5 rounded-md border text-xs font-medium \
                      border-slate-300 text-slate-700 bg-white dark:bg-slate-900 \
                      dark:border-slate-700 dark:text-slate-300"

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -92,11 +92,11 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                         target="_blank"
                         rel="noopener noreferrer"
                         className="relative w-24 h-14 shrink-0 rounded-md overflow-hidden bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 cursor-pointer"
-                        aria-label={video.title}
+                        aria-label={t("results.table.watchOnYoutubeAria", { title: video.title })}
                       >
                         <img
                           src={video.thumbnailUrl}
-                          alt={video.title}
+                          alt=""
                           className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
                           loading="lazy"
                         />


### PR DESCRIPTION
Accessibility sweep across the shared UI component layer. All 5 findings are `aria-*` fixes — no behaviour or visual changes.

## Findings

| # | File | Category | Finding | Effort |
|---|------|----------|---------|--------|
| 1 | `ApiQuotaIndicator.tsx` | a11y | Icon-only close button had no `aria-label` | S |
| 2 | `LanguageSwitcher.tsx` | a11y | `<select aria-label>` hardcoded to English instead of `t("language.label")` | S |
| 3 | `FavoriteRow.tsx` | a11y | Timeframe picker button missing `aria-label` (only had `title`) | S |
| 4 | `FavoriteRow.tsx` | a11y | Max-results picker button missing `aria-label` (only had `title`) | S |
| 5 | `VideoListTable.tsx` | a11y | Thumbnail `<a>` had same label as adjacent text link + img with same alt → title announced 2–3× by screen reader | S |

All fixes are additive (`aria-label` additions / attribute corrections). TypeScript typecheck and production build both pass.

Closes #201

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsfjxvAcwC26MygzN1BXeZ)_