### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -233,6 +233,42 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
         </div>
       )}
 
+      {/* Loading skeleton: shown while fetching when there are no prior results yet */}
+      {searchState.isLoading && !searchState.data && (
+        <div
+          className="space-y-8 animate-pulse"
+          role="status"
+          aria-label={t(
+            searchState.step === "analyzing_ai"
+              ? "loadingState.analyzing"
+              : "loadingState.fetchingYoutube",
+          )}
+        >
+          {/* Skeleton control bar */}
+          <div className="h-14 rounded-xl bg-slate-200 dark:bg-slate-800" />
+          {/* Skeleton card grid (topN=6 placeholder cards) */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-xl overflow-hidden border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 flex flex-col"
+              >
+                <div className="h-40 bg-slate-200 dark:bg-slate-700" />
+                <div className="p-4 space-y-2 flex-1">
+                  <div className="h-3 w-3/4 rounded bg-slate-200 dark:bg-slate-700" />
+                  <div className="h-3 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
+                  <div className="grid grid-cols-3 gap-2 mt-3">
+                    {[0, 1, 2].map((j) => (
+                      <div key={j} className="h-12 rounded-lg bg-slate-100 dark:bg-slate-700" />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Empty State */}
       {!searchState.data && !searchState.isLoading && (
         <EmptyState

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -414,7 +414,13 @@ export const InputSection: React.FC<InputSectionProps> = ({
               aria-expanded={
                 (showSuggestions && suggestions.length > 0) || (showHistory && history.length > 0)
               }
-              aria-controls="search-listbox"
+              aria-controls={
+                showSuggestions && suggestions.length > 0
+                  ? "search-suggestions-listbox"
+                  : showHistory && history.length > 0
+                    ? "search-history-listbox"
+                    : undefined
+              }
               aria-haspopup="listbox"
             />
 
@@ -439,7 +445,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
             {/* Suggestions Dropdown */}
             {showSuggestions && suggestions.length > 0 && (
               <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in">
-                <ul id="search-listbox" role="listbox">
+                <ul id="search-suggestions-listbox" role="listbox">
                   {suggestions.map((sug) => (
                     <li key={sug.id} role="option" aria-selected="false">
                       <button
@@ -472,7 +478,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
             {/* History Dropdown (shown only on focus when input is empty) */}
             {showHistory && history.length > 0 && (
               <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in">
-                <ul id="search-listbox" role="listbox">
+                <ul id="search-history-listbox" role="listbox">
                   {history.map((item, idx) => (
                     <li
                       key={`${item}-${idx}`}

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -47,7 +47,7 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
   return (
     <div className="bg-white/50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden backdrop-blur-sm shadow-xl">
       <div className="overflow-x-auto">
-        <table className="w-full text-left border-collapse">
+        <table className="w-full text-left border-collapse" aria-label={t("results.moreVideos")}>
           <thead>
             <tr className="bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800 text-xs uppercase tracking-wider text-slate-500 font-semibold">
               <th scope="col" className="p-4 w-16 text-center">
@@ -84,7 +84,9 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                   key={video.id}
                   className="hover:bg-slate-100/40 dark:hover:bg-slate-800/40 transition-colors group"
                 >
-                  <td className="p-4 text-center text-slate-500 font-mono font-medium">{rank}</td>
+                  <td className="p-4 text-center text-slate-500 font-mono font-medium" scope="row">
+                    {rank}
+                  </td>
                   <td className="p-4">
                     <div className="flex items-center gap-4">
                       <a


### PR DESCRIPTION
Closes #203

UX refine sweep — 3 existing features sharpened (comfort/UX). No new user-facing text added; all aria-label/role-status values reuse existing i18n keys. Verified: `format:check` + `vite build` green.

| # | Feature | UX gap | Improvement | Effort | Recommendation |
|---|---|---|---|---|---|
| 1 | Analyser search loading | Welcome empty-state shown during active search — no below-fold feedback | Pulsing skeleton grid (control bar + 6 card placeholders) while `isLoading && !data`; accessible `role="status"` with translated label | S | auto-refine |
| 2 | Results table (VideoListTable) | `<table>` had no accessible name; rank `<td>` lacked `scope="row"` | `aria-label` on table reusing existing `results.moreVideos` key; `scope="row"` on rank cell | S | auto-refine |
| 3 | Search input combobox (InputSection) | Duplicate `id="search-listbox"` on both suggestions and history dropdowns — HTML validity violation, `aria-controls` could reference wrong element | Split into `search-suggestions-listbox` / `search-history-listbox`; `aria-controls` now points dynamically to whichever listbox is visible | S | auto-refine |

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01VUsKKUXwYL7HuEAmiPVe2T)_