### PR TITLE
ux: best-practice sweep (Vite + React)

### DIFF
--- a/src/shared/components/layout/Footer.tsx
+++ b/src/shared/components/layout/Footer.tsx
@@ -32,8 +32,10 @@ export function Footer() {
             onClick={() => setShowDetails(!showDetails)}
             className="flex items-center gap-1 px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
             title={t("footer.toggleDetails")}
+            aria-label={t("footer.toggleDetails")}
+            aria-expanded={showDetails}
           >
-            <Info className="w-3.5 h-3.5" />
+            <Info className="w-3.5 h-3.5" aria-hidden="true" />
             <span className="hidden sm:inline">{t("footer.buildInfo")}</span>
           </button>
         </div>
@@ -63,8 +65,9 @@ export function Footer() {
             rel="noopener noreferrer"
             className="flex items-center gap-1 px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
             title="GitHub"
+            aria-label="GitHub"
           >
-            <Github className="w-3.5 h-3.5" />
+            <Github className="w-3.5 h-3.5" aria-hidden="true" />
           </a>
         </div>
       </div>

--- a/src/shared/components/ui/FavoriteAvatar.tsx
+++ b/src/shared/components/ui/FavoriteAvatar.tsx
@@ -95,6 +95,7 @@ export const FavoriteAvatar: React.FC<FavoriteAvatarProps> = ({
       onClick={onClick}
       className={`relative shrink-0 group ${buttonSizeClasses} ${isRefreshing ? "avatar-loading-spin" : ""}`}
       title={channelTitle}
+      aria-label={channelTitle}
     >
       {/* Avatar circle */}
       <div

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -620,8 +620,9 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
                 : "border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
             }`}
             title={t("favorites.refresh")}
+            aria-label={t("favorites.refresh")}
           >
-            <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />{" "}
+            <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} aria-hidden="true" />{" "}
             {t("actions.refresh")}
           </button>
 
@@ -631,8 +632,9 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
               onClick={() => onRemove?.(currentFavId)}
               className="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-md border border-red-500/30 text-red-400 dark:text-red-300 hover:bg-red-500/10 transition-colors"
               title={t("favorites.remove")}
+              aria-label={t("favorites.remove")}
             >
-              <Trash2 className="w-3 h-3" /> {t("actions.remove")}
+              <Trash2 className="w-3 h-3" aria-hidden="true" /> {t("actions.remove")}
             </button>
           )}
         </div>

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -57,8 +57,14 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center">
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      {/* Backdrop — keyboard users can close with Escape (handled above); the button role and label expose it to AT as well */}
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm cursor-default"
+        onClick={onClose}
+        aria-label={t("modal.close")}
+        tabIndex={-1}
+      />
 
       {/* Modal */}
       <div


### PR DESCRIPTION
## Stack
Vite 8 + React 19 + TypeScript + Tailwind CSS v4 + i18next (UI strings via `t('key')`)

## Findings
| # | File | Category | Issue | Fix | Impact | Effort | Recommendation | Status |
|---|------|----------|-------|-----|--------|--------|----------------|--------|
| 1 | `src/shared/components/layout/Footer.tsx` | a11y | GitHub icon-only `<a>` has no `aria-label` — screen readers announce nothing | Add `aria-label="GitHub"` + `aria-hidden` on icon | Screen reader users get silent link | S | auto-fix | ✅ fixed |
| 2 | `src/shared/components/layout/Footer.tsx` | a11y | Build-info button is icon-only on mobile (`<span className="hidden sm:inline">`) with no `aria-label` and no `aria-expanded` | Add `aria-label={t("footer.toggleDetails")}` + `aria-expanded={showDetails}` | Toggle state invisible to AT on small screens | S | auto-fix | ✅ fixed |
| 3 | `src/shared/components/ui/FavoriteAvatar.tsx` | a11y | Avatar `<button>` has `title` but no `aria-label` — `title` is not reliably announced by all screen readers | Add `aria-label={channelTitle}` | Channel name not exposed to AT | S | auto-fix | ✅ fixed |
| 4 | `src/shared/components/ui/HiddenHighlightsModal.tsx` | a11y / interaction | Modal backdrop is a plain `<div onClick={onClose}>` — non-interactive for keyboard users and not announced by AT | Replace with `<button type="button" tabIndex={-1} aria-label={t("modal.close")}>` | Keyboard users cannot close modal via backdrop click; WCAG 2.1.2 | S | auto-fix | ✅ fixed |
| 5 | `src/shared/components/ui/FavoriteRow.tsx` | a11y | Refresh and Remove buttons have `title` only, no `aria-label`; icons lack `aria-hidden` | Add `aria-label` matching `title` text; add `aria-hidden="true"` to decorative icons | Tooltips not reliably surfaced by AT | S | auto-fix | ✅ fixed |

## Further findings (not touched — dropped by tie-breaker)
| File | Category | Issue | Effort | Recommendation |
|------|----------|-------|--------|----------------|
| — none — | | | | |

## Deferred (too large / equivalence unclear)
| File | Issue | Effort | Recommendation | Reason |
|------|-------|--------|----------------|--------|
| — none — | | | | |

## Out of scope
- No `npm run lint` script configured (ESLint not set up) — not a blocker for this sweep.
- No test framework configured (`npm test` not available) — build + typecheck used as quality gate.
- Microcopy improvements would require new i18n keys in multiple locale files — deferred per sweep rules.
- Touch-target sizes (w-7 h-7 = 28 px < 44 px) on VideoCard/HighlightVideoCard action buttons are below WCAG 2.5.5 recommendation but fixing them requires layout restructuring (L effort) — deferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeezvWdcwBLC6U1X4irHqT)_