### PR TITLE
security: hardening sweep (Vite/React SPA)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,12 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # Content-Security-Policy: scoped to what the SPA actually loads.
+    # - script-src allows 'unsafe-inline' for the inline FOUC theme script in index.html
+    #   (the Vite app bundle itself is external under /assets/).
+    # - connect-src allows the YouTube Data API; img-src allows YouTube thumbnail CDNs
+    #   (i.ytimg.com, *.ggpht.com, *.googleusercontent.com) via the generic https: source.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     # Gzip compression for text assets
     gzip on;
@@ -28,5 +34,6 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     }
 }


### PR DESCRIPTION
## Security Hardening Sweep — TubeTrend

Scoped, behaviour-equivalent security hardening of the browser-reachable frontend / nginx web layer. Electron, Capacitor/Android, and Chrome-extension wrappers were out of scope.

### Changes

| # | Category | Severity | File | Fix class | Status |
|---|----------|----------|------|-----------|--------|
| 1 | Security Misconfiguration (missing CSP) | Medium | `nginx.conf` | safe / S | Fixed |

**Added a `Content-Security-Policy` header** to `nginx.conf` (both the `server` block and the `/assets/` child block, since nginx `add_header` in a child block replaces the parent set). The SPA already shipped `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, and `Permissions-Policy`, but had no CSP.

The CSP is scoped to exactly what the app loads, so nothing it currently does is blocked:

- `script-src 'self' 'unsafe-inline'` (inline FOUC theme script in `index.html`; the Vite bundle is external under `/assets/`)
- `style-src 'self' 'unsafe-inline'` (Tailwind / React inline styles)
- `img-src 'self' data: https:` (YouTube thumbnail CDNs)
- `connect-src 'self' https://www.googleapis.com` (YouTube Data API v3)
- `font-src 'self' data:` (bundled Inter fonts)
- `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`, `object-src 'none'`

### Verification

`npm ci` (0 vulnerabilities) → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. Config-only change; Prettier has no `.conf` parser, and the TS/Vite build is unchanged.

### Notes

- No XSS sinks found (`src/**` uses React's default escaping; no `dangerouslySetInnerHTML`/`innerHTML`/`eval`); all `target="_blank"` links already have `rel="noopener noreferrer"`; all `href`s are fixed-prefix `https://`/`blob:` URLs.
- No hardcoded secrets; the YouTube API key stays in `localStorage` and is sent only to `googleapis.com` per the API's key-auth design.

Refs #206

---
_Generated by [Claude Code](https://claude.ai/code/session_014eomoWq9FHGaAL432ZorKq)_