### PR TITLE
chore: quality & housekeeping sweep 2026-06-07

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,11 @@ Repository: `https://github.com/fo0/tubetrend`
 | Runtime              | Node.js                            | 22+                                                                                                   |
 | Language             | TypeScript                         | ~6.0.3                                                                                                |
 | UI Framework         | React                              | ^19.2.6                                                                                               |
-| Build Tool           | Vite                               | ^8.0.13                                                                                               |
+| Build Tool           | Vite                               | ^8.0.14                                                                                               |
 | Vite Plugin          | @vitejs/plugin-react               | ^6.0.2                                                                                                |
 | CSS Framework        | Tailwind CSS                       | ^4.2.4 (@tailwindcss/vite plugin)                                                                     |
 | Font                 | @fontsource/inter                  | ^5.2 (locally bundled)                                                                                |
-| Icons                | Lucide React                       | ^1.16.0                                                                                               |
+| Icons                | Lucide React                       | ^1.17.0                                                                                               |
 | i18n                 | i18next + react-i18next            | ^26.2 / ^17.0.8                                                                                       |
 | Language Detection   | i18next-browser-languagedetector   | ^8.2.1                                                                                                |
 | Package Manager      | npm                                | (lockfile v3)                                                                                         |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Use clear, descriptive commit messages:
 
 ### localStorage Keys
 
-The app uses localStorage for persistence. When debugging, you may need to clear these keys (see CLAUDE.md for the full list).
+The app uses localStorage for persistence. When debugging, you may need to clear these keys. The full list is defined in `src/shared/constants/config.ts` (`STORAGE_KEYS`).
 
 ### i18n
 


### PR DESCRIPTION
## Housekeeping Sweep — 2026-06-07

Rein dokumentarische Fixes. **Keine Version-Bumps enthalten.**

### Findings

| # | Pass | Datei(en) | Befund | Aufwand | Status |
|---|---|---|---|---|---|
| 1 | E Docs | `CLAUDE.md` | Vite `^8.0.13→^8.0.14` und Lucide React `^1.16.0→^1.17.0` in Tech-Stack-Tabelle veraltet (nach Dependabot-PRs #165/#193) | S | auto-fix |
| 2 | E Docs | `CONTRIBUTING.md` | localStorage-Keys-Verweis zeigte auf CLAUDE.md (kein Inhalt dort) statt auf `src/shared/constants/config.ts` | S | auto-fix |

### Tooling-Status

| Tool | Status |
|---|---|
| Prettier format:check | ✅ grün |
| tsc --noEmit | ✅ grün |
| ESLint | ❌ nicht konfiguriert (out-of-scope) |
| Tests | ❌ nicht konfiguriert (out-of-scope) |

Closes #217


---
_Generated by [Claude Code](https://claude.ai/code/session_013pihupduX4RNpYJgFbG8Em)_