### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { AlertCircle, Eye, List, Trophy } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertCircle, Check, Copy, Download, Eye, List, Trophy } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { InputSection } from "@/src/shared/components/ui/InputSection";
 import { VideoCard } from "@/src/shared/components/ui/VideoCard";
@@ -8,6 +8,7 @@ import { EmptyState } from "@/src/shared/components/ui/EmptyState";
 import { useTranslation } from "react-i18next";
 import type { SearchType, TimeFrame } from "@/src/shared/types";
 import type { SearchState } from "@/src/features/search/hooks/useSearch";
+import { buildResultsCsv, buildResultsCsvFilename } from "@/src/features/videos";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 
 interface AnalyserPageProps {
@@ -88,6 +89,52 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
     return null;
   }, [searchState.channelId, searchState.channelName]);
 
+  // Comfort: export current (sorted) results as CSV + copy all URLs at once.
+  const [copiedAll, setCopiedAll] = useState(false);
+  const copiedAllTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedAllTimerRef.current) clearTimeout(copiedAllTimerRef.current);
+    };
+  }, []);
+
+  const handleExportCsv = () => {
+    if (sortedVideos.length === 0) return;
+    try {
+      const csv = buildResultsCsv(sortedVideos);
+      const filename = buildResultsCsvFilename(searchState.channelName);
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch {
+      // ignore download errors (e.g. blocked environments)
+    }
+  };
+
+  const handleCopyAllUrls = () => {
+    if (sortedVideos.length === 0) return;
+    // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
+    if (!navigator.clipboard) return;
+    const urls = sortedVideos.map((v) => v.url).join("\n");
+    navigator.clipboard.writeText(urls).then(
+      () => {
+        setCopiedAll(true);
+        if (copiedAllTimerRef.current) clearTimeout(copiedAllTimerRef.current);
+        copiedAllTimerRef.current = setTimeout(() => setCopiedAll(false), 1500);
+      },
+      () => {
+        // Clipboard API unavailable
+      },
+    );
+  };
+
   return (
     <>
       <InputSection
@@ -138,6 +185,34 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
             </div>
 
             <div className="flex items-center gap-3 text-sm font-medium">
+              {/* Export & Share actions */}
+              <div className="inline-flex items-center rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 p-0.5">
+                <button
+                  type="button"
+                  onClick={handleCopyAllUrls}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  title={t("results.copyAllUrls")}
+                  aria-label={t("results.copyAllUrls")}
+                >
+                  {copiedAll ? (
+                    <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
+                  ) : (
+                    <Copy className="w-4 h-4" aria-hidden="true" />
+                  )}
+                  <span className="hidden lg:inline">{t("results.copyAll")}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleExportCsv}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  title={t("results.exportCsv")}
+                  aria-label={t("results.exportCsv")}
+                >
+                  <Download className="w-4 h-4" aria-hidden="true" />
+                  <span className="hidden lg:inline">CSV</span>
+                </button>
+              </div>
+
               <span className="text-slate-500 dark:text-slate-400 whitespace-nowrap">
                 {t("results.sortedBy")}{" "}
                 {sortMode === "trend" ? t("results.sortModes.trend") : t("results.sortModes.views")}

--- a/src/features/videos/index.ts
+++ b/src/features/videos/index.ts
@@ -7,3 +7,4 @@ export * from "./types";
 
 // Services
 export { analyzeVideoStats } from "./services/trendAnalysisService";
+export { buildResultsCsv, buildResultsCsvFilename } from "./services/exportResults";

--- a/src/features/videos/services/exportResults.ts
+++ b/src/features/videos/services/exportResults.ts
@@ -1,0 +1,75 @@
+/**
+ * Export analyser results (a list of analysed videos) to a CSV string.
+ *
+ * Pure, dependency-free, and side-effect-free so it can be unit-tested and
+ * reused across surfaces. The download/blob handling stays in the UI layer.
+ */
+
+import type { VideoData } from "../types";
+
+/** Stable, machine-readable CSV column order. */
+const CSV_COLUMNS = [
+  "rank",
+  "title",
+  "url",
+  "views",
+  "viewsPerHour",
+  "engagementRate",
+  "trendingScore",
+  "publishedAt",
+] as const;
+
+/**
+ * Escape a single CSV field per RFC 4180: wrap in double quotes when the value
+ * contains a comma, quote, or newline, and double any embedded quotes.
+ */
+function escapeCsvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Build a CSV document (header + one row per video) from analyser results.
+ * Order is preserved exactly as passed in (the caller controls sorting).
+ */
+export function buildResultsCsv(videos: VideoData[]): string {
+  const header = CSV_COLUMNS.join(",");
+  const rows = videos.map((video, index) => {
+    const fields = [
+      String(index + 1),
+      video.title,
+      video.url,
+      String(video.views),
+      video.viewsPerHour != null ? String(video.viewsPerHour) : "",
+      video.engagementRate != null ? String(video.engagementRate) : "",
+      String(video.trendingScore),
+      new Date(video.publishedTimestamp).toISOString(),
+    ];
+    return fields.map((f) => escapeCsvField(f)).join(",");
+  });
+  return [header, ...rows].join("\r\n");
+}
+
+/**
+ * Build a filesystem-safe, timestamped CSV filename for an analyser export.
+ * e.g. buildResultsCsvFilename("@MrBeast") -> "tubetrend-MrBeast_2026-06-08_12-30-00.csv"
+ */
+export function buildResultsCsvFilename(
+  label: string | null | undefined,
+  now: Date = new Date(),
+): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const stamp =
+    `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}` +
+    `_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+  const slug = (label ?? "")
+    .replace(/^@/, "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  const namePart = slug ? `-${slug}` : "";
+  return `tubetrend${namePart}_${stamp}.csv`;
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -163,8 +163,13 @@
       "copyUrl": "Video-URL kopieren",
       "copyUrlAria": "URL kopieren für {{title}}",
       "watchOnYoutube": "Auf YouTube ansehen",
-      "watchOnYoutubeAria": "{{title}} – auf YouTube ansehen"
-    }
+      "watchOnYoutubeAria": "{{title}} – auf YouTube ansehen",
+      "copyTitle": "Videotitel kopieren",
+      "copyTitleAria": "Titel für {{title}} kopieren"
+    },
+    "copyAll": "Alle kopieren",
+    "copyAllUrls": "Alle Video-URLs kopieren",
+    "exportCsv": "Ergebnisse als CSV exportieren"
   },
   "timeAgo": {
     "justNow": "gerade eben",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -163,8 +163,13 @@
       "copyUrl": "Copy video URL",
       "copyUrlAria": "Copy URL for {{title}}",
       "watchOnYoutube": "Watch on YouTube",
-      "watchOnYoutubeAria": "{{title}} – watch on YouTube"
-    }
+      "watchOnYoutubeAria": "{{title}} – watch on YouTube",
+      "copyTitle": "Copy video title",
+      "copyTitleAria": "Copy title for {{title}}"
+    },
+    "copyAll": "Copy all",
+    "copyAllUrls": "Copy all video URLs",
+    "exportCsv": "Export results as CSV"
   },
   "timeAgo": {
     "justNow": "just now",

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, Eye, Heart, TrendingUp, Zap } from "lucide-react";
+import { Check, Clock, Copy, Eye, Heart, TrendingUp, Type, Zap } from "lucide-react";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { useTranslation } from "react-i18next";
 
@@ -11,11 +11,14 @@ interface VideoCardProps {
 export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
+  const [titleCopied, setTitleCopied] = useState(false);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetTitleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
       if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      if (resetTitleTimerRef.current) clearTimeout(resetTitleTimerRef.current);
     };
   }, []);
 
@@ -34,6 +37,22 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
       },
       () => {
         // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+      },
+    );
+  };
+
+  const handleCopyTitle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(video.title).then(
+      () => {
+        setTitleCopied(true);
+        if (resetTitleTimerRef.current) clearTimeout(resetTitleTimerRef.current);
+        resetTitleTimerRef.current = setTimeout(() => setTitleCopied(false), 1500);
+      },
+      () => {
+        // Clipboard API unavailable
       },
     );
   };
@@ -124,6 +143,19 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
 
         {/* Actions */}
         <div className="mt-auto pt-2 flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={handleCopyTitle}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700"
+            title={t("results.table.copyTitle")}
+            aria-label={t("results.table.copyTitleAria", { title: video.title })}
+          >
+            {titleCopied ? (
+              <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
+            ) : (
+              <Type className="w-3.5 h-3.5" aria-hidden="true" />
+            )}
+          </button>
           <button
             type="button"
             onClick={handleCopy}


### PR DESCRIPTION
## Stack

Vite + React 19 + TypeScript SPA. UI strings via i18n keys (en + de).

## Features

| # | Bereich/Datei | Kategorie | Feature | Nutzen für User | Aufwand | Empfehlung | Status |
|---|---------------|-----------|---------|-----------------|---------|------------|--------|
| 1 | `src/features/videos/services/exportResults.ts`, `src/app/routes/AnalyserPage.tsx` | Komfort | Export analyser results as CSV (pure `buildResultsCsv`/`buildResultsCsvFilename`, blob download from the control bar) | Trend data (rank, title, URL, views, velocity, engagement, score, upload) goes straight into Excel/Sheets — no manual copy/paste | M | auto-build | done |
| 2 | `src/app/routes/AnalyserPage.tsx` | Komfort | "Copy all URLs" button in the results control bar | Share or batch-open a whole result set at once instead of copying each video individually | S | auto-build | done |
| 3 | `src/shared/components/ui/VideoCard.tsx` | Polish | "Copy title" action on result cards (next to copy-URL, same check-mark feedback) | Grab a video's exact title for notes/scripts without opening the video | S | auto-build | done |

All features reuse existing patterns: i18n keys (no hardcoded strings), path aliases, `import type`, the established clipboard guard, and the existing blob-download approach. CSV building is a pure, testable, dependency-free service.

## Weitere Feature-Ideen

- Persist the last analyser result set across reloads (M, deferred — cache/quota equivalence risk).
- Toast system to replace `window.alert` (M, deferred — no toast lib present).

## Deferred

- `FavoriteRow.tsx` split (L, tracked in #126 / #185) — out of comfort-sweep scope.

## Out of Scope

- Refactors, dependency bumps, dependabot, Electron/Capacitor/Chrome-extension wrappers.
- Adding a test framework (none configured; verification is typecheck + build).

## Verification

`npm ci` (0 vulnerabilities) → `npm run format:check` → `npm run typecheck` → `npm run build` — all green.

Closes #219

---
_Generated by [Claude Code](https://claude.ai/code/session_017qEKJWSa8QRWKksWkEDDiR)_