### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/features/youtube/services/channelService.ts
+++ b/src/features/youtube/services/channelService.ts
@@ -141,7 +141,7 @@ export async function searchChannels(query: string): Promise<ChannelSuggestion[]
       .filter((id): id is string => typeof id === "string" && id.length > 0);
 
     // Fetch correct thumbnails via the channels endpoint (1 unit per up to 50 channels)
-    let thumbnailMap: Record<string, string> = {};
+    const thumbnailMap: Record<string, string> = {};
     if (channelIds.length > 0) {
       try {
         const channelsData = await fetchFromApi<YoutubeChannelListResponse>(


### PR DESCRIPTION
Behavior-equivalent best-practice sweep. One commit, one high-confidence finding. Gate (`npm run typecheck`) and `npm run build` both green locally.

## Findings

| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | `src/features/youtube/services/channelService.ts` | Maintainability (prefer-const) | `thumbnailMap` declared `let` but only ever index-mutated, never reassigned | `let` → `const` | S | ✅ done |

The codebase has been through several prior sweeps and is in good shape; no further in-scope behavior-equivalent findings surfaced. One uncertain item (`parseISO8601DurationToSeconds` regex edge case) is documented as deferred in the issue.

## Verification

- `npm ci` — ok
- `npm run typecheck` (`tsc --noEmit`) — **green** (authoritative gate)
- `npm run build` (vite) — **green** (1832 modules, built in ~386ms)

Closes #221

https://claude.ai/code/session_019y9cQ3rDUeP7r47xQ8u6jd

---
_Generated by [Claude Code](https://claude.ai/code/session_019y9cQ3rDUeP7r47xQ8u6jd)_