### PR TITLE
ux(a11y): best-practice sweep — aria-hidden and aria-pressed fixes

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -223,6 +223,7 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
                 <button
                   type="button"
                   onClick={() => setSortMode("trend")}
+                  aria-pressed={sortMode === "trend"}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
                     sortMode === "trend"
                       ? "bg-indigo-600 text-white"
@@ -230,12 +231,13 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
                   }`}
                   title={t("results.sortTitles.trend")}
                 >
-                  <Trophy className="w-4 h-4" />
+                  <Trophy className="w-4 h-4" aria-hidden="true" />
                   <span>{t("results.sortButtons.trendScore")}</span>
                 </button>
                 <button
                   type="button"
                   onClick={() => setSortMode("views")}
+                  aria-pressed={sortMode === "views"}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
                     sortMode === "views"
                       ? "bg-indigo-600 text-white"
@@ -243,7 +245,7 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
                   }`}
                   title={t("results.sortTitles.views")}
                 >
-                  <Eye className="w-4 h-4" />
+                  <Eye className="w-4 h-4" aria-hidden="true" />
                   <span>{t("results.sortButtons.views")}</span>
                 </button>
               </div>
@@ -253,6 +255,7 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
                 <button
                   type="button"
                   onClick={() => setTopN(3)}
+                  aria-pressed={topN === 3}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
                     topN === 3
                       ? "bg-indigo-600 text-white"
@@ -265,6 +268,7 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
                 <button
                   type="button"
                   onClick={() => setTopN(6)}
+                  aria-pressed={topN === 6}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
                     topN === 6
                       ? "bg-indigo-600 text-white"

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -260,6 +260,7 @@ export function DashboardPage({
               <button
                 type="button"
                 onClick={() => onSortClick("alpha")}
+                aria-pressed={dashboardSortMode === "alpha"}
                 className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
                   dashboardSortMode === "alpha"
                     ? "bg-indigo-600 text-white"
@@ -278,6 +279,7 @@ export function DashboardPage({
               <button
                 type="button"
                 onClick={() => onSortClick("velocity")}
+                aria-pressed={dashboardSortMode === "velocity"}
                 className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
                   dashboardSortMode === "velocity"
                     ? "bg-indigo-600 text-white"
@@ -285,7 +287,7 @@ export function DashboardPage({
                 }`}
                 title={t("dashboard.sorting.velocityTitle")}
               >
-                <Activity className="w-3 h-3" />
+                <Activity className="w-3 h-3" aria-hidden="true" />
                 <span>
                   {t("dashboard.sorting.activity")}
                   {dashboardSortMode === "velocity"

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -82,7 +82,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
         </a>
 
         <div className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm text-white text-xs font-bold px-2 py-1 rounded flex items-center gap-1 pointer-events-none">
-          <Clock className="w-3 h-3 text-slate-300" />
+          <Clock className="w-3 h-3 text-slate-300" aria-hidden="true" />
           {formatTimeAgo(video.publishedTimestamp, t)}
         </div>
 
@@ -90,7 +90,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
           className="absolute top-3 left-3 px-2.5 py-1 rounded-full text-xs font-bold border border-indigo-200/70 bg-indigo-600/90 text-white backdrop-blur-md flex items-center gap-1 pointer-events-none"
           title={`${sourceLabel} • Top ${sourceRank}`}
         >
-          <Sparkles className="w-3 h-3" />#{highlightRank}
+          <Sparkles className="w-3 h-3" aria-hidden="true" />#{highlightRank}
         </div>
 
         {/* Ausblenden-Button */}
@@ -110,7 +110,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
             title={t("dashboard.highlights.hide")}
             aria-label={t("dashboard.highlights.hide")}
           >
-            <EyeOff className="w-4 h-4" />
+            <EyeOff className="w-4 h-4" aria-hidden="true" />
           </button>
         )}
       </div>
@@ -142,7 +142,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
         <div className="grid grid-cols-2 gap-2 mb-3">
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" />{" "}
+              <Eye className="w-3 h-3 text-indigo-500 dark:text-indigo-400" aria-hidden="true" />{" "}
               {t("results.table.views")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">
@@ -151,7 +151,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
           </div>
           <div className="flex flex-col justify-center bg-slate-100/50 dark:bg-slate-900/50 p-2 rounded-lg border border-slate-200/50 dark:border-slate-700/50">
             <div className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 text-xs uppercase font-semibold mb-0.5">
-              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" />{" "}
+              <Zap className="w-3 h-3 text-yellow-500 dark:text-yellow-400" aria-hidden="true" />{" "}
               {t("results.table.velocity")}
             </div>
             <span className="text-slate-700 dark:text-slate-200 font-mono text-sm">

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -556,7 +556,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 ))}
               </select>
               <div className="absolute inset-y-0 right-0 flex items-center px-4 pointer-events-none text-slate-500">
-                <svg className="w-4 h-4 fill-current" viewBox="0 0 20 20">
+                <svg className="w-4 h-4 fill-current" viewBox="0 0 20 20" aria-hidden="true">
                   <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
                 </svg>
               </div>
@@ -569,7 +569,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
               htmlFor="maxResults"
               className="block text-xs font-semibold uppercase tracking-wider text-slate-500 flex items-center gap-1"
             >
-              <ListFilter className="w-3 h-3" /> {t("labels.maxResults")}
+              <ListFilter className="w-3 h-3" aria-hidden="true" /> {t("labels.maxResults")}
             </label>
             <div className="relative">
               <select
@@ -586,7 +586,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
                 ))}
               </select>
               <div className="absolute inset-y-0 right-0 flex items-center px-4 pointer-events-none text-slate-500">
-                <svg className="w-4 h-4 fill-current" viewBox="0 0 20 20">
+                <svg className="w-4 h-4 fill-current" viewBox="0 0 20 20" aria-hidden="true">
                   <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
                 </svg>
               </div>

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -141,7 +141,7 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                   <td className="p-4 text-right font-mono text-slate-500 dark:text-slate-400 hidden lg:table-cell">
                     {video.engagementRate != null ? (
                       <span className="flex items-center justify-end gap-1 text-pink-600/80 dark:text-pink-500/80">
-                        <Heart className="w-3 h-3" />
+                        <Heart className="w-3 h-3" aria-hidden="true" />
                         {video.engagementRate}%
                       </span>
                     ) : (


### PR DESCRIPTION
Closes #223

## Changes

Five a11y fixes across four components. All changes are purely additive HTML attribute additions — no logic, no i18n strings, no visual changes.

### Commits

1. **InputSection.tsx** — `aria-hidden="true"` on `<ListFilter>` inside `<label>` and on both decorative `<svg>` dropdown arrows (timeframe + maxResults selects)
2. **AnalyserPage.tsx** — `aria-pressed={sortMode === "trend"|"views"}` on sort-mode toggles; `aria-pressed={topN === 3|6}` on top-N toggles; `aria-hidden="true"` on Trophy + Eye icons
3. **HighlightVideoCard.tsx** — `aria-hidden="true"` on EyeOff (inside button with aria-label), Sparkles (rank badge), Clock (age overlay), Eye (views stat), Zap (velocity stat)
4. **VideoListTable.tsx** — `aria-hidden="true"` on Heart icon in engagement rate cell
5. **DashboardPage.tsx** — `aria-pressed={dashboardSortMode === "alpha"|"velocity"}` on sort toggles; `aria-hidden="true"` on Activity icon

## Test plan

- [ ] `npm run typecheck` passes (pre-existing `@types/node` env issue unrelated to these changes)
- [ ] Screen reader (NVDA/VoiceOver) no longer announces icon names inside labels or toggle buttons that already have text labels
- [ ] Toggle buttons announce selected state ("pressed" / "not pressed") to screen readers
- [ ] No visual regressions — changes are attribute-only


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bu5PwtBgkJqrFpjJb6jj3f)_