### PR TITLE
refine: ux sweep 2026-06-11 – i18n loading text, copy-title button, re-fetch indicator

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, Check, Copy, Download, Eye, List, Trophy } from "lucide-react";
+import { AlertCircle, Check, Copy, Download, Eye, List, Loader2, Trophy } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { InputSection } from "@/src/shared/components/ui/InputSection";
 import { VideoCard } from "@/src/shared/components/ui/VideoCard";
@@ -182,6 +182,16 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
               <span className="bg-slate-200 dark:bg-slate-700 text-xs px-2 py-0.5 rounded-full text-slate-600 dark:text-slate-300 border border-slate-300 dark:border-slate-600">
                 {t("results.videosCount", { count: sortedVideos.length })}
               </span>
+              {searchState.isLoading && (
+                <span
+                  className="inline-flex items-center gap-1 text-xs text-indigo-500 dark:text-indigo-400"
+                  role="status"
+                  aria-label={t("loading")}
+                >
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />
+                  {t("loading")}
+                </span>
+              )}
             </div>
 
             <div className="flex items-center gap-3 text-sm font-medium">

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -599,12 +599,13 @@ export const InputSection: React.FC<InputSectionProps> = ({
           <button
             type="submit"
             disabled={isLoading || !inputValue.trim()}
+            aria-busy={isLoading}
             className="flex-1 xl:flex-none py-4 px-8 font-bold rounded-xl shadow-lg transition-all flex items-center justify-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-[1.02] active:scale-[0.98] bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-500 hover:to-purple-500 text-white shadow-indigo-500/25 shrink-0"
           >
             {isLoading ? (
               <>
                 <Loader2 className="animate-spin w-5 h-5" />
-                <span>...</span>
+                <span>{t("loading")}</span>
               </>
             ) : (
               <>

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, ExternalLink, Heart } from "lucide-react";
+import { Check, Clock, Copy, ExternalLink, Heart, Type } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
@@ -12,12 +12,15 @@ interface VideoListTableProps {
 export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startIndex }) => {
   const { t } = useTranslation();
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copiedTitleId, setCopiedTitleId] = useState<string | null>(null);
   const resetCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetCopiedTitleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Clear pending copy-feedback timer on unmount to avoid setState after unmount
+  // Clear pending copy-feedback timers on unmount to avoid setState after unmount
   useEffect(() => {
     return () => {
       if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
+      if (resetCopiedTitleTimerRef.current) clearTimeout(resetCopiedTitleTimerRef.current);
     };
   }, []);
 
@@ -31,6 +34,20 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
         setCopiedId(video.id);
         if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
         resetCopiedTimerRef.current = setTimeout(() => setCopiedId(null), 1500);
+      },
+      () => {
+        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+      },
+    );
+  };
+
+  const handleCopyTitle = (video: VideoData) => {
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(video.title).then(
+      () => {
+        setCopiedTitleId(video.id);
+        if (resetCopiedTitleTimerRef.current) clearTimeout(resetCopiedTitleTimerRef.current);
+        resetCopiedTitleTimerRef.current = setTimeout(() => setCopiedTitleId(null), 1500);
       },
       () => {
         // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
@@ -157,6 +174,19 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                   </td>
                   <td className="p-4 text-center">
                     <div className="flex items-center justify-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => handleCopyTitle(video)}
+                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
+                        title={t("results.table.copyTitle")}
+                        aria-label={t("results.table.copyTitleAria", { title: video.title })}
+                      >
+                        {copiedTitleId === video.id ? (
+                          <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
+                        ) : (
+                          <Type className="w-4 h-4" aria-hidden="true" />
+                        )}
+                      </button>
                       <button
                         type="button"
                         onClick={() => handleCopy(video)}


### PR DESCRIPTION
Closes #225

## Summary

Three additive UX refinements — no behavior changes to existing features, no new deps, all visible text via i18n keys.

| # | File | Change |
|---|------|--------|
| 1 | `InputSection.tsx` | Replace hardcoded `"..."` with `t("loading")`; add `aria-busy={isLoading}` to submit button |
| 2 | `VideoListTable.tsx` | Add copy-title button (pre-existing `results.table.copyTitle` keys; `Type` icon; same 1.5 s green-check feedback pattern) |
| 3 | `AnalyserPage.tsx` | Show inline `Loader2` spinner + `t("loading")` with `role="status"` in the control bar during re-fetch of existing results |

## Verification

- `npm run build` — clean ✓ (1832 modules, no errors)
- `npm run typecheck` — pre-existing `TS2688 node` type error on `main`; not introduced by this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01McmvxrjvMVdM8WFEhB6Xvd)_