### PR TITLE
chore: reconcile package-lock after dependabot batch merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,6 +239,24 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@electron/asar/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -493,6 +511,23 @@
       },
       "engines": {
         "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
@@ -2601,6 +2636,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2804,6 +2846,24 @@
       "dependencies": {
         "minimatch": "^3.0.5",
         "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/dir-compare/node_modules/minimatch": {
@@ -3410,6 +3470,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {


### PR DESCRIPTION
## Problem

A batch of dependabot squash-merges on `main` left `package-lock.json` out of sync with `package.json`. `npm ci` failed with `EUSAGE`:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: brace-expansion@1.1.15 from lock file
npm error Missing: balanced-match@1.0.2 from lock file
npm error Missing: concat-map@0.0.1 from lock file
npm error Missing: brace-expansion@2.1.1 from lock file
```

These transitive packages are pulled in via the `electron-builder → app-builder-lib → minimatch → brace-expansion: ^5.0.6` **override** in `package.json`; the override graph (nested under `@electron/asar`, `@electron/universal`, `dir-compare`, `filelist`) was never written back into the lockfile during the squash merges.

Because **all four PR-check jobs** (`TypeScript Check`, `Build Check`, `Lint Check`, `Security Audit`) begin with `npm ci`, this single desync turned the whole `pr-checks.yml` run red.

## Fix

Ran `npm install` (NOT `npm ci`) to regenerate a consistent lockfile for the already-merged dependency versions.

- **Diff is purely additive** (+77 lines): only the previously-missing nested transitive entries (`brace-expansion`, `balanced-match`, `concat-map`).
- **No declared dependency version changed** — `package.json` is untouched; all root dep ranges in the lockfile still match (`react ^19.2.7`, `lucide-react ^1.18.0`, `vite ^8.0.16`, `electron-builder ^26.15.3`, `tailwindcss ^4.3.1`, …). `lockfileVersion: 3` preserved. Zero removed lines.

## (B) Pre-existing red Lint / TypeScript / Build — diagnosis

There is **no separate code-level failure**. Once `npm ci` works, every downstream check is green with zero source changes:

| Check | Result |
| --- | --- |
| `npm ci` (clean room: `rm -rf node_modules` + `npm ci`) | ✅ added 423 packages, 0 vulnerabilities |
| `npm run format:check` (Prettier) | ✅ all files formatted |
| `npm run typecheck` (`tsc --noEmit`) | ✅ no errors |
| `npm run build` (`vite build`) | ✅ built in ~0.5s, `dist/` produced |
| Lint job | n/a — repo has **no** `lint` script; the CI job's guard skips the lint step (it was red only at `npm ci`) |

So the red Lint/TypeScript/Build checks were all failing **solely at their `npm ci` step** — reconciling the lockfile fixes all of them.

## Verification

`rm -rf node_modules && npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` all green locally on Node 22.

Ready for review. Does not trigger any deploy.

https://claude.ai/code/session_018RBZBE2Kh8HrakCDXeMCgG

---
_Generated by [Claude Code](https://claude.ai/code/session_018RBZBE2Kh8HrakCDXeMCgG)_