### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,7 +20,7 @@ import type { VideoData } from "@/src/features/videos/types";
 import type { SearchType, TimeFrame } from "@/src/shared/types";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 import { dispatchEvent } from "@/src/shared/lib/eventBus";
-import { safeWrite } from "@/src/shared/lib/storage";
+import { safeRead, safeWrite } from "@/src/shared/lib/storage";
 
 const App: React.FC = () => {
   const { t } = useTranslation();
@@ -32,8 +32,15 @@ const App: React.FC = () => {
   const [isApiKeyModalOpen, setIsApiKeyModalOpen] = useState(false);
   const [isHiddenHighlightsModalOpen, setIsHiddenHighlightsModalOpen] = useState(false);
 
-  // Navigation state
-  const [activePage, setActivePage] = useState<PageType>("dashboard");
+  // Navigation state — persist the last active page so a reload restores it.
+  const [activePage, setActivePage] = useState<PageType>(() => {
+    const stored = safeRead<PageType>(STORAGE_KEYS.ACTIVE_PAGE, "dashboard");
+    return stored === "analyser" ? "analyser" : "dashboard";
+  });
+
+  useEffect(() => {
+    safeWrite(STORAGE_KEYS.ACTIVE_PAGE, activePage);
+  }, [activePage]);
 
   // External input values for analyzer
   const [externalInputValues, setExternalInputValues] = useState<{

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -69,19 +69,37 @@ const App: React.FC = () => {
   // Sorted favorites
   const sortedFavorites = useMemo(() => sortFavorites(favorites), [favorites, sortFavorites]);
 
-  // Global hotkey: press "r" on dashboard to refresh all favorites
+  // Global hotkeys:
+  // - "d" / "a" switch between Dashboard and Analyser
+  // - "r" on the dashboard refreshes all favorites
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key !== "r" && e.key !== "R") return;
-      // Skip when focus is inside an input, textarea, or contentEditable element
+      // Skip when focus is inside an input, textarea, or contentEditable element,
+      // or when a modifier key is held (avoid hijacking browser/OS shortcuts).
       const target = e.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
         return;
       }
-      if (activePage !== "dashboard") return;
-      if (favorites.length === 0) return;
-      e.preventDefault();
-      refreshAll();
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const key = e.key.toLowerCase();
+
+      if (key === "d") {
+        e.preventDefault();
+        setActivePage("dashboard");
+        return;
+      }
+      if (key === "a") {
+        e.preventDefault();
+        setActivePage("analyser");
+        return;
+      }
+      if (key === "r") {
+        if (activePage !== "dashboard") return;
+        if (favorites.length === 0) return;
+        e.preventDefault();
+        refreshAll();
+      }
     },
     [activePage, favorites.length, refreshAll],
   );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -274,6 +274,8 @@
   "keyboard": {
     "label": "Tastaturkuerzel",
     "focusSearch": "Suche fokussieren",
+    "openDashboard": "Dashboard öffnen",
+    "openAnalyser": "Analyser öffnen",
     "refreshAll": "Alle Favoriten aktualisieren"
   },
   "scroll": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -244,6 +244,7 @@
     "exhausted": "Kontingent erschöpft! Reset um Mitternacht PT.",
     "historyTitle": "API-Nutzung",
     "units": "Einheiten",
+    "copySummary": "Kontingent-Übersicht kopieren",
     "calls": "Aufrufe",
     "last24Hours": "Letzte 24 Stunden",
     "lastTimeWindow": "Letzte {{time}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -244,6 +244,7 @@
     "exhausted": "Quota exhausted! Resets at midnight PT.",
     "historyTitle": "API Usage",
     "units": "Units",
+    "copySummary": "Copy quota summary",
     "calls": "Calls",
     "last24Hours": "Last 24 hours",
     "lastTimeWindow": "Last {{time}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -274,6 +274,8 @@
   "keyboard": {
     "label": "Keyboard shortcuts",
     "focusSearch": "Focus search",
+    "openDashboard": "Open Dashboard",
+    "openAnalyser": "Open Analyser",
     "refreshAll": "Refresh all favorites"
   },
   "scroll": {

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -171,6 +171,22 @@ function KeyboardShortcutsHint({ activePage }: { activePage: PageType }) {
                 /
               </kbd>
             </div>
+            <div className="flex items-center justify-between">
+              <span className="text-slate-500 dark:text-slate-400">
+                {t("keyboard.openDashboard")}
+              </span>
+              <kbd className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 font-mono text-slate-600 dark:text-slate-300">
+                D
+              </kbd>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-slate-500 dark:text-slate-400">
+                {t("keyboard.openAnalyser")}
+              </span>
+              <kbd className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 font-mono text-slate-600 dark:text-slate-300">
+                A
+              </kbd>
+            </div>
             {activePage === "dashboard" && (
               <div className="flex items-center justify-between">
                 <span className="text-slate-500 dark:text-slate-400">

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -1,5 +1,16 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Activity, AlertTriangle, AtSign, Hash, Search, User, X, Zap } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  AtSign,
+  Check,
+  Copy,
+  Hash,
+  Search,
+  User,
+  X,
+  Zap,
+} from "lucide-react";
 import { quotaService } from "@/src/features/youtube";
 import type { QuotaHistoryEntry } from "@/src/shared/types";
 import { useTranslation } from "react-i18next";
@@ -202,7 +213,35 @@ export const ApiQuotaIndicator: React.FC = () => {
   const [quota, setQuota] = useState(quotaService.getInfo());
   const [history, setHistory] = useState<QuotaHistoryEntry[]>([]);
   const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the copy-feedback timer on unmount to avoid setState after unmount
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  // Copy a plain-text quota summary (used / limit / percentage) to the clipboard.
+  const handleCopyQuota = () => {
+    // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
+    if (!navigator.clipboard) return;
+    const summary = `${t("quota.label")}: ${formatNumber(quota.used)} / ${formatNumber(
+      quota.limit,
+    )} ${t("quota.units")} (${quota.percentage}%)`;
+    navigator.clipboard.writeText(summary).then(
+      () => {
+        setCopied(true);
+        if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+        copyTimerRef.current = setTimeout(() => setCopied(false), 1500);
+      },
+      () => {
+        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+      },
+    );
+  };
 
   useEffect(() => {
     // Initial load
@@ -412,11 +451,26 @@ export const ApiQuotaIndicator: React.FC = () => {
 
           {/* Quota summary */}
           <div className="px-3 py-2 border-b border-slate-700/50">
-            <div className="flex items-center justify-between text-xs">
+            <div className="flex items-center justify-between gap-2 text-xs">
               <span className="text-slate-400">{t("quota.label")}</span>
-              <span className={colors.text}>
-                {formatNumber(quota.used)} / {formatNumber(quota.limit)} {t("quota.units")}
-              </span>
+              <div className="flex items-center gap-1.5">
+                <span className={colors.text}>
+                  {formatNumber(quota.used)} / {formatNumber(quota.limit)} {t("quota.units")}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleCopyQuota}
+                  className="inline-flex items-center justify-center w-6 h-6 rounded-md bg-slate-800/60 hover:bg-slate-700 text-slate-400 hover:text-slate-200 transition-colors border border-slate-700"
+                  title={t("quota.copySummary")}
+                  aria-label={t("quota.copySummary")}
+                >
+                  {copied ? (
+                    <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
+                  ) : (
+                    <Copy className="w-3.5 h-3.5" aria-hidden="true" />
+                  )}
+                </button>
+              </div>
             </div>
             {/* Full-width progress bar */}
             <div className="mt-2 h-1.5 bg-slate-700 rounded-full overflow-hidden">

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -19,6 +19,7 @@ export const STORAGE_KEYS = {
   HIDDEN_HIGHLIGHTS: "tt.dashboard.hiddenHighlights.v1",
   ANALYSER_SORT_MODE: "tt.analyser.sortMode",
   ANALYSER_TOP_N: "tt.analyser.topN",
+  ACTIVE_PAGE: "tt.activePage",
   THEME: "tt.theme",
 } as const;
 


### PR DESCRIPTION
Autonomous comfort sweep — three small SPA quality-of-life wins. Verified green (format + typecheck w/ noUnusedLocals + vite build). UI strings via `t()` keys added to `en`+`de`.

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand |
|---|---------------|-----------|---------|--------|---------|
| 1 | `ApiQuotaIndicator.tsx` | Komfort | Copy quota usage summary | One-click copy of "used / limit units (%)" | S |
| 2 | `App.tsx` + `config.ts` | Komfort | Persist last active page | Reload restores Dashboard/Analyser via StorageAdapter | S |
| 3 | `App.tsx` + `Header.tsx` | Komfort | `D`/`A` page-switch hotkeys | Input-guarded + no-modifier; documented in shortcuts popover | S |

No deps added. Reuses existing StorageAdapter / EventBus / hotkey pattern.

Closes #239

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCKbRrKvKfRNnrJy6myQnA)_