### PR TITLE
refactor: best-practice sweep (Vite + React 19 + TypeScript)

### DIFF
--- a/src/shared/components/ui/LanguageSwitcher.tsx
+++ b/src/shared/components/ui/LanguageSwitcher.tsx
@@ -98,9 +98,7 @@ export const LanguageSwitcher: React.FC = () => {
       <div className="relative">
         <select
           aria-label={t("language.label")}
-          className="px-3 py-1.5 rounded-md border text-xs font-medium \
-                     border-slate-300 text-slate-700 bg-white dark:bg-slate-900 \
-                     dark:border-slate-700 dark:text-slate-300"
+          className="px-3 py-1.5 rounded-md border text-xs font-medium border-slate-300 text-slate-700 bg-white dark:bg-slate-900 dark:border-slate-700 dark:text-slate-300"
           value={mode === "system" ? "system" : explicitLng}
           onChange={(e) => {
             const val = e.target.value as "system" | ExplicitLang;

--- a/src/shared/components/ui/ThemeToggle.tsx
+++ b/src/shared/components/ui/ThemeToggle.tsx
@@ -23,9 +23,7 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={nextTheme}
-      className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors \
-                 border-slate-300 text-slate-700 hover:bg-slate-100 \
-                 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+      className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
       title={`${t("theme.label")}: ${title} (${t("theme.clickToCycle")})`}
       aria-label={`${t("theme.label")}: ${title}`}
     >


### PR DESCRIPTION
Autonomous best-practice sweep. One genuine defect found and fixed; behavior-equivalent.

## Merged findings

| # | File(s) | Category | Fix |
| - | ------- | -------- | --- |
| 1 | `src/shared/components/ui/ThemeToggle.tsx`, `src/shared/components/ui/LanguageSwitcher.tsx` | correctness | Removed shell-style backslash line-continuations from `className` strings. JSX string attributes keep the literal `\` + newline + indentation verbatim (confirmed via TSC transpile), emitting junk `\` tokens into the rendered `className`. Collapsed each to a single line with the same intended Tailwind classes. |

## Verification (local, green)

- `npm run typecheck` ✓
- `npm run build` ✓
- `npx prettier --check .` ✓

## Notes

The codebase is in very good shape — most CLAUDE.md "Refactoring Notes" easy-wins are already resolved. Three borderline items were deliberately **deferred** (dead-code bug in `formatBytes`, behavior-risky regex in `parseISO8601DurationToSeconds`, and an `ApiKeyModal` threshold inconsistency whose fix would be a behavior change) — see the issue for details.

Closes #241

---
_Generated by [Claude Code](https://claude.ai/code/session_011njaxjRJMJm1zDkb98At7q)_