### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -159,6 +159,7 @@
       "views": "Aufrufe",
       "velocity": "Velocity",
       "score": "Score",
+      "scoreTooltip": "Trend-Score (0–100): Aufruf-Geschwindigkeit (70%) + Engagement (30%)",
       "engagement": "Engage",
       "copyUrl": "Video-URL kopieren",
       "copyUrlAria": "URL kopieren für {{title}}",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -196,6 +196,8 @@
       "description": "Gib deinen YouTube Data API-Schlüssel ein, um fortzufahren.",
       "save": "Speichern",
       "cancel": "Abbrechen",
+      "showKey": "API-Key anzeigen",
+      "hideKey": "API-Key verbergen",
       "helpToggle": "Wie bekomme ich einen API-Key?",
       "quotaTitle": "Kostenloses Kontingent",
       "quotaInfo": "Jeder API-Key hat 10.000 Einheiten pro Tag kostenlos. Eine Suche kostet ~100 Einheiten, Video-Details nur 1 Einheit. Das reicht für ca. 100 Suchen täglich.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -159,6 +159,7 @@
       "views": "Views",
       "velocity": "Velocity",
       "score": "Score",
+      "scoreTooltip": "Trend score (0–100): view velocity (70%) + engagement (30%)",
       "engagement": "Engage",
       "copyUrl": "Copy video URL",
       "copyUrlAria": "Copy URL for {{title}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -196,6 +196,8 @@
       "description": "Enter your YouTube Data API key to continue.",
       "save": "Save",
       "cancel": "Cancel",
+      "showKey": "Show API key",
+      "hideKey": "Hide API key",
       "helpToggle": "How do I get an API key?",
       "quotaTitle": "Free quota",
       "quotaInfo": "Each API key includes 10,000 free units per day. A search costs ~100 units, video details only 1 unit. That's enough for about 100 searches daily.",

--- a/src/shared/components/ui/ApiKeyModal.tsx
+++ b/src/shared/components/ui/ApiKeyModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Check, HelpCircle, Key, ExternalLink, Zap } from "lucide-react";
+import { Check, Eye, EyeOff, HelpCircle, Key, ExternalLink, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 const FOCUSABLE_SELECTOR =
@@ -12,6 +12,8 @@ interface ApiKeyModalProps {
 export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
   const [inputKey, setInputKey] = useState("");
   const [showHelp, setShowHelp] = useState(false);
+  // The key is masked by default (privacy / shoulder-surfing); a toggle reveals it.
+  const [showKey, setShowKey] = useState(false);
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
 
@@ -77,15 +79,32 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
               >
                 YouTube Data API v3 Key
               </label>
-              <input
-                type="text"
-                id="apiKey"
-                value={inputKey}
-                onChange={(e) => setInputKey(e.target.value)}
-                placeholder="AIzaSy..."
-                className="w-full px-4 py-3 bg-slate-50 dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-xl focus:ring-2 focus:ring-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 outline-none transition-all font-mono text-sm"
-                autoFocus
-              />
+              <div className="relative">
+                <input
+                  type={showKey ? "text" : "password"}
+                  id="apiKey"
+                  value={inputKey}
+                  onChange={(e) => setInputKey(e.target.value)}
+                  placeholder="AIzaSy..."
+                  className="w-full pl-4 pr-11 py-3 bg-slate-50 dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-xl focus:ring-2 focus:ring-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 outline-none transition-all font-mono text-sm"
+                  autoFocus
+                  autoComplete="off"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowKey((v) => !v)}
+                  aria-label={showKey ? t("modal.apiKey.hideKey") : t("modal.apiKey.showKey")}
+                  aria-pressed={showKey}
+                  title={showKey ? t("modal.apiKey.hideKey") : t("modal.apiKey.showKey")}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                >
+                  {showKey ? (
+                    <EyeOff className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <Eye className="w-4 h-4" aria-hidden="true" />
+                  )}
+                </button>
+              </div>
             </div>
 
             <button

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Clock, Eye, Trash2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { hiddenHighlightsService, type HiddenHighlight } from "@/src/features/dashboard";
 import { getLocale } from "@/src/shared/lib/locale";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface HiddenHighlightsModalProps {
   isOpen: boolean;
@@ -12,6 +15,7 @@ interface HiddenHighlightsModalProps {
 export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModalProps) {
   const { t } = useTranslation();
   const [hiddenItems, setHiddenItems] = useState<HiddenHighlight[]>([]);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // Load the list when the modal opens
   useEffect(() => {
@@ -29,6 +33,34 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
+
+  // Focus trap: keep Tab focus inside the dialog while it is open (WCAG 2.4.3),
+  // mirroring ApiKeyModal. Without this, Tab can move focus to the page behind.
+  const handleTabKey = useCallback((e: KeyboardEvent) => {
+    if (e.key !== "Tab" || !dialogRef.current) return;
+
+    const focusable = dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener("keydown", handleTabKey);
+    // Move focus into the dialog on open so the trap has a starting point.
+    dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+    return () => document.removeEventListener("keydown", handleTabKey);
+  }, [isOpen, handleTabKey]);
 
   const handleUnhide = (videoId: string) => {
     hiddenHighlightsService.show(videoId);
@@ -68,6 +100,7 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
 
       {/* Modal */}
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hidden-highlights-modal-title"

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -87,9 +87,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           {formatTimeAgo(video.publishedTimestamp, t)}
         </div>
         <div
-          className={`absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-bold border backdrop-blur-md flex items-center gap-1 pointer-events-none ${getScoreColor(video.trendingScore)}`}
+          className={`absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-bold border backdrop-blur-md flex items-center gap-1 cursor-help ${getScoreColor(video.trendingScore)}`}
+          tabIndex={0}
+          title={t("results.table.scoreTooltip")}
+          aria-label={`${t("results.table.score")}: ${video.trendingScore} — ${t("results.table.scoreTooltip")}`}
         >
-          <TrendingUp className="w-3 h-3" />
+          <TrendingUp className="w-3 h-3" aria-hidden="true" />
           {t("results.table.score")}: {video.trendingScore}
         </div>
       </div>

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -86,7 +86,9 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                 {t("results.table.engagement")}
               </th>
               <th scope="col" className="p-4 text-center">
-                {t("results.table.score")}
+                <span className="cursor-help" title={t("results.table.scoreTooltip")}>
+                  {t("results.table.score")}
+                </span>
               </th>
               <th scope="col" className="p-4 w-16 text-center">
                 <span className="sr-only">{t("results.table.copyUrl")}</span>


### PR DESCRIPTION
Small, additive UX/comfort refinements to three existing features. No new features, no dependency changes, no architecture changes. Verified with `npm run typecheck && npm run build` (both green) and `format:check`.

| # | Feature | Bereich/Datei | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---|---|---|---|---|---|
| 1 | Analyser / trend score | `VideoCard.tsx`, `VideoListTable.tsx`, `en/de.json` | Qualität/Feedback | Score-Badge erklärte die Zahl nicht | i18n-Tooltip mit 0–100-Zusammensetzung (Velocity 70% + Engagement 30%); VideoCard-Badge fokussierbar + aria-label | S |
| 2 | Dashboard / Hidden-Highlights-Modal | `HiddenHighlightsModal.tsx` | A11y-Polish | Modal hatte kein Focus-Trap (nur Escape) | Focus-Trap nach `ApiKeyModal`-Muster (WCAG 2.4.3) + Initial-Fokus | S |
| 3 | Settings / API-Key-Modal | `ApiKeyModal.tsx`, `en/de.json` | Komfort | API-Key im Klartext (`type=text`) | Maskiert per Default + Eye-Toggle (aria-pressed + i18n) | S |

All UI strings added to both `en` and `de` translation files. Existing patterns reused (focus-trap from ApiKeyModal, `results.table.*` i18n namespace).

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011XS1RuiP7io49gb8SMZbFX)_