### PR TITLE
ci: merge PR-check jobs into one + weekly GHCR cleanup

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,25 @@
+name: Cleanup old GHCR images
+
+# Untagged GHCR image versions pile up on every push to main (each rebuild
+# leaves the previous layers dangling). This prunes them weekly. Tagged images
+# (latest, version tags) are never touched.
+on:
+  schedule:
+    - cron: "0 4 * * 0" # weekly, Sunday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Delete untagged GHCR image versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune untagged versions (keep latest 10)
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: tubetrend
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,9 +19,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TypeScript type checking
-  typecheck:
-    name: TypeScript Check
+  # Format, typecheck, lint and build in a single job so dependencies are
+  # installed once per run instead of once per check (previously 4 jobs each
+  # ran their own `npm ci`).
+  checks:
+    name: Typecheck / Lint / Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -42,22 +44,14 @@ jobs:
       - name: Run TypeScript type check
         run: npx tsc --noEmit
 
-  # Production build test
-  build:
-    name: Build Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Run linter (if available)
+        run: |
+          if npm run 2>/dev/null | grep -q "^\s*lint"; then
+            echo "Running npm run lint..."
+            npm run lint
+          else
+            echo "No lint script found in package.json - skipping"
+          fi
 
       - name: Build project
         run: npm run build
@@ -71,33 +65,7 @@ jobs:
           echo "Build successful - dist/ contains:"
           ls -la dist/
 
-  # Linting (if configured)
-  lint:
-    name: Lint Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run linter (if available)
-        run: |
-          if npm run 2>/dev/null | grep -q "^\s*lint"; then
-            echo "Running npm run lint..."
-            npm run lint
-          else
-            echo "No lint script found in package.json - skipping"
-          fi
-
-  # Dependency security audit
+  # Dependency security audit (no install needed — runs off the lockfile)
   security:
     name: Security Audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two CI cost reductions.

## 1. `pr-checks.yml` — fewer Actions minutes

Previously 4 separate jobs (`typecheck`, `build`, `lint`, `security`) each ran their own `checkout` + `setup-node` + `npm ci` — i.e. dependencies were installed ~4× per PR. Collapsed `typecheck` + `lint` + `build` into a single sequential `checks` job (one `npm ci`). `security` (`npm audit`) stays a separate job and needs no install. Net: **4 jobs → 2, ~3 fewer `npm ci` per PR**. Same checks, same `paths-ignore`, same concurrency cancel.

> ⚠️ **Branch protection — action required:** this renames the status checks. The old required checks (`TypeScript Check` / `Build Check` / `Lint Check`) no longer exist, so update the required status check on `main` to **`Typecheck / Lint / Build`** (Settings → Branches). Otherwise this and every future PR stay blocked waiting for a check that never reports.

## 2. `cleanup-ghcr.yml` — less package storage

`docker-publish.yml` pushes a new image on every push to `main`; each rebuild leaves the previous layers **untagged**, and these dangling versions accumulate in GHCR storage. New weekly workflow prunes them:

- `delete-only-untagged-versions: true` — tagged images (`latest`, version tags) are **never** touched
- `min-versions-to-keep: 10` safety net
- runs weekly + `workflow_dispatch`

### Before relying on it

Trigger it once via **Actions → Cleanup old GHCR images → Run workflow** to confirm it has access. `fo0/tubetrend` is a user-owned package; if the default `GITHUB_TOKEN` can't delete the versions, switch the action to a PAT with `delete:packages`. Nothing is auto-merged — review first.