### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -72,6 +72,7 @@ const App: React.FC = () => {
   // Global hotkeys:
   // - "d" / "a" switch between Dashboard and Analyser
   // - "r" on the dashboard refreshes all favorites
+  // - "?" toggles the keyboard-shortcuts help popover
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       // Skip when focus is inside an input, textarea, or contentEditable element,
@@ -80,6 +81,15 @@ const App: React.FC = () => {
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
         return;
       }
+
+      // "?" opens/closes the shortcuts hint. It is the only shortcut that needs
+      // Shift (Shift + "/" on most layouts), so handle it before the modifier guard.
+      if (e.key === "?") {
+        e.preventDefault();
+        dispatchEvent("toggle-shortcuts-hint");
+        return;
+      }
+
       if (e.ctrlKey || e.metaKey || e.altKey) return;
 
       const key = e.key.toLowerCase();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,7 +17,7 @@ import {
 import { useSearch } from "@/src/features/search/hooks/useSearch";
 import type { FavoriteConfig } from "@/src/features/favorites/types";
 import type { VideoData } from "@/src/features/videos/types";
-import type { SearchType, TimeFrame } from "@/src/shared/types";
+import { type SearchType, TimeFrame } from "@/src/shared/types";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 import { dispatchEvent } from "@/src/shared/lib/eventBus";
 import { safeRead, safeWrite } from "@/src/shared/lib/storage";
@@ -238,6 +238,18 @@ const App: React.FC = () => {
     [handleSearch, setSearchResult],
   );
 
+  // Quick-start example from the welcome empty state: pre-fill the search box
+  // (via the external-sync channel) with sensible defaults and run the search.
+  const handlePickExample = useCallback(
+    (query: string, searchType: SearchType) => {
+      const timeFrame = TimeFrame.LAST_MONTH;
+      const maxResults = -1;
+      setExternalInputValues({ query, timeFrame, maxResults, searchType, syncToken: Date.now() });
+      handleSearch(query, timeFrame, maxResults, searchType);
+    },
+    [handleSearch],
+  );
+
   return (
     <div className="min-h-screen flex flex-col bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 font-sans selection:bg-indigo-500/30">
       {isApiKeyModalOpen && <ApiKeyModal onSave={handleSaveKey} />}
@@ -281,6 +293,7 @@ const App: React.FC = () => {
             searchState={searchState}
             externalInputValues={externalInputValues}
             onSearch={handleSearch}
+            onPickExample={handlePickExample}
           />
         )}
       </main>

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -4,9 +4,9 @@ import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { InputSection } from "@/src/shared/components/ui/InputSection";
 import { VideoCard } from "@/src/shared/components/ui/VideoCard";
 import { VideoListTable } from "@/src/shared/components/ui/VideoListTable";
-import { EmptyState } from "@/src/shared/components/ui/EmptyState";
+import { EmptyState, type EmptyStateExample } from "@/src/shared/components/ui/EmptyState";
 import { useTranslation } from "react-i18next";
-import type { SearchType, TimeFrame } from "@/src/shared/types";
+import { SearchType, type TimeFrame } from "@/src/shared/types";
 import type { SearchState } from "@/src/features/search/hooks/useSearch";
 import { buildResultsCsv, buildResultsCsvFilename } from "@/src/features/videos";
 import { STORAGE_KEYS } from "@/src/shared/constants";
@@ -26,10 +26,32 @@ interface AnalyserPageProps {
     maxResults: number,
     searchType: SearchType,
   ) => void;
+  /** Run a quick-start example from the welcome empty state (pre-fills the search box + searches). */
+  onPickExample?: (query: string, searchType: SearchType) => void;
 }
 
-export function AnalyserPage({ searchState, externalInputValues, onSearch }: AnalyserPageProps) {
+export function AnalyserPage({
+  searchState,
+  externalInputValues,
+  onSearch,
+  onPickExample,
+}: AnalyserPageProps) {
   const { t } = useTranslation();
+
+  // Quick-start examples for the welcome empty state. Labels are how the user
+  // would type them; queries are the bare identifiers passed to the search.
+  const welcomeExamples = useMemo<EmptyStateExample[]>(
+    () => [
+      { label: "@MrBeast", query: "@MrBeast", searchType: SearchType.CHANNEL },
+      { label: "@mkbhd", query: "@mkbhd", searchType: SearchType.CHANNEL },
+      {
+        label: `#${t("empty.exampleKeyword")}`,
+        query: t("empty.exampleKeyword"),
+        searchType: SearchType.KEYWORD,
+      },
+    ],
+    [t],
+  );
 
   const [sortMode, setSortMode] = useState<"trend" | "views">(() => {
     try {
@@ -365,6 +387,8 @@ export function AnalyserPage({ searchState, externalInputValues, onSearch }: Ana
       {!searchState.data && !searchState.isLoading && (
         <EmptyState
           variant={searchState.step === "idle" && !searchState.error ? "welcome" : "no-results"}
+          examples={welcomeExamples}
+          onPickExample={onPickExample}
         />
       )}
     </>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -279,7 +279,8 @@
     "focusSearch": "Suche fokussieren",
     "openDashboard": "Dashboard öffnen",
     "openAnalyser": "Analyser öffnen",
-    "refreshAll": "Alle Favoriten aktualisieren"
+    "refreshAll": "Alle Favoriten aktualisieren",
+    "toggleHint": "Kuerzel anzeigen"
   },
   "scroll": {
     "toTop": "Nach oben scrollen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -239,7 +239,10 @@
   },
   "empty": {
     "title": "YouTube-Kanäle analysieren",
-    "desc": "Suche einen Kanal und erhalte Trend-Einblicke für verschiedene Zeiträume."
+    "desc": "Suche einen Kanal und erhalte Trend-Einblicke für verschiedene Zeiträume.",
+    "tryExamples": "Beispiel ausprobieren",
+    "exampleTitle": "{{example}} suchen",
+    "exampleKeyword": "lofi"
   },
   "quota": {
     "label": "API-Kontingent",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -239,7 +239,10 @@
   },
   "empty": {
     "title": "Analyze YouTube channels",
-    "desc": "Search a channel and get trend insights for different time frames."
+    "desc": "Search a channel and get trend insights for different time frames.",
+    "tryExamples": "Try an example",
+    "exampleTitle": "Search {{example}}",
+    "exampleKeyword": "lofi"
   },
   "quota": {
     "label": "API Quota",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -279,7 +279,8 @@
     "focusSearch": "Focus search",
     "openDashboard": "Open Dashboard",
     "openAnalyser": "Open Analyser",
-    "refreshAll": "Refresh all favorites"
+    "refreshAll": "Refresh all favorites",
+    "toggleHint": "Show shortcuts"
   },
   "scroll": {
     "toTop": "Scroll to top",

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 import { Activity, BarChart3, Keyboard, LayoutDashboard, Settings } from "lucide-react";
-import { useRef, useState, useEffect } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import { ThemeToggle } from "@/src/shared/components/ui/ThemeToggle";
 import { LanguageSwitcher } from "@/src/shared/components/ui/LanguageSwitcher";
 import { ApiQuotaIndicator } from "@/src/shared/components/ui/ApiQuotaIndicator";
+import { useEventBus } from "@/src/shared/lib/eventBus";
 import { useTranslation } from "react-i18next";
 
 export type PageType = "dashboard" | "analyser";
@@ -123,6 +124,10 @@ function KeyboardShortcutsHint({ activePage }: { activePage: PageType }) {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
+  // Allow the global "?" hotkey (dispatched from App) to toggle this popover.
+  const handleToggle = useCallback(() => setIsOpen((prev) => !prev), []);
+  useEventBus("toggle-shortcuts-hint", handleToggle);
+
   useEffect(() => {
     if (!isOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -197,6 +202,12 @@ function KeyboardShortcutsHint({ activePage }: { activePage: PageType }) {
                 </kbd>
               </div>
             )}
+            <div className="flex items-center justify-between">
+              <span className="text-slate-500 dark:text-slate-400">{t("keyboard.toggleHint")}</span>
+              <kbd className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 font-mono text-slate-600 dark:text-slate-300">
+                ?
+              </kbd>
+            </div>
           </div>
         </div>
       )}

--- a/src/shared/components/ui/EmptyState.tsx
+++ b/src/shared/components/ui/EmptyState.tsx
@@ -1,13 +1,27 @@
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Search } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { useTranslation } from "react-i18next";
+import { SearchType } from "@/src/shared/types";
+
+/** One clickable quick-start example shown on the welcome screen. */
+export interface EmptyStateExample {
+  /** Text shown on the chip and used to pre-fill the search box (e.g. "@MrBeast", "#lofi"). */
+  label: string;
+  /** Query passed to the search (without any "#" prefix). */
+  query: string;
+  searchType: SearchType;
+}
 
 interface EmptyStateProps {
   /** "welcome" = initial state before any search; "no-results" = search returned nothing */
   variant?: "welcome" | "no-results";
+  /** Quick-start examples; only rendered for the "welcome" variant when onPickExample is set. */
+  examples?: EmptyStateExample[];
+  /** Invoked when a quick-start example chip is clicked. */
+  onPickExample?: (query: string, searchType: SearchType) => void;
 }
 
-export function EmptyState({ variant = "welcome" }: EmptyStateProps) {
+export function EmptyState({ variant = "welcome", examples, onPickExample }: EmptyStateProps) {
   const { t } = useTranslation();
 
   if (variant === "no-results") {
@@ -24,6 +38,8 @@ export function EmptyState({ variant = "welcome" }: EmptyStateProps) {
     );
   }
 
+  const showExamples = !!onPickExample && !!examples && examples.length > 0;
+
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center px-4">
       <div className="w-24 h-24 bg-slate-100 dark:bg-slate-800 rounded-full flex items-center justify-center mb-6 shadow-xl border border-slate-200 dark:border-slate-700 animate-pulse">
@@ -33,6 +49,33 @@ export function EmptyState({ variant = "welcome" }: EmptyStateProps) {
         {t("empty.title")}
       </h2>
       <p className="text-slate-500 dark:text-slate-400 max-w-md">{t("empty.desc")}</p>
+
+      {showExamples && (
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+            {t("empty.tryExamples")}
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            {examples.map((ex) => (
+              <button
+                key={`${ex.searchType}:${ex.query}`}
+                type="button"
+                onClick={() => onPickExample(ex.query, ex.searchType)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors
+                           border-slate-300 text-slate-700 hover:bg-slate-100 hover:text-slate-900 hover:border-slate-400
+                           dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white dark:hover:border-slate-600"
+                title={t("empty.exampleTitle", { example: ex.label })}
+              >
+                <Search
+                  className="w-3.5 h-3.5 text-indigo-500 dark:text-indigo-400"
+                  aria-hidden="true"
+                />
+                {ex.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -336,18 +336,31 @@ export const InputSection: React.FC<InputSectionProps> = ({
     setShowHistory(false);
   };
 
-  // Escape closes any open dropdown (suggestions or history)
+  // Escape behaviour (only while the search input itself is focused, so we never
+  // hijack Escape from modals or other widgets):
+  //   1. If a dropdown (suggestions / history) is open, close it.
+  //   2. Otherwise, if the input has text, clear it.
   useEffect(() => {
-    if (!showSuggestions && !showHistory) return;
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key !== "Escape") return;
+      if (document.activeElement !== searchInputRef.current) return;
+
+      if (showSuggestions || showHistory) {
+        setShowSuggestions(false);
+        setShowHistory(false);
+        return;
+      }
+      if (inputValue) {
+        // Mirror clearInput(): reset the query and any pending dropdowns.
+        setInputValue("");
+        setSuggestions([]);
         setShowSuggestions(false);
         setShowHistory(false);
       }
     };
     document.addEventListener("keydown", handleEsc);
     return () => document.removeEventListener("keydown", handleEsc);
-  }, [showSuggestions, showHistory]);
+  }, [showSuggestions, showHistory, inputValue]);
 
   // Synchronisiere Favoriten-Status, wenn Eingabe/Zeitfenster/MaxErgebnisse/SearchType sich ändern
   useEffect(() => {

--- a/src/shared/lib/eventBus.ts
+++ b/src/shared/lib/eventBus.ts
@@ -12,6 +12,7 @@ export interface EventMap {
   "hidden-highlights-changed": undefined;
   "favorite-refresh-start": { id: string };
   "favorite-refresh-end": { id: string };
+  "toggle-shortcuts-hint": undefined;
 }
 
 type EventKey = keyof EventMap;


### PR DESCRIPTION
Automated end-user comfort sweep (Vite + React 19 + TypeScript + Tailwind v4 + i18next). All three features reuse existing patterns and add i18n keys to both `en` and `de`.

## Merged features

| # | Area/File | Category | Feature | User benefit | Effort | Status |
|---|-----------|----------|---------|--------------|--------|--------|
| 1 | `App.tsx`, `Header.tsx`, `eventBus.ts` | Keyboard shortcut | Global `?` (Shift+/) hotkey toggles the keyboard-shortcuts help popover; `?` row added to the popover | Discover/recall shortcuts hands-on-keyboard | M | merged |
| 2 | `InputSection.tsx` | Keyboard shortcut / UX | `Escape` clears the focused search input when no dropdown is open | One keystroke to reset the query | S | merged |
| 3 | `EmptyState.tsx`, `AnalyserPage.tsx`, `App.tsx` | Empty-state + CTA | Welcome empty state shows quick-start example chips that pre-fill the search box and run a search | One-click path from blank screen to results | M | merged |

## Notes

- #1 adds a `"toggle-shortcuts-hint"` event to the type-safe `EventMap`; dispatched from the existing input-guarded global keydown handler, consumed via `useEventBus`. No new dependency.
- #2 scopes `Escape` to fire only while the search `<input>` is focused, so it never hijacks `Escape` from the API-key modal; dropdown-close still takes precedence.
- #3 routes chip clicks through the same `externalInputValues` + `handleSearch` channel the favorites→Analyser flow uses (defaults: `LAST_MONTH`, max results = All); labels/keyword come from i18n.

## Verification

`npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. No test framework configured (per CLAUDE.md). i18n `en`/`de` key parity verified.

Closes #260

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4B1zYUguPZb1fhRFtz52m)_