### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/features/dashboard/services/hiddenHighlightsService.ts
+++ b/src/features/dashboard/services/hiddenHighlightsService.ts
@@ -1,8 +1,8 @@
 /**
- * Service für das Ausblenden von Highlight-Karten im Dashboard.
+ * Service for hiding highlight cards on the dashboard.
  *
- * Videos werden über ihre eindeutige videoId ausgeblendet.
- * Einmal ausgeblendete Videos bleiben dauerhaft versteckt.
+ * Videos are hidden by their unique videoId.
+ * Once hidden, a video stays hidden permanently.
  */
 
 import { safeRead, safeWrite } from "@/src/shared/lib/storage";
@@ -12,12 +12,12 @@ import { STORAGE_KEYS } from "@/src/shared/constants";
 const HIDDEN_HIGHLIGHTS_KEY = STORAGE_KEYS.HIDDEN_HIGHLIGHTS;
 
 export interface HiddenHighlight {
-  videoId: string; // Eindeutige Video-ID (primärer Schlüssel)
-  sourceId: string; // Favorit/Kanal-ID (für Anzeige/Kontext)
-  hiddenAt: number; // Zeitstempel wann ausgeblendet wurde (für chronologische Sortierung)
-  videoTitle?: string; // Video-Titel für die Anzeige in der Liste
-  thumbnailUrl?: string; // Thumbnail-URL für die Anzeige in der Liste
-  sourceLabel?: string; // Kanal-/Favoritenname für die Anzeige in der Liste
+  videoId: string; // Unique video ID (primary key)
+  sourceId: string; // Favorite/channel ID (for display/context)
+  hiddenAt: number; // Timestamp when the video was hidden (for chronological sorting)
+  videoTitle?: string; // Video title for display in the list
+  thumbnailUrl?: string; // Thumbnail URL for display in the list
+  sourceLabel?: string; // Channel/favorite name for display in the list
 }
 
 // Keep old type names for backwards compatibility
@@ -30,12 +30,12 @@ export interface HiddenHighlightMeta {
 
 export const hiddenHighlightsService = {
   /**
-   * Gibt alle ausgeblendeten Highlights zurück.
-   * Alte Einträge ohne hiddenAt bekommen einen Default-Zeitstempel.
+   * Returns all hidden highlights.
+   * Legacy entries without hiddenAt get a default timestamp.
    */
   list(): HiddenHighlight[] {
     const raw = safeRead<unknown[]>(HIDDEN_HIGHLIGHTS_KEY, []);
-    // Validierung: nur gültige Einträge behalten und alte Einträge migrieren
+    // Validation: keep only valid entries and migrate legacy entries
     return raw
       .map((entry) => entry as Record<string, unknown> | null | undefined)
       .filter(
@@ -58,14 +58,14 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Gibt alle ausgeblendeten Highlights chronologisch sortiert zurück (neueste zuerst).
+   * Returns all hidden highlights sorted chronologically (newest first).
    */
   listChronological(): HiddenHighlight[] {
     return this.list().sort((a, b) => b.hiddenAt - a.hiddenAt);
   },
 
   /**
-   * Blendet ein Video dauerhaft aus (über die eindeutige videoId).
+   * Hides a video permanently (by its unique videoId).
    */
   hide(
     sourceId: string,
@@ -74,16 +74,16 @@ export const hiddenHighlightsService = {
   ): void {
     const list = this.list();
     const now = Date.now();
-    // Prüfen ob Video bereits ausgeblendet ist (nach videoId)
+    // Check whether the video is already hidden (by videoId)
     const existingIdx = list.findIndex((h) => h.videoId === videoId);
     if (existingIdx >= 0) {
-      // Video bereits ausgeblendet - nur Metadaten aktualisieren falls nötig
+      // Video already hidden - only update metadata if needed
       list[existingIdx].hiddenAt = now;
       if (meta?.videoTitle) list[existingIdx].videoTitle = meta.videoTitle;
       if (meta?.thumbnailUrl) list[existingIdx].thumbnailUrl = meta.thumbnailUrl;
       if (meta?.sourceLabel) list[existingIdx].sourceLabel = meta.sourceLabel;
     } else {
-      // Neues Video ausblenden
+      // Hide a new video
       list.push({
         videoId,
         sourceId,
@@ -98,7 +98,7 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Zeigt ein ausgeblendetes Video wieder an (entfernt es aus der Liste).
+   * Shows a hidden video again (removes it from the list).
    */
   show(videoId: string): void {
     const list = this.list().filter((h) => h.videoId !== videoId);
@@ -121,22 +121,22 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Prüft ob ein Video ausgeblendet ist (über die eindeutige videoId).
-   * Einmal ausgeblendete Videos bleiben dauerhaft versteckt.
+   * Checks whether a video is hidden (by its unique videoId).
+   * Once hidden, a video stays hidden permanently.
    */
   isHidden(videoId: string): boolean {
     return this.list().some((h) => h.videoId === videoId);
   },
 
   /**
-   * Prüft ob für einen sourceId ein Eintrag existiert (unabhängig von der videoId).
+   * Checks whether an entry exists for a sourceId (independent of the videoId).
    */
   hasEntry(sourceId: string): boolean {
     return this.list().some((h) => h.sourceId === sourceId);
   },
 
   /**
-   * Gibt die gespeicherte videoId für einen sourceId zurück, oder null wenn nicht vorhanden.
+   * Returns the stored videoId for a sourceId, or null if none exists.
    */
   getHiddenVideoId(sourceId: string): string | null {
     const entry = this.list().find((h) => h.sourceId === sourceId);
@@ -144,7 +144,7 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Entfernt alle ausgeblendeten Highlights.
+   * Removes all hidden highlights.
    */
   clearAll(): void {
     safeWrite(HIDDEN_HIGHLIGHTS_KEY, []);
@@ -159,7 +159,7 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Bereinigt veraltete Einträge für sourceIds, die nicht mehr in den Favoriten existieren.
+   * Cleans up stale entries for sourceIds that no longer exist in favorites.
    */
   cleanup(validSourceIds: string[]): void {
     const validSet = new Set(validSourceIds);

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -10,9 +10,9 @@ interface HighlightVideoCardProps {
   sourceLabel: string;
   sourceRank: number;
   sourceId: string;
-  // Wenn true, wird die Karte visuell als "wird aktualisiert" markiert
+  // When true, the card is visually marked as "refreshing"
   isRefreshing?: boolean;
-  // Callback zum Ausblenden der Karte (mit optionalen Metadaten für die Liste)
+  // Callback to hide the card (with optional metadata for the list)
   onHide?: (
     sourceId: string,
     videoId: string,
@@ -55,7 +55,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
     );
   };
 
-  // Frische Videos (jünger als 24h) mit grünem Rand hervorheben
+  // Highlight fresh videos (younger than 24h) with a green border
   const isFresh =
     typeof video?.publishedTimestamp === "number" &&
     Date.now() - video.publishedTimestamp < 24 * 60 * 60 * 1000;
@@ -93,7 +93,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
           <Sparkles className="w-3 h-3" aria-hidden="true" />#{highlightRank}
         </div>
 
-        {/* Ausblenden-Button */}
+        {/* Hide button */}
         {onHide && (
           <button
             type="button"

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -5,7 +5,7 @@
 export const STORAGE_KEYS = {
   API_KEY: "yt_api_key",
   CHANNEL_CACHE: "yt_channel_cache",
-  // v2: Cache-Key geändert um alte Einträge mit falschen Thumbnail-URLs zu invalidieren
+  // v2: Cache key changed to invalidate old entries with incorrect thumbnail URLs
   AUTOCOMPLETE_CACHE: "yt_autocomplete_cache_v2",
   QUOTA_TRACKING: "yt_quota_tracking",
   FAVORITES: "tt.favorites.v1",

--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -36,8 +36,8 @@ export enum SortOption {
 }
 
 /**
- * Legacy-Mapping: ältere Versionen haben deutsche String-Werte im Storage gespeichert.
- * Damit bestehende Nutzer nichts verlieren, mappen wir alte Werte auf die neuen Codes.
+ * Legacy mapping: older versions stored German string values in storage.
+ * To avoid breaking existing users, we map those old values onto the new codes.
  */
 export const LEGACY_TIMEFRAME_MAP: Record<string, TimeFrame> = {
   "Letzte Stunde": TimeFrame.LAST_HOUR,


### PR DESCRIPTION
Autonomous best-practice sweep — behavior-equivalent only. Verified locally: `npm ci` → `npm run typecheck` → `npm run build` all green (no test framework configured).

The codebase is already very clean from prior sweeps (no `any`, no `@ts-ignore`, no loose equality, no missing-radix `parseInt`). The only in-scope findings were violations of the English-only code-comment convention.

## Findings

| # | Datei | Kategorie | Befund | Vorschlag | Impact | Aufwand | Empfehlung | Status |
| - | ----- | --------- | ------ | --------- | ------ | ------- | ---------- | ------ |
| 1 | `src/features/dashboard/services/hiddenHighlightsService.ts` | Maintainability / Convention | Entire service documented in German (module JSDoc, field comments, ~10 method JSDoc blocks) — violates English-only code-comment rule | Translate all comments/JSDoc to English; code untouched | Comment-only, behavior-equivalent | M (24 lines, 1 file) | auto-fix | ✅ Fixed |
| 2 | `src/shared/constants/config.ts`, `src/shared/types/common.ts`, `src/shared/components/ui/HighlightVideoCard.tsx` | Maintainability / Convention | Scattered German comments (cache-key note, legacy-map JSDoc, 4 component comments) | Translate to English; `LEGACY_TIMEFRAME_MAP` German *storage-value keys* stay (persisted data) | Comment/JSX-comment only, behavior-equivalent | S (7 lines, 3 files) | auto-fix | ✅ Fixed |

## Deferred

- `InputSection.tsx` (~656 LoC, ~8 German comment lines) and `FavoriteRow.tsx` (~676 LoC, ~31 German comment lines) — comment cleanup belongs with the already-tracked God-component split refactor; outside the ≤3-file / ≤50-LoC sweep budget.

## Out of Scope

- Dependency changes (none). God-component splits, test-framework setup, magic-number extraction (all L-effort, tracked in CLAUDE.md). `LEGACY_TIMEFRAME_MAP` keys + native language labels (intentional data). Repo-wide `React.FC<>` style (deliberate, not an outlier).

Closes #264

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvfX6sA6MuPpjnS4hFjrB9)_