### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -112,14 +112,28 @@ export function AnalyserPage({
   }, [searchState.channelId, searchState.channelName]);
 
   // Comfort: export current (sorted) results as CSV + copy all URLs at once.
+  // Both actions surface a short inline state so a failure (blocked clipboard /
+  // download) is no longer a silent no-op.
   const [copiedAll, setCopiedAll] = useState(false);
+  const [copyAllFailed, setCopyAllFailed] = useState(false);
+  const [exportFailed, setExportFailed] = useState(false);
   const copiedAllTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exportFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
       if (copiedAllTimerRef.current) clearTimeout(copiedAllTimerRef.current);
+      if (copyFailedTimerRef.current) clearTimeout(copyFailedTimerRef.current);
+      if (exportFailedTimerRef.current) clearTimeout(exportFailedTimerRef.current);
     };
   }, []);
+
+  const flashCopyFailed = () => {
+    setCopyAllFailed(true);
+    if (copyFailedTimerRef.current) clearTimeout(copyFailedTimerRef.current);
+    copyFailedTimerRef.current = setTimeout(() => setCopyAllFailed(false), 2500);
+  };
 
   const handleExportCsv = () => {
     if (sortedVideos.length === 0) return;
@@ -136,14 +150,20 @@ export function AnalyserPage({
       a.remove();
       setTimeout(() => URL.revokeObjectURL(url), 0);
     } catch {
-      // ignore download errors (e.g. blocked environments)
+      // Surface download errors (e.g. blocked environments) instead of failing silently.
+      setExportFailed(true);
+      if (exportFailedTimerRef.current) clearTimeout(exportFailedTimerRef.current);
+      exportFailedTimerRef.current = setTimeout(() => setExportFailed(false), 2500);
     }
   };
 
   const handleCopyAllUrls = () => {
     if (sortedVideos.length === 0) return;
     // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
-    if (!navigator.clipboard) return;
+    if (!navigator.clipboard) {
+      flashCopyFailed();
+      return;
+    }
     const urls = sortedVideos.map((v) => v.url).join("\n");
     navigator.clipboard.writeText(urls).then(
       () => {
@@ -152,7 +172,8 @@ export function AnalyserPage({
         copiedAllTimerRef.current = setTimeout(() => setCopiedAll(false), 1500);
       },
       () => {
-        // Clipboard API unavailable
+        // Clipboard write rejected (permissions / focus) — show feedback.
+        flashCopyFailed();
       },
     );
   };
@@ -225,26 +246,44 @@ export function AnalyserPage({
                 <button
                   type="button"
                   onClick={handleCopyAllUrls}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-                  title={t("results.copyAllUrls")}
-                  aria-label={t("results.copyAllUrls")}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
+                    copyAllFailed
+                      ? "text-red-500 dark:text-red-400"
+                      : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800"
+                  }`}
+                  title={copyAllFailed ? t("results.copyAllFailed") : t("results.copyAllUrls")}
+                  aria-label={copyAllFailed ? t("results.copyAllFailed") : t("results.copyAllUrls")}
                 >
-                  {copiedAll ? (
+                  {copyAllFailed ? (
+                    <AlertCircle className="w-4 h-4" aria-hidden="true" />
+                  ) : copiedAll ? (
                     <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
                   ) : (
                     <Copy className="w-4 h-4" aria-hidden="true" />
                   )}
-                  <span className="hidden lg:inline">{t("results.copyAll")}</span>
+                  <span className="hidden lg:inline">
+                    {copyAllFailed ? t("results.copyAllFailed") : t("results.copyAll")}
+                  </span>
                 </button>
                 <button
                   type="button"
                   onClick={handleExportCsv}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-                  title={t("results.exportCsv")}
-                  aria-label={t("results.exportCsv")}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
+                    exportFailed
+                      ? "text-red-500 dark:text-red-400"
+                      : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800"
+                  }`}
+                  title={exportFailed ? t("results.exportFailed") : t("results.exportCsv")}
+                  aria-label={exportFailed ? t("results.exportFailed") : t("results.exportCsv")}
                 >
-                  <Download className="w-4 h-4" aria-hidden="true" />
-                  <span className="hidden lg:inline">CSV</span>
+                  {exportFailed ? (
+                    <AlertCircle className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <Download className="w-4 h-4" aria-hidden="true" />
+                  )}
+                  <span className="hidden lg:inline">
+                    {exportFailed ? t("results.exportFailed") : "CSV"}
+                  </span>
                 </button>
               </div>
 

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -104,6 +104,29 @@ export function AnalyserPage({
   const topVideos = sortedVideos.slice(0, topN);
   const otherVideos = sortedVideos.slice(topN);
 
+  // Screen-reader announcement for async result changes (the visual count badge
+  // alone is silent to assistive tech). Polite so it never interrupts typing.
+  const resultsAnnouncement = useMemo(() => {
+    if (searchState.isLoading) return t("results.announceLoading");
+    if (searchState.error) return "";
+    if (searchState.data) {
+      return sortedVideos.length > 0
+        ? t("results.announceResults", {
+            count: sortedVideos.length,
+            channel: searchState.channelName || "",
+          })
+        : t("results.announceNoResults");
+    }
+    return "";
+  }, [
+    searchState.isLoading,
+    searchState.error,
+    searchState.data,
+    searchState.channelName,
+    sortedVideos.length,
+    t,
+  ]);
+
   const channelUrl = useMemo(() => {
     if (searchState.channelId) return `https://www.youtube.com/channel/${searchState.channelId}`;
     const q = (searchState.channelName || "").trim();
@@ -189,6 +212,11 @@ export function AnalyserPage({
         externalSearchType={externalInputValues.searchType}
         externalSyncToken={externalInputValues.syncToken}
       />
+
+      {/* Screen-reader-only live region: announces loading / result count / no-results. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {resultsAnnouncement}
+      </p>
 
       {/* Error Message */}
       {searchState.error && (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -22,7 +22,8 @@
   },
   "emptyState": {
     "title": "Keine Ergebnisse",
-    "description": "Versuche andere Suchbegriffe oder Filter."
+    "description": "Versuche andere Suchbegriffe oder Filter.",
+    "tryExamples": "Oder probiere eines davon:"
   },
   "labels": {
     "search": "Suche",
@@ -170,7 +171,13 @@
     },
     "copyAll": "Alle kopieren",
     "copyAllUrls": "Alle Video-URLs kopieren",
-    "exportCsv": "Ergebnisse als CSV exportieren"
+    "copyAllFailed": "Zwischenablage nicht verfügbar",
+    "exportCsv": "Ergebnisse als CSV exportieren",
+    "exportFailed": "Export fehlgeschlagen",
+    "announceLoading": "Ergebnisse werden geladen…",
+    "announceResults_one": "{{count}} Video für {{channel}} gefunden.",
+    "announceResults_other": "{{count}} Videos für {{channel}} gefunden.",
+    "announceNoResults": "Keine Ergebnisse gefunden."
   },
   "timeAgo": {
     "justNow": "gerade eben",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -22,7 +22,8 @@
   },
   "emptyState": {
     "title": "No results",
-    "description": "Try different search terms or filters."
+    "description": "Try different search terms or filters.",
+    "tryExamples": "Or try one of these:"
   },
   "labels": {
     "search": "Search",
@@ -170,7 +171,13 @@
     },
     "copyAll": "Copy all",
     "copyAllUrls": "Copy all video URLs",
-    "exportCsv": "Export results as CSV"
+    "copyAllFailed": "Clipboard unavailable",
+    "exportCsv": "Export results as CSV",
+    "exportFailed": "Export failed",
+    "announceLoading": "Loading results…",
+    "announceResults_one": "{{count}} video found for {{channel}}.",
+    "announceResults_other": "{{count}} videos found for {{channel}}.",
+    "announceNoResults": "No results found."
   },
   "timeAgo": {
     "justNow": "just now",

--- a/src/shared/components/ui/EmptyState.tsx
+++ b/src/shared/components/ui/EmptyState.tsx
@@ -24,6 +24,33 @@ interface EmptyStateProps {
 export function EmptyState({ variant = "welcome", examples, onPickExample }: EmptyStateProps) {
   const { t } = useTranslation();
 
+  const showExamples = !!onPickExample && !!examples && examples.length > 0;
+
+  // Shared quick-start chips so a dead-end ("no results") search still offers an
+  // instant recovery path, not just a static message.
+  const exampleChips =
+    showExamples && examples && onPickExample ? (
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {examples.map((ex) => (
+          <button
+            key={`${ex.searchType}:${ex.query}`}
+            type="button"
+            onClick={() => onPickExample(ex.query, ex.searchType)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors
+                       border-slate-300 text-slate-700 hover:bg-slate-100 hover:text-slate-900 hover:border-slate-400
+                       dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white dark:hover:border-slate-600"
+            title={t("empty.exampleTitle", { example: ex.label })}
+          >
+            <Search
+              className="w-3.5 h-3.5 text-indigo-500 dark:text-indigo-400"
+              aria-hidden="true"
+            />
+            {ex.label}
+          </button>
+        ))}
+      </div>
+    ) : null;
+
   if (variant === "no-results") {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center px-4">
@@ -34,11 +61,18 @@ export function EmptyState({ variant = "welcome", examples, onPickExample }: Emp
           {t("emptyState.title")}
         </h2>
         <p className="text-slate-500 dark:text-slate-400 max-w-md">{t("emptyState.description")}</p>
+
+        {exampleChips && (
+          <div className="mt-8 flex flex-col items-center gap-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+              {t("emptyState.tryExamples")}
+            </p>
+            {exampleChips}
+          </div>
+        )}
       </div>
     );
   }
-
-  const showExamples = !!onPickExample && !!examples && examples.length > 0;
 
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center px-4">
@@ -50,30 +84,12 @@ export function EmptyState({ variant = "welcome", examples, onPickExample }: Emp
       </h2>
       <p className="text-slate-500 dark:text-slate-400 max-w-md">{t("empty.desc")}</p>
 
-      {showExamples && (
+      {exampleChips && (
         <div className="mt-8 flex flex-col items-center gap-3">
           <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
             {t("empty.tryExamples")}
           </p>
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            {examples.map((ex) => (
-              <button
-                key={`${ex.searchType}:${ex.query}`}
-                type="button"
-                onClick={() => onPickExample(ex.query, ex.searchType)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors
-                           border-slate-300 text-slate-700 hover:bg-slate-100 hover:text-slate-900 hover:border-slate-400
-                           dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white dark:hover:border-slate-600"
-                title={t("empty.exampleTitle", { example: ex.label })}
-              >
-                <Search
-                  className="w-3.5 h-3.5 text-indigo-500 dark:text-indigo-400"
-                  aria-hidden="true"
-                />
-                {ex.label}
-              </button>
-            ))}
-          </div>
+          {exampleChips}
         </div>
       )}
     </div>


### PR DESCRIPTION
Additive, local UX polish for TubeTrend (Vite + React 19). No new features, no refactor-only churn, no dependency changes. New UI strings added as i18n keys (en + de).

## Refinements

| # | Existing feature | Area / file | Category | UX gap | Improvement | Effort |
|---|------------------|-------------|----------|--------|-------------|--------|
| 1 | Analyser search results | `src/app/routes/AnalyserPage.tsx` | A11y polish | Async result changes were silent to screen readers (visual count badge only) | Visually-hidden `role="status" aria-live="polite"` region announcing loading / "{{count}} videos found for {{channel}}" / "no results"; message memoized from `searchState`. New `results.announce*` keys | S |
| 2 | Copy-all URLs & CSV export | `src/app/routes/AnalyserPage.tsx` | Comfort / feedback | Both buttons silently no-op'd when `navigator.clipboard` is unavailable or a download is blocked | Transient inline failure state (AlertCircle + red + "Clipboard unavailable" / "Export failed", auto-clears 2.5s), reusing the existing copied-feedback timer pattern. New `results.copyAllFailed` / `results.exportFailed` keys | S |
| 3 | "No results" empty state | `src/shared/components/ui/EmptyState.tsx` | Comfort | A no-results search was a dead end (static text, no action) | Quick-start example chips (already on the welcome screen) now also render in the `no-results` variant for instant recovery; shared chip rendering extracted, welcome branch unchanged. New `emptyState.tryExamples` key | S |

## Deferred / Out of scope

- **Defer:** arrow-key navigation in the search history/autocomplete dropdowns (`InputSection.tsx`, ~50 LoC + new state in a hot component); replacing `window.alert` backup confirmations with toasts (needs new toast infra).
- **Out of scope:** pre-existing `README.md` Prettier drift on `main` (not touched); Electron/Capacitor/extension wrappers (not browser UX surfaces); `FavoriteRow.tsx` god-component split (tracked in #126/#185).

## Verification

`prettier --check src/**` clean · `npm run typecheck` clean · `npm run build` green (1834 modules). No test framework configured in this repo.

Closes #266

---
_Generated by [Claude Code](https://claude.ai/code/session_01HupszNkfHkYciKNZvMHgHw)_