### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { SearchType, type TimeFrame } from "@/src/shared/types";
 import type { SearchState } from "@/src/features/search/hooks/useSearch";
 import { buildResultsCsv, buildResultsCsvFilename } from "@/src/features/videos";
+import { formatCompactNumber, formatNumber } from "@/src/shared/lib/formatters";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 
 interface AnalyserPageProps {
@@ -103,6 +104,13 @@ export function AnalyserPage({
 
   const topVideos = sortedVideos.slice(0, topN);
   const otherVideos = sortedVideos.slice(topN);
+
+  // Comfort: at-a-glance aggregate of all result views in the current time frame.
+  // Compact label (e.g. "1.2M") with the exact figure in the tooltip.
+  const totalViews = useMemo(
+    () => sortedVideos.reduce((sum, v) => sum + (v.views || 0), 0),
+    [sortedVideos],
+  );
 
   // Screen-reader announcement for async result changes (the visual count badge
   // alone is silent to assistive tech). Polite so it never interrupts typing.
@@ -256,6 +264,16 @@ export function AnalyserPage({
               <span className="bg-slate-200 dark:bg-slate-700 text-xs px-2 py-0.5 rounded-full text-slate-600 dark:text-slate-300 border border-slate-300 dark:border-slate-600">
                 {t("results.videosCount", { count: sortedVideos.length })}
               </span>
+              {totalViews > 0 && (
+                <span
+                  className="bg-indigo-500/10 text-xs px-2 py-0.5 rounded-full text-indigo-600 dark:text-indigo-300 border border-indigo-500/20 whitespace-nowrap cursor-help"
+                  title={t("results.totalViewsTitle", {
+                    count: formatNumber(totalViews),
+                  })}
+                >
+                  {t("results.totalViews", { count: formatCompactNumber(totalViews) })}
+                </span>
+              )}
               {searchState.isLoading && (
                 <span
                   className="inline-flex items-center gap-1 text-xs text-indigo-500 dark:text-indigo-400"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -169,7 +169,9 @@
       "watchOnYoutube": "Auf YouTube ansehen",
       "watchOnYoutubeAria": "{{title}} – auf YouTube ansehen",
       "copyTitle": "Videotitel kopieren",
-      "copyTitleAria": "Titel für {{title}} kopieren"
+      "copyTitleAria": "Titel für {{title}} kopieren",
+      "urlCopied": "Video-URL kopiert",
+      "titleCopied": "Videotitel kopiert"
     },
     "copyAll": "Alle kopieren",
     "copyAllUrls": "Alle Video-URLs kopieren",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -137,6 +137,8 @@
     "resultsFor": "Ergebnisse für",
     "videosCount_one": "{{count}} Video",
     "videosCount_other": "{{count}} Videos",
+    "totalViews": "{{count}} Aufrufe gesamt",
+    "totalViewsTitle": "Gesamtaufrufe über alle {{count}} Ergebnisse in diesem Zeitraum",
     "sortedBy": "Sortiert nach",
     "sortModes": {
       "trend": "Trend Score (Velocity)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -169,7 +169,9 @@
       "watchOnYoutube": "Watch on YouTube",
       "watchOnYoutubeAria": "{{title}} – watch on YouTube",
       "copyTitle": "Copy video title",
-      "copyTitleAria": "Copy title for {{title}}"
+      "copyTitleAria": "Copy title for {{title}}",
+      "urlCopied": "Video URL copied",
+      "titleCopied": "Video title copied"
     },
     "copyAll": "Copy all",
     "copyAllUrls": "Copy all video URLs",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -137,6 +137,8 @@
     "resultsFor": "Results for",
     "videosCount_one": "{{count}} video",
     "videosCount_other": "{{count}} videos",
+    "totalViews": "{{count}} total views",
+    "totalViewsTitle": "Total views across all {{count}} results in this time frame",
     "sortedBy": "Sorted by",
     "sortModes": {
       "trend": "Trend score (velocity)",

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Clock, Eye, Trash2, X } from "lucide-react";
+import { Clock, ExternalLink, Eye, Trash2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { hiddenHighlightsService, type HiddenHighlight } from "@/src/features/dashboard";
 import { getLocale } from "@/src/shared/lib/locale";
@@ -165,6 +165,18 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
 
                   {/* Actions */}
                   <div className="flex items-center gap-2 shrink-0">
+                    <a
+                      href={`https://www.youtube.com/watch?v=${item.videoId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                      title={t("results.table.watchOnYoutube")}
+                      aria-label={t("results.table.watchOnYoutubeAria", {
+                        title: item.videoTitle ?? "",
+                      })}
+                    >
+                      <ExternalLink className="w-3 h-3" aria-hidden="true" />
+                    </a>
                     <button
                       type="button"
                       onClick={() => handleUnhide(item.videoId)}

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -67,6 +67,11 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
 
   return (
     <div className="bg-white border-slate-200 dark:bg-slate-800 rounded-xl overflow-hidden border dark:border-slate-700 shadow-lg hover:shadow-xl hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300 group flex flex-col h-full relative">
+      {/* Polite live region: announce copy success to assistive tech (the green
+          checkmark alone is silent to screen readers). */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {copied ? t("results.table.urlCopied") : titleCopied ? t("results.table.titleCopied") : ""}
+      </span>
       {/* Thumbnail Area */}
       <div className="relative h-40 overflow-hidden bg-slate-100 dark:bg-slate-900">
         <a

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -63,6 +63,15 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
 
   return (
     <div className="bg-white/50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden backdrop-blur-sm shadow-xl">
+      {/* Polite live region: announce copy success to assistive tech (the green
+          checkmark alone is silent to screen readers). */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {copiedId
+          ? t("results.table.urlCopied")
+          : copiedTitleId
+            ? t("results.table.titleCopied")
+            : ""}
+      </span>
       <div className="overflow-x-auto">
         <table className="w-full text-left border-collapse" aria-label={t("results.moreVideos")}>
           <thead>


### PR DESCRIPTION
## Comfort Sweep — TubeTrend (Vite + React 19 + TypeScript)

Three small, verified end-user comfort/quality features. Branch off fresh `origin/main` (`bca0a14`). All i18n keys added to **both** `en` + `de`; reuses existing patterns (event bus, `formatters`, locale JSON, Tailwind `dark:` variants). No new dependencies, no refactors, no dep bumps.

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand | Empfehlung | Status |
|---|---------------|-----------|---------|--------|---------|------------|--------|
| 1 | `app/routes/AnalyserPage.tsx` + i18n | Komfort | Total-views summary badge on the results control bar (compact, e.g. `1.2M`) | At-a-glance reach of all results in the selected time frame, exact figure in tooltip | S | merge | merged |
| 2 | `shared/components/ui/HiddenHighlightsModal.tsx` | Komfort | "Watch on YouTube" link per entry in the Hidden Videos modal | Open a hidden highlight without un-hiding it first — parity with other video surfaces | S | merge | merged |
| 3 | `shared/components/ui/VideoCard.tsx`, `VideoListTable.tsx` + i18n | Qualität (a11y) | Polite `aria-live` announcement when a URL/title is copied | Screen-reader users get copy confirmation (was a silent visual checkmark) | S | merge | merged |

### i18n keys (en + de)
`results.totalViews`, `results.totalViewsTitle`, `results.table.urlCopied`, `results.table.titleCopied`. Feature 2 reuses the existing `results.table.watchOnYoutube` / `watchOnYoutubeAria` keys.

### Verification
`npm install` (electron binary skipped via `ELECTRON_SKIP_BINARY_DOWNLOAD=1` — blocked binary fetch unrelated to the web source build) → `typecheck` **green** → `build` (vite, 1834 modules) **green** → `prettier --check` on changed files **clean**. No test framework configured; typecheck + build is the gate.

### Notes
- `README.md` Prettier warning in full-repo `format:check` is pre-existing (tracked by #268), not touched here.

Closes #270

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4xVRT8RQ2XyJ7u1Q1BqWp)_