### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -164,14 +164,22 @@ export function DashboardPage({
                 <button
                   type="button"
                   onClick={onRefreshAll}
-                  disabled={favorites.length === 0}
+                  disabled={favorites.length === 0 || refreshingIds.size > 0}
+                  aria-busy={refreshingIds.size > 0}
                   className="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-md border transition-colors
                            border-slate-300 text-slate-700 hover:bg-slate-100
                            disabled:opacity-50 disabled:cursor-not-allowed
                            dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
-                  title={t("actions.refreshAll")}
+                  title={
+                    refreshingIds.size > 0
+                      ? t("favorites.status.refreshing")
+                      : t("actions.refreshAll")
+                  }
                 >
-                  <RefreshCw className="w-3 h-3" /> {t("actions.refreshAll")}
+                  <RefreshCw
+                    className={`w-3 h-3 ${refreshingIds.size > 0 ? "animate-spin" : ""}`}
+                  />{" "}
+                  {t("actions.refreshAll")}
                 </button>
                 {favorites.length > 0 && (
                   <button

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -287,6 +287,18 @@ export const ApiQuotaIndicator: React.FC = () => {
     };
   }, [isOpen]);
 
+  // Close on Escape — consistency with the app's other dropdowns/modals
+  // (search history, shortcuts hint, hidden-highlights modal), which the quota
+  // panel previously lacked (it only closed on an outside click).
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [isOpen]);
+
   // Determine optimal time window for chart
   const timeWindow = useMemo(() => getOptimalTimeWindow(history), [history]);
 
@@ -407,6 +419,11 @@ export const ApiQuotaIndicator: React.FC = () => {
         aria-expanded={isOpen}
         aria-haspopup="dialog"
         aria-controls="quota-history-panel"
+        title={t("quota.tooltip", {
+          used: formatNumber(quota.used),
+          limit: formatNumber(quota.limit),
+          percentage: quota.percentage,
+        })}
       >
         {/* Icon - warning when exhausted, otherwise battery */}
         {quota.exhausted ? (

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -65,6 +65,12 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
       className={`bg-white border-slate-200 dark:bg-slate-800 rounded-xl overflow-hidden border dark:border-slate-700 shadow-lg hover:shadow-xl hover:border-slate-300 dark:hover:border-slate-600 transition-all duration-300 group flex flex-col h-full relative ${isFresh ? "fresh-green-border" : ""} ${isRefreshing ? "opacity-60" : ""}`}
       aria-busy={isRefreshing}
     >
+      {/* Polite live region: announce copy success to assistive tech (the green
+          checkmark alone is silent to screen readers). Mirrors VideoCard. */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {copied ? t("results.table.urlCopied") : ""}
+      </span>
+
       {/* Thumbnail Area */}
       <div className="relative h-40 overflow-hidden bg-slate-100 dark:bg-slate-900">
         <a


### PR DESCRIPTION
Small, additive, local UX refinements to three existing user-facing features. No new features, no refactors, no dependency changes, no behavior-default changes. All three reuse existing i18n keys (no new `en`/`de` strings).

| Feature | Datei | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---|---|---|---|---|
| Favoriten-Dashboard „Alle aktualisieren" | `src/app/routes/DashboardPage.tsx` | Komfort / Performance | Button blieb während laufender Aktualisierung klickbar & ohne Fortschritt → doppelte, quota-kostspielige Refresh-All-Auslösungen | Disable während `refreshingIds > 0`, rotierendes Icon, `aria-busy`, Titel „Aktualisiere…" | S |
| API-Quota-Indikator | `src/shared/components/ui/ApiQuotaIndicator.tsx` | Komfort / A11y-Polish | Kein Hover-Tooltip auf der Mini-Batterie; Panel schloss nicht per Escape (inkonsistent) | `title` mit used/limit/% (aktiviert ungenutzten `quota.tooltip`-Key) + Escape-to-close | S |
| Highlight-Karte | `src/shared/components/ui/HighlightVideoCard.tsx` | A11y-Polish | Kopier-Erfolg für Screenreader stumm (anders als `VideoCard`/`VideoListTable`) | `sr-only` `aria-live="polite"` meldet „Video-URL kopiert" | S |

**Verifikation:** `npm ci` (Electron-Binary übersprungen) → `npm run typecheck` (grün) → `npm run build` (grün). Geänderte Dateien Prettier-konform. `README.md`-Formatierung ist bereits auf `main` rot (pre-existing, #268) und außerhalb dieses Sweeps.

Closes #275

<!-- screenshot: optional -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khv4mgWVEzG4poWZF9cYar)_