### PR TITLE
chore: docs quality maintenance (Vite/React)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,10 @@
 # - If a variable is left empty, the app may use its own internal fallback.
 
 # Default search value shown in the input field when the app loads.
-# If not set, the app will use these fallbacks:
+# Optional. If not set, the app will use these fallbacks:
 #   - Dev mode: "TEDx"
 #   - Production: "" (empty)
+# Format: free-text search query string.
 # Example: VITE_DEFAULT_SEARCH=TEDx
 VITE_DEFAULT_SEARCH=
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ npm run electron:dist
 
 The packaged app will be in the `release/` directory — portable, no Docker needed.
 
+For local development with hot reload:
+
+```bash
+npm run electron:dev
+```
+
 For a quick preview without packaging:
 
 ```bash


### PR DESCRIPTION
Automated repo-quality-maintenance sweep. Additive documentation only — no runtime config, no secrets, no code or dependency changes.

### Changes
| Pass | File | Finding | Fix |
|---|---|---|---|
| Defaults | `.env.example` | `VITE_DEFAULT_SEARCH` lacked the "Optional."/"Format:" tag the other 3 entries have | add optional + format hint |
| README | `README.md` | `npm run electron:dev` (documented in CLAUDE.md) missing from Desktop App section | +1 command |

ENV/config parity was already complete (all `VITE_*` keys documented).

Scope: docs/config-example artifacts only. Housekeeping/dependency work is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeV8bkzR7jKXsQd9oNcHyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeV8bkzR7jKXsQd9oNcHyf)_