### PR TITLE
security: hardening sweep (Vite + React SPA)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,9 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # HSTS: only honored by browsers over HTTPS (ignored on plain HTTP), so it is
+    # a no-op for the HTTP-only container yet hardens deployments fronted by TLS.
+    add_header Strict-Transport-Security "max-age=31536000" always;
     # Content-Security-Policy: scoped to what the SPA actually loads.
     # - script-src allows 'unsafe-inline' for the inline FOUC theme script in index.html
     #   (the Vite app bundle itself is external under /assets/).
@@ -34,6 +37,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     }
 }

--- a/src/features/videos/services/exportResults.ts
+++ b/src/features/videos/services/exportResults.ts
@@ -20,14 +20,29 @@ const CSV_COLUMNS = [
 ] as const;
 
 /**
+ * Neutralize spreadsheet formula injection ("CSV injection"): a field whose
+ * first character is a formula trigger (=, +, -, @, tab, or CR) is prefixed
+ * with a single quote so Excel / LibreOffice / Google Sheets treat it as
+ * literal text instead of evaluating it. Video titles and labels are
+ * attacker-controllable via the YouTube Data API, so this runs on every field.
+ * See OWASP "CSV Injection". Behavior-equivalent for normal values (only the
+ * rare value starting with a trigger char is affected).
+ */
+function neutralizeFormula(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
+/**
  * Escape a single CSV field per RFC 4180: wrap in double quotes when the value
- * contains a comma, quote, or newline, and double any embedded quotes.
+ * contains a comma, quote, or newline, and double any embedded quotes. Leading
+ * formula triggers are neutralized first to prevent CSV/formula injection.
  */
 function escapeCsvField(value: string): string {
-  if (/[",\r\n]/.test(value)) {
-    return `"${value.replace(/"/g, '""')}"`;
+  const safe = neutralizeFormula(value);
+  if (/[",\r\n]/.test(safe)) {
+    return `"${safe.replace(/"/g, '""')}"`;
   }
-  return value;
+  return safe;
 }
 
 /**


### PR DESCRIPTION
## Description

Autonomous security-hardening sweep of the browser-reachable web layer (client-only Vite + React SPA + its static nginx config). Two `safe`, behavior-equivalent fixes, one commit each.

| # | Category | Severity | File | Fix |
|---|----------|----------|------|-----|
| 1 | C — CSV/Formula Injection | Medium | `src/features/videos/services/exportResults.ts` | Attacker-controllable video titles (YouTube API) flowed verbatim into exported CSV cells; RFC-4180 quoting does not stop spreadsheet formula execution. `escapeCsvField` now prefixes any field starting with a formula trigger (`= + - @` / tab / CR) with `'` before quoting, so Excel/Sheets/LibreOffice treat it as literal text. Behavior-equivalent for normal values. |
| 2 | E — Missing HSTS header | Low | `nginx.conf` | Added `Strict-Transport-Security "max-age=31536000"` to the server + `/assets/` blocks. Browsers ignore HSTS over plain HTTP, so it is a no-op for the HTTP-only container yet hardens TLS-fronted deployments. |

Server-side categories (Broken Access Control / Auth / SSRF / CSRF) are n/a — this repo has no backend. Dependency CVEs (`undici`, `tar` — transitive build tooling) are flagged in the issue for the Dependabot routine, not touched here.

## Type of Change

- [x] Bug fix (security hardening)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines (Prettier-clean)
- [x] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable) — n/a, no UI strings changed
- [x] Tested locally — `npm run typecheck` + `npm run build` green

## Related Issues

Refs #278

---
_Generated by [Claude Code](https://claude.ai/code/session_018gTQKV93YUUyFQfJtkCDVB)_