### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,6 +41,20 @@ function createWindow(): void {
     return { action: "deny" };
   });
 
+  // Block in-window navigation away from the app (Electron security checklist:
+  // "disable or limit navigation"). Only the Vite dev server (HMR reloads) and
+  // the packaged file:// bundle are legitimate destinations; anything else
+  // (e.g. a link or file dragged onto the window) opens externally instead.
+  win.webContents.on("will-navigate", (event, url) => {
+    const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+    const isDevServer = !!devServerUrl && url.startsWith(devServerUrl);
+    if (isDevServer || url.startsWith("file://")) return;
+    event.preventDefault();
+    if (url.startsWith("https://") || url.startsWith("http://")) {
+      shell.openExternal(url);
+    }
+  });
+
   // vite-plugin-electron sets VITE_DEV_SERVER_URL in dev mode
   if (process.env.VITE_DEV_SERVER_URL) {
     win.loadURL(process.env.VITE_DEV_SERVER_URL);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,7 +6,10 @@ import { Header, Footer, type PageType } from "@/src/shared/components/layout";
 import { DashboardPage } from "./routes/DashboardPage";
 import { AnalyserPage } from "./routes/AnalyserPage";
 import { useTranslation } from "react-i18next";
-import { setApiKey as setYoutubeApiKey } from "@/src/features/youtube";
+import {
+  getApiKey as getYoutubeApiKey,
+  setApiKey as setYoutubeApiKey,
+} from "@/src/features/youtube";
 import { dashboardBackupService } from "@/src/features/dashboard";
 import { favoritesService } from "@/src/features/favorites";
 import {
@@ -25,9 +28,10 @@ import { safeRead, safeWrite } from "@/src/shared/lib/storage";
 const App: React.FC = () => {
   const { t } = useTranslation();
 
-  // API Key state
+  // API Key state — read via the canonical accessor (guarded against blocked
+  // storage). An empty key is normalized to null ("no key configured").
   const [apiKey, setApiKey] = useState<string | null>(() => {
-    return localStorage.getItem(STORAGE_KEYS.API_KEY);
+    return getYoutubeApiKey() || null;
   });
   const [isApiKeyModalOpen, setIsApiKeyModalOpen] = useState(false);
   const [isHiddenHighlightsModalOpen, setIsHiddenHighlightsModalOpen] = useState(false);

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -96,17 +96,25 @@ export function useFavorites() {
 export function useDashboardSort() {
   const [sortMode, setSortMode] = useState<DashboardSortMode>(() => {
     if (typeof window === "undefined") return "alpha";
-    const v = localStorage.getItem(STORAGE_KEYS.DASHBOARD_SORT);
-    return v === "velocity" ? "velocity" : "alpha";
+    try {
+      const v = localStorage.getItem(STORAGE_KEYS.DASHBOARD_SORT);
+      return v === "velocity" ? "velocity" : "alpha";
+    } catch {
+      return "alpha";
+    }
   });
 
   const [sortOrder, setSortOrder] = useState<SortOrder>(() => {
     if (typeof window === "undefined") return "asc";
-    const saved = localStorage.getItem(STORAGE_KEYS.DASHBOARD_ORDER);
-    if (saved === "asc" || saved === "desc") return saved;
-    const mode =
-      localStorage.getItem(STORAGE_KEYS.DASHBOARD_SORT) === "velocity" ? "velocity" : "alpha";
-    return mode === "velocity" ? "desc" : "asc";
+    try {
+      const saved = localStorage.getItem(STORAGE_KEYS.DASHBOARD_ORDER);
+      if (saved === "asc" || saved === "desc") return saved;
+      const mode =
+        localStorage.getItem(STORAGE_KEYS.DASHBOARD_SORT) === "velocity" ? "velocity" : "alpha";
+      return mode === "velocity" ? "desc" : "asc";
+    } catch {
+      return "asc";
+    }
   });
 
   const [cacheTick, setCacheTick] = useState(0);

--- a/src/features/youtube/services/youtubeApiClient.ts
+++ b/src/features/youtube/services/youtubeApiClient.ts
@@ -6,20 +6,30 @@ type Endpoint = keyof typeof API_COSTS;
 
 // Single source of truth: localStorage. No module-level mirror to avoid drift
 // when the key is changed in another tab/window or by other code paths.
+// Storage access is guarded (try/catch) like the shared storage helpers so a
+// blocked localStorage (privacy mode / blocked site data) degrades gracefully.
 export function setApiKey(key: string): void {
   if (typeof window === "undefined") return;
-  if (key) {
-    localStorage.setItem(STORAGE_KEYS.API_KEY, key);
-  } else {
-    localStorage.removeItem(STORAGE_KEYS.API_KEY);
-    // Reset quota statistics when API key is deleted
-    quotaService.reset();
+  try {
+    if (key) {
+      localStorage.setItem(STORAGE_KEYS.API_KEY, key);
+    } else {
+      localStorage.removeItem(STORAGE_KEYS.API_KEY);
+      // Reset quota statistics when API key is deleted
+      quotaService.reset();
+    }
+  } catch {
+    // Ignore storage errors
   }
 }
 
 export function getApiKey(): string {
   if (typeof window === "undefined") return "";
-  return localStorage.getItem(STORAGE_KEYS.API_KEY) || "";
+  try {
+    return localStorage.getItem(STORAGE_KEYS.API_KEY) || "";
+  } catch {
+    return "";
+  }
 }
 
 export class YouTubeApiError extends Error {

--- a/src/features/youtube/services/youtubeApiClient.ts
+++ b/src/features/youtube/services/youtubeApiClient.ts
@@ -50,10 +50,13 @@ export async function fetchFromApi<T>(
 
   const cost = API_COSTS[endpoint];
   const response = await fetch(url.toString(), { signal });
-  const data = await response.json();
+  // The YouTube API always answers with JSON; guard against non-JSON bodies
+  // (proxy/HTML error pages, empty responses) so a parse failure surfaces as a
+  // typed YouTubeApiError instead of a cryptic SyntaxError leaking to the UI.
+  const data = await response.json().catch(() => null);
 
   if (!response.ok) {
-    if (data.error) {
+    if (data?.error) {
       const msg: string = typeof data.error.message === "string" ? data.error.message : "";
       const lower = msg.toLowerCase();
 
@@ -82,6 +85,10 @@ export async function fetchFromApi<T>(
     }
 
     throw new YouTubeApiError(`HTTP error: ${response.status}`, response.status);
+  }
+
+  if (data === null) {
+    throw new YouTubeApiError("Invalid response from YouTube API.", response.status);
   }
 
   // Track successful request

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -19,9 +19,14 @@ function getSystemTheme(): ResolvedTheme {
 
 function getStoredTheme(): Theme {
   if (typeof window === "undefined") return "system";
-  const stored = localStorage.getItem(STORAGE_KEYS.THEME);
-  if (stored === "light" || stored === "dark" || stored === "system") {
-    return stored;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.THEME);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
+  } catch {
+    // Storage blocked (privacy mode) — fall back to system preference,
+    // matching the guarded FOUC script in index.html.
   }
   return "system";
 }
@@ -36,7 +41,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
     if (typeof window !== "undefined") {
-      localStorage.setItem(STORAGE_KEYS.THEME, newTheme);
+      try {
+        localStorage.setItem(STORAGE_KEYS.THEME, newTheme);
+      } catch {
+        // Ignore storage errors — the in-memory theme still applies
+      }
     }
   };
 

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -7,6 +7,7 @@ import { favoritesService } from "@/src/features/favorites";
 import { analyzeVideoStats } from "@/src/features/videos";
 import {
   findChannelInfo,
+  getApiKey,
   getChannelQueryType,
   getVideosFromChannel,
   searchVideosByKeyword,
@@ -23,7 +24,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
-import { MAX_RESULTS_OPTIONS, STORAGE_KEYS, TIME_FRAMES } from "@/src/shared/constants";
+import { MAX_RESULTS_OPTIONS, TIME_FRAMES } from "@/src/shared/constants";
 import { useTranslation } from "react-i18next";
 import { dispatchEvent, eventBus } from "@/src/shared/lib/eventBus";
 import { formatTimeAgo } from "@/src/shared/lib/formatters";
@@ -350,7 +351,8 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
 
     let cancelled = false;
     // Ohne API-Key kein Versuch, die Metadaten zu laden
-    const hasKey = typeof window !== "undefined" && !!localStorage.getItem(STORAGE_KEYS.API_KEY);
+    // (canonical accessor — window guard + storage error handling built in)
+    const hasKey = !!getApiKey();
     if (!hasKey) return;
 
     // Kurze Verzögerung um dem Haupt-useEffect Zeit zu geben, Cache-Daten zu laden

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -80,9 +80,20 @@ export const InputSection: React.FC<InputSectionProps> = ({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Generation counter for suggestion lookups: bumped whenever the input
+  // changes or is cleared so pending timers / in-flight responses for an
+  // outdated value can neither reopen the dropdown nor overwrite fresh results.
+  const suggestionRequestRef = useRef(0);
   const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [justSaved, setJustSaved] = useState<boolean>(false);
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
+
+  // Invalidate any pending/in-flight suggestion lookup (timer + response guard)
+  const cancelSuggestionLookup = () => {
+    suggestionRequestRef.current += 1;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    setIsSearchingSuggestions(false);
+  };
 
   // Clear timers on unmount to avoid state updates on unmounted component
   useEffect(() => {
@@ -130,6 +141,8 @@ export const InputSection: React.FC<InputSectionProps> = ({
   // externalSyncToken als Dependency sorgt dafür, dass auch bei gleichem Favoriten die Werte aktualisiert werden
   useEffect(() => {
     if (externalQuery !== undefined && externalSyncToken !== undefined) {
+      // The synced value replaces whatever was typed — drop pending lookups.
+      cancelSuggestionLookup();
       // Bei Keyword-Suche: Präfix # hinzufügen, falls nicht vorhanden
       const prefix =
         externalSearchType === SearchType.KEYWORD && !externalQuery.startsWith("#") ? "#" : "";
@@ -209,6 +222,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
     // Hide history once user starts typing
     if (val.length > 0) setShowHistory(false);
 
+    // The input changed — a lookup scheduled for the previous value is stale.
+    cancelSuggestionLookup();
+
     // Autocomplete nur bei Kanal-Suche (basierend auf neuem Wert)
     const newSearchType = detectSearchType(val);
     if (newSearchType !== SearchType.CHANNEL) {
@@ -231,23 +247,26 @@ export const InputSection: React.FC<InputSectionProps> = ({
     }
 
     // Debounce API call
-    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
-
+    const requestId = suggestionRequestRef.current;
     setIsSearchingSuggestions(true);
     debounceTimerRef.current = setTimeout(async () => {
       try {
         const results = await searchChannels(val);
+        if (requestId !== suggestionRequestRef.current) return; // stale response
         setSuggestions(results);
         setShowSuggestions(true);
       } catch (err) {
         if (import.meta.env.DEV) console.error(err);
       } finally {
-        setIsSearchingSuggestions(false);
+        if (requestId === suggestionRequestRef.current) {
+          setIsSearchingSuggestions(false);
+        }
       }
     }, 500); // 500ms delay
   };
 
   const selectSuggestion = (suggestion: ChannelSuggestion) => {
+    cancelSuggestionLookup();
     setInputValue(suggestion.title); // Use title for display
     setSuggestions([]);
     setShowSuggestions(false);
@@ -255,6 +274,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
   };
 
   const clearInput = () => {
+    cancelSuggestionLookup();
     setInputValue("");
     setSuggestions([]);
     setShowSuggestions(false);
@@ -351,11 +371,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
         return;
       }
       if (inputValue) {
-        // Mirror clearInput(): reset the query and any pending dropdowns.
-        setInputValue("");
-        setSuggestions([]);
-        setShowSuggestions(false);
-        setShowHistory(false);
+        // Mirror clearInput(): reset the query, any pending dropdowns, and
+        // cancel a pending suggestion lookup for the cleared value.
+        clearInput();
       }
     };
     document.addEventListener("keydown", handleEsc);


### PR DESCRIPTION
## Description

Automated best-practice sweep (Vite + React stack). Five small, behavior-equivalent hardening/correctness fixes — one commit per finding:

| # | Datei(en) | Kategorie | Befund → Fix | Aufwand | Empfehlung |
|---|-----------|-----------|--------------|---------|------------|
| 1 | `electron/main.ts` | Security | No `will-navigate` guard (window navigable to remote origins, e.g. dragged links) → deny non-app navigation, open http(s) externally, mirroring `setWindowOpenHandler` | S | auto-fix |
| 2 | `src/features/youtube/services/youtubeApiClient.ts` | Correctness | Unguarded `response.json()` threw raw `SyntaxError` on non-JSON bodies, bypassing typed errors + 4xx quota tracking → parse-safe with typed `YouTubeApiError` fallback | S | auto-fix |
| 3 | `src/shared/components/ui/InputSection.tsx` | Correctness | Autocomplete debounce not cancelled on early-return/clear/pick/sync paths — stale dropdown, stuck spinner, stray 100-unit `search` quota calls, out-of-order responses → generation counter + shared cancel helper | M | auto-fix |
| 4 | `youtubeApiClient.ts`, `App.tsx`, `FavoriteRow.tsx` | Correctness | `get/setApiKey` unguarded + duplicated raw `localStorage` reads of the API key → guarded canonical accessors, reused app-wide | M | auto-fix |
| 5 | `ThemeProvider.tsx`, `useDashboard.ts` | Correctness | Unguarded `localStorage` in theme/sort state initializers (blocked storage crashed first render / theme toggle) → try/catch with existing defaults per documented storage pattern | M | auto-fix |

Full finding tables (incl. deferred + tie-breaker overflow): #285

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no UI text changed
- [x] Tested locally — `npm run format:check`, `npm run typecheck`, `npm run build`, `ELECTRON=true vite build` all green (no test framework configured)

## Related Issues

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128iQ6UzgYxW49pUi3aHGBM

---
_Generated by [Claude Code](https://claude.ai/code/session_0128iQ6UzgYxW49pUi3aHGBM)_