### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,6 +18,7 @@ import {
   useHighlights,
 } from "@/src/features/dashboard/hooks/useDashboard";
 import { useSearch } from "@/src/features/search/hooks/useSearch";
+import { useTheme } from "@/src/providers/ThemeProvider";
 import type { FavoriteConfig } from "@/src/features/favorites/types";
 import type { VideoData } from "@/src/features/videos/types";
 import { type SearchType, TimeFrame } from "@/src/shared/types";
@@ -27,6 +28,7 @@ import { safeRead, safeWrite } from "@/src/shared/lib/storage";
 
 const App: React.FC = () => {
   const { t } = useTranslation();
+  const { theme, setTheme } = useTheme();
 
   // API Key state — read via the canonical accessor (guarded against blocked
   // storage). An empty key is normalized to null ("no key configured").
@@ -76,6 +78,7 @@ const App: React.FC = () => {
   // Global hotkeys:
   // - "d" / "a" switch between Dashboard and Analyser
   // - "r" on the dashboard refreshes all favorites
+  // - "t" cycles the theme (system → light → dark)
   // - "?" toggles the keyboard-shortcuts help popover
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -108,6 +111,14 @@ const App: React.FC = () => {
         setActivePage("analyser");
         return;
       }
+      if (key === "t") {
+        e.preventDefault();
+        // Cycle system → light → dark, matching the ThemeToggle button.
+        const order: Array<"system" | "light" | "dark"> = ["system", "light", "dark"];
+        const idx = order.indexOf(theme);
+        setTheme(order[(idx + 1) % order.length]);
+        return;
+      }
       if (key === "r") {
         if (activePage !== "dashboard") return;
         if (favorites.length === 0) return;
@@ -115,7 +126,7 @@ const App: React.FC = () => {
         refreshAll();
       }
     },
-    [activePage, favorites.length, refreshAll],
+    [activePage, favorites.length, refreshAll, theme, setTheme],
   );
   useEventListener("keydown", handleKeyDown, document);
 

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertCircle, Check, Copy, Download, Eye, List, Loader2, Trophy } from "lucide-react";
+import {
+  AlertCircle,
+  Check,
+  Copy,
+  Download,
+  Eye,
+  FileJson,
+  List,
+  Loader2,
+  Trophy,
+} from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
 import { InputSection } from "@/src/shared/components/ui/InputSection";
 import { VideoCard } from "@/src/shared/components/ui/VideoCard";
@@ -8,7 +18,12 @@ import { EmptyState, type EmptyStateExample } from "@/src/shared/components/ui/E
 import { useTranslation } from "react-i18next";
 import { SearchType, type TimeFrame } from "@/src/shared/types";
 import type { SearchState } from "@/src/features/search/hooks/useSearch";
-import { buildResultsCsv, buildResultsCsvFilename } from "@/src/features/videos";
+import {
+  buildResultsCsv,
+  buildResultsCsvFilename,
+  buildResultsJson,
+  buildResultsJsonFilename,
+} from "@/src/features/videos";
 import { formatCompactNumber, formatNumber } from "@/src/shared/lib/formatters";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 
@@ -148,15 +163,18 @@ export function AnalyserPage({
   const [copiedAll, setCopiedAll] = useState(false);
   const [copyAllFailed, setCopyAllFailed] = useState(false);
   const [exportFailed, setExportFailed] = useState(false);
+  const [exportJsonFailed, setExportJsonFailed] = useState(false);
   const copiedAllTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copyFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const exportFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exportJsonFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
       if (copiedAllTimerRef.current) clearTimeout(copiedAllTimerRef.current);
       if (copyFailedTimerRef.current) clearTimeout(copyFailedTimerRef.current);
       if (exportFailedTimerRef.current) clearTimeout(exportFailedTimerRef.current);
+      if (exportJsonFailedTimerRef.current) clearTimeout(exportJsonFailedTimerRef.current);
     };
   }, []);
 
@@ -185,6 +203,28 @@ export function AnalyserPage({
       setExportFailed(true);
       if (exportFailedTimerRef.current) clearTimeout(exportFailedTimerRef.current);
       exportFailedTimerRef.current = setTimeout(() => setExportFailed(false), 2500);
+    }
+  };
+
+  const handleExportJson = () => {
+    if (sortedVideos.length === 0) return;
+    try {
+      const json = buildResultsJson(sortedVideos, searchState.channelName);
+      const filename = buildResultsJsonFilename(searchState.channelName);
+      const blob = new Blob([json], { type: "application/json;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch {
+      // Surface download errors (e.g. blocked environments) instead of failing silently.
+      setExportJsonFailed(true);
+      if (exportJsonFailedTimerRef.current) clearTimeout(exportJsonFailedTimerRef.current);
+      exportJsonFailedTimerRef.current = setTimeout(() => setExportJsonFailed(false), 2500);
     }
   };
 
@@ -329,6 +369,28 @@ export function AnalyserPage({
                   )}
                   <span className="hidden lg:inline">
                     {exportFailed ? t("results.exportFailed") : "CSV"}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleExportJson}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors ${
+                    exportJsonFailed
+                      ? "text-red-500 dark:text-red-400"
+                      : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800"
+                  }`}
+                  title={exportJsonFailed ? t("results.exportFailed") : t("results.exportJson")}
+                  aria-label={
+                    exportJsonFailed ? t("results.exportFailed") : t("results.exportJson")
+                  }
+                >
+                  {exportJsonFailed ? (
+                    <AlertCircle className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <FileJson className="w-4 h-4" aria-hidden="true" />
+                  )}
+                  <span className="hidden lg:inline">
+                    {exportJsonFailed ? t("results.exportFailed") : "JSON"}
                   </span>
                 </button>
               </div>

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -24,7 +24,8 @@ import {
   buildResultsJson,
   buildResultsJsonFilename,
 } from "@/src/features/videos";
-import { formatCompactNumber, formatNumber } from "@/src/shared/lib/formatters";
+import { formatCompactNumber, formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
+import { getLocale } from "@/src/shared/lib/locale";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 
 interface AnalyserPageProps {
@@ -312,6 +313,16 @@ export function AnalyserPage({
                   })}
                 >
                   {t("results.totalViews", { count: formatCompactNumber(totalViews) })}
+                </span>
+              )}
+              {searchState.resultSavedAt != null && !searchState.isLoading && (
+                <span
+                  className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap cursor-help"
+                  title={new Date(searchState.resultSavedAt).toLocaleString(getLocale())}
+                >
+                  {t("results.analyzedAgo", {
+                    time: formatTimeAgo(searchState.resultSavedAt, t),
+                  })}
                 </span>
               )}
               {searchState.isLoading && (

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -10,6 +10,8 @@ import {
   searchVideosByKeyword,
   YouTubeApiError,
 } from "@/src/features/youtube";
+import { CACHE_TTL, STORAGE_KEYS } from "@/src/shared/constants";
+import { safeRead, safeRemove, safeWrite } from "@/src/shared/lib/storage";
 
 export interface SearchState {
   isLoading: boolean;
@@ -18,6 +20,8 @@ export interface SearchState {
   data: VideoData[] | null;
   channelName: string;
   channelId?: string;
+  /** Epoch ms when the currently displayed analysis was produced (undefined for cached favorite views). */
+  resultSavedAt?: number;
 }
 
 const initialSearchState: SearchState = {
@@ -28,12 +32,62 @@ const initialSearchState: SearchState = {
   channelName: "",
 };
 
+/** Snapshot of the last completed analyser search, persisted so it survives a page reload. */
+interface PersistedAnalyserResult {
+  data: VideoData[];
+  channelName: string;
+  channelId?: string;
+  savedAt: number;
+}
+
+function isPersistedAnalyserResult(value: unknown): value is PersistedAnalyserResult {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    Array.isArray(v.data) &&
+    typeof v.channelName === "string" &&
+    typeof v.savedAt === "number" &&
+    (v.channelId === undefined || typeof v.channelId === "string")
+  );
+}
+
+/** Read the persisted last result, ignoring anything malformed or older than the TTL. */
+function readPersistedResult(): PersistedAnalyserResult | null {
+  const raw = safeRead<unknown>(STORAGE_KEYS.ANALYSER_LAST_RESULT, null);
+  if (!isPersistedAnalyserResult(raw)) return null;
+  if (Date.now() - raw.savedAt > CACHE_TTL.ANALYSER_RESULT) return null;
+  return raw;
+}
+
+function persistResult(result: PersistedAnalyserResult): void {
+  safeWrite(STORAGE_KEYS.ANALYSER_LAST_RESULT, result);
+}
+
+function clearPersistedResult(): void {
+  safeRemove(STORAGE_KEYS.ANALYSER_LAST_RESULT);
+}
+
+/** Rehydrate the last completed search on mount so a reload keeps the results in view. */
+function restoreInitialSearchState(): SearchState {
+  const persisted = readPersistedResult();
+  if (!persisted) return initialSearchState;
+  return {
+    isLoading: false,
+    step: "complete",
+    error: null,
+    data: persisted.data,
+    channelName: persisted.channelName,
+    channelId: persisted.channelId,
+    resultSavedAt: persisted.savedAt,
+  };
+}
+
 interface UseSearchOptions {
   onApiKeyInvalid?: () => void;
 }
 
 export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
-  const [searchState, setSearchState] = useState<SearchState>(initialSearchState);
+  const [searchState, setSearchState] = useState<SearchState>(restoreInitialSearchState);
 
   const handleSearch = useCallback(
     async (
@@ -92,6 +146,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
         setSearchState((prev) => ({ ...prev, step: "analyzing_ai" }));
         const analyzedVideos = analyzeVideoStats(apiVideos, displayName, timeFrame);
 
+        const savedAt = Date.now();
         setSearchState({
           isLoading: false,
           step: "complete",
@@ -99,7 +154,10 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
           data: analyzedVideos,
           channelName: displayName,
           channelId,
+          resultSavedAt: savedAt,
         });
+        // Persist the snapshot so a page reload keeps the results in view.
+        persistResult({ data: analyzedVideos, channelName: displayName, channelId, savedAt });
       } catch (err: unknown) {
         if (import.meta.env.DEV) console.error(err);
         const errorMessage = err instanceof Error ? err.message : "Analysis failed.";
@@ -143,6 +201,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
   );
 
   const resetSearch = useCallback(() => {
+    clearPersistedResult();
     setSearchState(initialSearchState);
   }, []);
 

--- a/src/features/videos/index.ts
+++ b/src/features/videos/index.ts
@@ -7,4 +7,9 @@ export * from "./types";
 
 // Services
 export { analyzeVideoStats } from "./services/trendAnalysisService";
-export { buildResultsCsv, buildResultsCsvFilename } from "./services/exportResults";
+export {
+  buildResultsCsv,
+  buildResultsCsvFilename,
+  buildResultsJson,
+  buildResultsJsonFilename,
+} from "./services/exportResults";

--- a/src/features/videos/services/exportResults.ts
+++ b/src/features/videos/services/exportResults.ts
@@ -68,11 +68,12 @@ export function buildResultsCsv(videos: VideoData[]): string {
 }
 
 /**
- * Build a filesystem-safe, timestamped CSV filename for an analyser export.
- * e.g. buildResultsCsvFilename("@MrBeast") -> "tubetrend-MrBeast_2026-06-08_12-30-00.csv"
+ * Build a filesystem-safe, timestamped export filename.
+ * e.g. buildExportFilename("@MrBeast", "csv") -> "tubetrend-MrBeast_2026-06-08_12-30-00.csv"
  */
-export function buildResultsCsvFilename(
+function buildExportFilename(
   label: string | null | undefined,
+  extension: string,
   now: Date = new Date(),
 ): string {
   const pad = (n: number) => String(n).padStart(2, "0");
@@ -86,5 +87,78 @@ export function buildResultsCsvFilename(
     .replace(/^-+|-+$/g, "")
     .slice(0, 40);
   const namePart = slug ? `-${slug}` : "";
-  return `tubetrend${namePart}_${stamp}.csv`;
+  return `tubetrend${namePart}_${stamp}.${extension}`;
+}
+
+/**
+ * Build a filesystem-safe, timestamped CSV filename for an analyser export.
+ * e.g. buildResultsCsvFilename("@MrBeast") -> "tubetrend-MrBeast_2026-06-08_12-30-00.csv"
+ */
+export function buildResultsCsvFilename(
+  label: string | null | undefined,
+  now: Date = new Date(),
+): string {
+  return buildExportFilename(label, "csv", now);
+}
+
+/** One video entry in the JSON export (mirrors the CSV columns, plus the stable video id). */
+interface JsonExportVideo {
+  rank: number;
+  id: string;
+  title: string;
+  url: string;
+  views: number;
+  viewsPerHour: number | null;
+  engagementRate: number | null;
+  trendingScore: number;
+  publishedAt: string;
+}
+
+/** Structured envelope for a JSON results export (self-describing for downstream tooling). */
+export interface ResultsJsonExport {
+  exportedAt: string;
+  channel: string | null;
+  count: number;
+  videos: JsonExportVideo[];
+}
+
+/**
+ * Build a pretty-printed JSON document from analyser results. Unlike the flat CSV
+ * export, this keeps the stable video id and wraps the rows in a self-describing
+ * envelope (export time + channel + count) so the data is easy to consume
+ * programmatically. Order is preserved exactly as passed in.
+ */
+export function buildResultsJson(
+  videos: VideoData[],
+  channel?: string | null,
+  now: Date = new Date(),
+): string {
+  const payload: ResultsJsonExport = {
+    exportedAt: now.toISOString(),
+    channel: channel && channel.trim() ? channel.trim() : null,
+    count: videos.length,
+    videos: videos.map((video, index) => ({
+      rank: index + 1,
+      id: video.id,
+      title: video.title,
+      url: video.url,
+      views: video.views,
+      viewsPerHour: video.viewsPerHour ?? null,
+      engagementRate: video.engagementRate ?? null,
+      trendingScore: video.trendingScore,
+      publishedAt: new Date(video.publishedTimestamp).toISOString(),
+    })),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+/**
+ * Build a filesystem-safe, timestamped JSON filename for an analyser export.
+ * e.g. buildResultsJsonFilename("@MrBeast") -> "tubetrend-MrBeast_2026-06-08_12-30-00.json"
+ */
+export function buildResultsJsonFilename(
+  label: string | null | undefined,
+  now: Date = new Date(),
+): string {
+  return buildExportFilename(label, "json", now);
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -180,6 +180,7 @@
     "exportCsv": "Ergebnisse als CSV exportieren",
     "exportJson": "Ergebnisse als JSON exportieren",
     "exportFailed": "Export fehlgeschlagen",
+    "analyzedAgo": "Analysiert {{time}}",
     "announceLoading": "Ergebnisse werden geladen…",
     "announceResults_one": "{{count}} Video für {{channel}} gefunden.",
     "announceResults_other": "{{count}} Videos für {{channel}} gefunden.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -178,6 +178,7 @@
     "copyAllUrls": "Alle Video-URLs kopieren",
     "copyAllFailed": "Zwischenablage nicht verfügbar",
     "exportCsv": "Ergebnisse als CSV exportieren",
+    "exportJson": "Ergebnisse als JSON exportieren",
     "exportFailed": "Export fehlgeschlagen",
     "announceLoading": "Ergebnisse werden geladen…",
     "announceResults_one": "{{count}} Video für {{channel}} gefunden.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -296,6 +296,7 @@
     "focusSearch": "Suche fokussieren",
     "openDashboard": "Dashboard öffnen",
     "openAnalyser": "Analyser öffnen",
+    "toggleTheme": "Theme wechseln",
     "refreshAll": "Alle Favoriten aktualisieren",
     "toggleHint": "Kuerzel anzeigen"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -180,6 +180,7 @@
     "exportCsv": "Export results as CSV",
     "exportJson": "Export results as JSON",
     "exportFailed": "Export failed",
+    "analyzedAgo": "Analyzed {{time}}",
     "announceLoading": "Loading results…",
     "announceResults_one": "{{count}} video found for {{channel}}.",
     "announceResults_other": "{{count}} videos found for {{channel}}.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -296,6 +296,7 @@
     "focusSearch": "Focus search",
     "openDashboard": "Open Dashboard",
     "openAnalyser": "Open Analyser",
+    "toggleTheme": "Toggle theme",
     "refreshAll": "Refresh all favorites",
     "toggleHint": "Show shortcuts"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -178,6 +178,7 @@
     "copyAllUrls": "Copy all video URLs",
     "copyAllFailed": "Clipboard unavailable",
     "exportCsv": "Export results as CSV",
+    "exportJson": "Export results as JSON",
     "exportFailed": "Export failed",
     "announceLoading": "Loading results…",
     "announceResults_one": "{{count}} video found for {{channel}}.",

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -192,6 +192,14 @@ function KeyboardShortcutsHint({ activePage }: { activePage: PageType }) {
                 A
               </kbd>
             </div>
+            <div className="flex items-center justify-between">
+              <span className="text-slate-500 dark:text-slate-400">
+                {t("keyboard.toggleTheme")}
+              </span>
+              <kbd className="px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 font-mono text-slate-600 dark:text-slate-300">
+                T
+              </kbd>
+            </div>
             {activePage === "dashboard" && (
               <div className="flex items-center justify-between">
                 <span className="text-slate-500 dark:text-slate-400">

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -19,6 +19,7 @@ export const STORAGE_KEYS = {
   HIDDEN_HIGHLIGHTS: "tt.dashboard.hiddenHighlights.v1",
   ANALYSER_SORT_MODE: "tt.analyser.sortMode",
   ANALYSER_TOP_N: "tt.analyser.topN",
+  ANALYSER_LAST_RESULT: "tt.analyser.lastResult.v1",
   ACTIVE_PAGE: "tt.activePage",
   THEME: "tt.theme",
 } as const;
@@ -26,6 +27,8 @@ export const STORAGE_KEYS = {
 export const CACHE_TTL = {
   AUTOCOMPLETE: 5 * 60 * 1000, // 5 minutes
   FAVORITES: 120 * 60 * 1000, // 2 hours
+  // Restore the last analyser result on reload only while it is reasonably fresh.
+  ANALYSER_RESULT: 24 * 60 * 60 * 1000, // 24 hours
 } as const;
 
 export const API_COSTS = {


### PR DESCRIPTION
## Comfort sweep — 3 end-user features

Vite 8 + React 19 + TypeScript SPA. All UI strings via i18n (en + de). Verified locally: `npm ci` → `npm run typecheck` → `npm run build` all green.

| # | Bereich/Datei | Kategorie | Feature | Nutzen für User | Aufwand | Status |
|---|---|---|---|---|---|---|
| 1 | `exportResults.ts`, `AnalyserPage.tsx` | Komfort/Qualität | **JSON export of analyser results** next to the CSV export — keeps the stable video `id` and wraps rows in a self-describing envelope (`exportedAt` + `channel` + `count`); reuses the blob-download pattern with inline failure feedback | Structured, programmatically consumable export alongside CSV | S | ✅ |
| 2 | `useSearch.ts`, `AnalyserPage.tsx`, `config.ts` | Komfort | **Restore last analysis after reload** — persist the last completed search snapshot to `localStorage` and rehydrate on mount (24h TTL); an "Analyzed {time}" chip surfaces snapshot age | Results survive a reload / app auto-restore instead of dropping to the welcome screen | M | ✅ |
| 3 | `App.tsx`, `Header.tsx` | Komfort | **`t` keyboard shortcut to cycle theme** (system → light → dark), documented in the shortcuts popover; guarded against firing while typing | One-key theme switch | S | ✅ |

### Notes
- No new dependencies. No drive-by refactors. `StorageAdapter` used for all persistence; new i18n keys added to both en + de.
- Deferred / further ideas (copy-all highlight URLs, restore last query text, re-run current search, `FavoriteRow` split) are documented in the tracking issue.

Closes #287

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuCWAGrv8hm7sfsrj9PEJm)_