### PR TITLE
ux: best-practice sweep (Vite + React)

### DIFF
--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -417,6 +417,20 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [showTfMenu, showMaxMenu]);
 
+  // Close an open popover on Escape (keyboard dismissal). Consistent with the
+  // app's other popovers (quota panel, search dropdowns, shortcuts hint); these
+  // two menus previously could only be closed via an outside mouse click.
+  useEffect(() => {
+    if (!showTfMenu && !showMaxMenu) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      setShowTfMenu(false);
+      setShowMaxMenu(false);
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [showTfMenu, showMaxMenu]);
+
   const handleChangeTimeFrame = (tf: TimeFrame) => {
     setShowTfMenu(false);
     if (tf === currentTimeFrame) return;

--- a/src/shared/components/ui/LanguageSwitcher.tsx
+++ b/src/shared/components/ui/LanguageSwitcher.tsx
@@ -109,7 +109,7 @@ export const LanguageSwitcher: React.FC = () => {
             if (val === "system") setSystem();
             else setLang(val);
           }}
-          title={`Language: ${title}`}
+          title={`${t("language.label")} ${title}`}
         >
           <option value="system">{t("language.system")}</option>
           {LANGS.map((lng) => (


### PR DESCRIPTION
## Summary
Autonomous UX best-practice sweep. Two objective, additive, low-risk fixes. The codebase is already extensively a11y-hardened, so scope was deliberately small.

## Findings (auto-fixed)
| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | `src/shared/components/ui/FavoriteRow.tsx` | interaction | Timeframe-/Max-Popovers schlossen nicht per `Escape` — einzige App-Popovers ohne Tastatur-Dismiss. | `Escape`-Handler ergänzt, der beide Menüs schließt (spiegelt Quota-Panel / Such-Dropdowns / Shortcuts-Hint). Additiv; Maus-Outside-Click unverändert. | S | ✅ |
| 2 | `src/shared/components/ui/LanguageSwitcher.tsx` | microcopy | `<select>`-Tooltip hardcoded Englisch `"Language: …"`, umgeht i18n. | Vorhandenen Key `language.label` wiederverwendet (`en "Language:"` / `de "Sprache:"`). | S | ✅ |

## Verifikation
- `npm run typecheck` (`tsc --noEmit`): Baseline **0 Fehler** → nach Änderungen **0 Fehler** (keine neuen Fehler).
- `npx prettier --write` auf beide geänderten Dateien (bereits formatiert).
- Kein App-/Electron-Build (Sandbox blockt Binary-Downloads).

## Scope
Beide Fixes sind rein additiv und erhalten Happy-Path-Äquivalenz. Details, Deferred- und Out-of-Scope-Punkte: siehe Issue.

Closes #289


---
_Generated by [Claude Code](https://claude.ai/code/session_018aETGbeor3YCa9a1xTm3Zy)_