### PR TITLE
chore: repo quality maintenance (Vite + React)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ VITE_GIT_BRANCH=
 # Default: unset (web-only build)
 # Example: ELECTRON=true
 ELECTRON=
+
+# Dev server URL the Electron shell loads in development (read in electron/main.ts).
+# Optional. Auto-injected by vite-plugin-electron during `npm run electron:dev`.
+# Do NOT set this manually — production Electron loads the bundled dist/index.html instead.
+# Default: unset (web/Docker builds ignore it entirely)
+# Example: VITE_DEV_SERVER_URL=http://localhost:3000
+VITE_DEV_SERVER_URL=

--- a/agent_docs/api-reference.md
+++ b/agent_docs/api-reference.md
@@ -64,4 +64,13 @@ All storage access goes through the type-safe `StorageAdapter` in `src/shared/li
 | `tt.search.history`    | Search input history                 | `InputSection.tsx`  |
 | `tt.lang.explicit`     | Explicit language selection          | `i18n/config.ts`    |
 | `tt.theme`             | Theme preference (light/dark/system) | `ThemeProvider.tsx` |
+| `tt.activePage`        | Active page (dashboard/analyser)     | `App.tsx`           |
 | `yt_quota_tracking`    | API quota usage tracking & history   | `quotaService.ts`   |
+
+### Analyser
+
+| Key                         | Purpose                                     | Used by            |
+| --------------------------- | ------------------------------------------- | ------------------ |
+| `tt.analyser.sortMode`      | Analyser result sort mode                   | `AnalyserPage.tsx` |
+| `tt.analyser.topN`          | Analyser top-N result count                 | `AnalyserPage.tsx` |
+| `tt.analyser.lastResult.v1` | Cached last analyser result (TTL: 24 hours) | `useSearch.ts`     |


### PR DESCRIPTION
## Repo-Quality-Maintenance-Sweep

Reiner Doku-PR aus dem automatisierten Vollständigkeits-Sweep. Nur Doku/Example-Artefakte, keine Runtime-Config, keine Secrets.

**Effektiver Diff gegen `main`: `.env.example` (+7) + `agent_docs/api-reference.md` (+9).** (fo0s UX-Sweep #290 ist bereits separat in `main` — gemeinsame Historie, nicht Teil dieses PR-Diffs.)

### Änderungen
| # | Pass | Datei | Änderung | Aufwand |
|---|------|-------|----------|---------|
| 1 | ENV | `.env.example` | `electron/main.ts` liest `process.env.VITE_DEV_SERVER_URL` (auto-injiziert von vite-plugin-electron), war nicht dokumentiert → als optional / „do NOT set manually" ergänzt, konsistent zum `ELECTRON`-Eintrag | S |
| 2 | Code→Doku | `agent_docs/api-reference.md` | `STORAGE_KEYS` (config.ts) = 18 Keys; 4 fehlende ergänzt: `tt.activePage` + Analyser-Tabelle (`tt.analyser.sortMode`/`topN`/`lastResult.v1`); Purpose/Used-by aus Code abgeleitet | S |

Closes #291
