### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -103,7 +103,8 @@
     "remove": "Favorit entfernen",
     "analyze": "Im Analyser öffnen (nutzt Cache-Daten)",
     "clearAll": "Alle Favoriten löschen",
-    "clearAllConfirm": "Alle {{count}} Favoriten entfernen? Das kann nicht rückgängig gemacht werden."
+    "clearAllConfirm": "Alle {{count}} Favoriten entfernen? Das kann nicht rückgängig gemacht werden.",
+    "noVideosInTimeFrame": "Keine Videos in diesem Zeitraum gefunden."
   },
   "dashboard": {
     "noFavorites": "Noch keine Favoriten. Lege im Analyser eine Suche als Favorit an.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -103,7 +103,8 @@
     "remove": "Remove favorite",
     "analyze": "Open in Analyzer (uses cached data)",
     "clearAll": "Clear all favorites",
-    "clearAllConfirm": "Remove all {{count}} favorites? This cannot be undone."
+    "clearAllConfirm": "Remove all {{count}} favorites? This cannot be undone.",
+    "noVideosInTimeFrame": "No videos found in this time frame."
   },
   "dashboard": {
     "noFavorites": "No favorites yet. Create a favorite from the analyzer.",

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -503,6 +503,17 @@ export const ApiQuotaIndicator: React.FC = () => {
                 style={{ width: `${quota.percentage}%` }}
               />
             </div>
+            {/* Exhausted notice: explains why searches fail and when the quota
+                resets (the button icon alone did not surface this). */}
+            {quota.exhausted && (
+              <div
+                className="mt-2 flex items-center gap-1.5 text-[11px] text-red-400"
+                role="status"
+              >
+                <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                <span>{t("quota.exhausted")}</span>
+              </div>
+            )}
           </div>
 
           {/* Timeline line chart - pure line chart showing usage over time */}

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -675,7 +675,7 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
         </div>
       )}
 
-      {!loading && !error && videos && (
+      {!loading && !error && videos && videos.length > 0 && (
         <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-3">
           {videos.map((video) => {
             const isFresh =
@@ -687,6 +687,15 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
               </div>
             );
           })}
+        </div>
+      )}
+
+      {/* Empty state: favorite loaded successfully but has no videos in the
+          selected time frame — previously this rendered a blank grid with no
+          explanation. */}
+      {!loading && !error && videos && videos.length === 0 && (
+        <div className="bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-800 rounded-xl p-4 text-sm text-slate-500 dark:text-slate-400">
+          {t("favorites.noVideosInTimeFrame")}
         </div>
       )}
     </section>

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -61,7 +61,17 @@ export const InputSection: React.FC<InputSectionProps> = ({
   externalSyncToken,
 }) => {
   const { t } = useTranslation();
-  const [inputValue, setInputValue] = useState<string>(DEFAULT_SEARCH_INPUT);
+  const [inputValue, setInputValue] = useState<string>(() => {
+    // Restore the last query so a page reload doesn't discard what was typed.
+    // Falls back to the configured default on the first ever load.
+    try {
+      const saved = localStorage.getItem(STORAGE_KEYS.SEARCH_QUERY);
+      if (saved !== null) return saved;
+    } catch {
+      // ignore storage errors
+    }
+    return DEFAULT_SEARCH_INPUT;
+  });
   const [timeFrame, setTimeFrame] = useState<TimeFrame>(TimeFrame.LAST_MONTH);
   const [maxResults, setMaxResults] = useState<number>(-1);
 
@@ -171,6 +181,15 @@ export const InputSection: React.FC<InputSectionProps> = ({
       // ignore storage errors
     }
   }, [timeFrame, maxResults]);
+
+  // Persist the query text so a reload restores it (mirrors timeframe/maxResults).
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.SEARCH_QUERY, inputValue);
+    } catch {
+      // ignore storage errors
+    }
+  }, [inputValue]);
 
   // Load history from storage once
   useEffect(() => {

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -14,6 +14,7 @@ export const STORAGE_KEYS = {
   DASHBOARD_ORDER: "tt.dashboard.sortOrder.v1",
   SEARCH_TIMEFRAME: "tt.search.timeframe",
   SEARCH_MAX_RESULTS: "tt.search.maxResults",
+  SEARCH_QUERY: "tt.search.query",
   SEARCH_HISTORY: "tt.search.history",
   LANGUAGE: "tt.lang.explicit",
   HIDDEN_HIGHLIGHTS: "tt.dashboard.hiddenHighlights.v1",


### PR DESCRIPTION
Small, additive UX/comfort refinements to 3 existing features. No new features, dependencies, refactors, or behavior changes.

| # | Feature | Datei(en) | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---------|-----------|-----------|----------|--------------|---------|
| 1 | Dashboard favorite row | `FavoriteRow.tsx` + `i18n/{en,de}` | Qualität | 0-Video-Timeframe → leeres Grid ohne Erklärung | Empty-State-Hinweis (neuer i18n-Key, en+de) | S |
| 2 | Analyser quota panel | `ApiQuotaIndicator.tsx` | Komfort | `quota.exhausted`-String nie gerendert — nur rotes Icon, kein Grund/Reset | Inline-Alert (`AlertTriangle` + `role="status"`) | S |
| 3 | Analyser search input | `InputSection.tsx`, `config.ts` | Komfort | Getippter Query ging bei Reload verloren (Timeframe/max-results persistierten) | Query in `localStorage` persistieren + restaurieren | S |

**Verifikation lokal:** `tsc --noEmit` grün · `npm run build` (Vite) grün · `prettier --check` grün · `package-lock.json` unberührt.

Closes #293

<!-- screenshot: optional -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqKhxBeVnChqWtH8CCC9Kw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqKhxBeVnChqWtH8CCC9Kw)_