### PR TITLE
security: hardening sweep (Vite+React)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,12 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # Cross-Origin-Opener-Policy: isolate this top-level browsing context so no
+    # cross-origin window can hold a reference to it. The app has no popup/OAuth or
+    # cross-window messaging and external links already use rel="noopener", so this
+    # is non-breaking. It only governs window.opener relationships — fetch() to the
+    # YouTube API and cross-origin thumbnails/subresources are unaffected.
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
     # HSTS: only honored by browsers over HTTPS (ignored on plain HTTP), so it is
     # a no-op for the HTTP-only container yet hardens deployments fronted by TLS.
     add_header Strict-Transport-Security "max-age=31536000" always;
@@ -38,6 +44,7 @@ server {
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     }
 }


### PR DESCRIPTION
## Summary

Client-side security hardening sweep of the externally-reachable web layer (the static **Vite + React SPA** served by **nginx**). The SPA is already well-hardened by prior sweeps (#207, #279); this PR adds the one clearly-safe missing security header. Manual and deferred items are tracked in the issue.

## Fixed (in this PR)

| # | Category | Severity | File | Change |
|---|----------|----------|------|--------|
| 1 | Misconfig — missing security header | Low (defense-in-depth) | `nginx.conf` (server block + `/assets/`) | Add `Cross-Origin-Opener-Policy: same-origin` |

**Why it's non-breaking:** the app has no `window.open`/popup/OAuth flow or cross-window messaging, and every external `target="_blank"` link already uses `rel="noopener"`. COOP only governs `window.opener` relationships — `fetch()` to the YouTube Data API and cross-origin thumbnails/subresources are unaffected (no COEP added, so image loading is untouched). Only nginx.conf changes; the Electron/Capacitor/Extension wrappers do not use nginx and are unaffected.

## Not included (see #295)
- **Manual (needs testing):** CSP still uses `script-src 'unsafe-inline'` for the inline FOUC script — tightening to a nonce/hash needs build integration + testing, so it is not auto-fixed here.
- **Deferred:** HSTS `includeSubDomains`/`preload` (deployment-dependent); `npm audit` dependency-CVE scan (deps not installed here — flag-only, no bumps).

## Out of scope
`electron/**`, `android/**`, `chrome-extension/**` and packaging configs — not the externally-reachable web server. No server-side component exists, so server-side OWASP categories are N/A.

Refs #295

⚠ For review — do NOT auto-merge.

_No PoC included. No secrets disclosed._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CvLDBaa3ubmhhxKMTkSXX

---
_Generated by [Claude Code](https://claude.ai/code/session_017CvLDBaa3ubmhhxKMTkSXX)_