### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -25,6 +25,7 @@ import { type SearchType, TimeFrame } from "@/src/shared/types";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 import { dispatchEvent } from "@/src/shared/lib/eventBus";
 import { safeRead, safeWrite } from "@/src/shared/lib/storage";
+import { downloadBlob } from "@/src/shared/lib/download";
 
 const App: React.FC = () => {
   const { t } = useTranslation();
@@ -161,15 +162,7 @@ const App: React.FC = () => {
 
   const downloadTextFile = useCallback((filename: string, text: string) => {
     try {
-      const blob = new Blob([text], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      downloadBlob(filename, new Blob([text], { type: "application/json" }));
     } catch {
       // ignore
     }

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/src/features/videos";
 import { formatCompactNumber, formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { getLocale } from "@/src/shared/lib/locale";
+import { downloadBlob } from "@/src/shared/lib/download";
 import { STORAGE_KEYS } from "@/src/shared/constants";
 
 interface AnalyserPageProps {
@@ -190,15 +191,7 @@ export function AnalyserPage({
     try {
       const csv = buildResultsCsv(sortedVideos);
       const filename = buildResultsCsvFilename(searchState.channelName);
-      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      downloadBlob(filename, new Blob([csv], { type: "text/csv;charset=utf-8;" }));
     } catch {
       // Surface download errors (e.g. blocked environments) instead of failing silently.
       setExportFailed(true);
@@ -212,15 +205,7 @@ export function AnalyserPage({
     try {
       const json = buildResultsJson(sortedVideos, searchState.channelName);
       const filename = buildResultsJsonFilename(searchState.channelName);
-      const blob = new Blob([json], { type: "application/json;charset=utf-8;" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      downloadBlob(filename, new Blob([json], { type: "application/json;charset=utf-8;" }));
     } catch {
       // Surface download errors (e.g. blocked environments) instead of failing silently.
       setExportJsonFailed(true);

--- a/src/features/videos/services/trendAnalysisService.ts
+++ b/src/features/videos/services/trendAnalysisService.ts
@@ -2,6 +2,27 @@ import type { YouTubeVideoItem } from "@/src/shared/types";
 import type { VideoData } from "../types";
 
 /**
+ * Trend-score tuning constants. The score is a pure heuristic (no external
+ * model): a weighted blend of view velocity and engagement, each capped.
+ */
+const SCORE_MAX = 100;
+const VELOCITY_LOG_MULTIPLIER = 20;
+const ENGAGEMENT_MULTIPLIER = 10;
+const VELOCITY_WEIGHT = 0.7;
+const ENGAGEMENT_WEIGHT = 0.3;
+
+/** Thresholds driving the human-readable reasoning string. */
+const VELOCITY_EXTREME_VPH = 10000;
+const VELOCITY_VERY_HIGH_VPH = 1000;
+const VELOCITY_GOOD_VPH = 100;
+const ENGAGEMENT_EXCEPTIONAL_PCT = 10;
+const ENGAGEMENT_HIGH_PCT = 5;
+const ENGAGEMENT_GOOD_PCT = 2;
+const AGE_VERY_FRESH_HOURS = 2;
+const AGE_FRESH_HOURS = 6;
+const VIEWS_ESTABLISHED = 100000;
+
+/**
  * Pure math-based trend analysis (no AI API calls)
  */
 export function analyzeVideoStats(
@@ -29,9 +50,14 @@ export function analyzeVideoStats(
 
     // Calculate trending score (0-100)
     // Formula: weighted combination of velocity and engagement
-    const velocityScore = Math.min(100, Math.log10(viewsPerHour + 1) * 20);
-    const engagementScore = Math.min(100, engagementRate * 10);
-    const trendingScore = Math.round(velocityScore * 0.7 + engagementScore * 0.3);
+    const velocityScore = Math.min(
+      SCORE_MAX,
+      Math.log10(viewsPerHour + 1) * VELOCITY_LOG_MULTIPLIER,
+    );
+    const engagementScore = Math.min(SCORE_MAX, engagementRate * ENGAGEMENT_MULTIPLIER);
+    const trendingScore = Math.round(
+      velocityScore * VELOCITY_WEIGHT + engagementScore * ENGAGEMENT_WEIGHT,
+    );
 
     // Generate reasoning
     const reasoning = generateReasoning(viewsPerHour, engagementRate, ageInHours, views);
@@ -50,7 +76,7 @@ export function analyzeVideoStats(
       thumbnailUrl,
       views,
       publishedTimestamp: publishedAt,
-      trendingScore: Math.max(0, Math.min(100, trendingScore)),
+      trendingScore: Math.max(0, Math.min(SCORE_MAX, trendingScore)),
       reasoning,
       viewsPerHour: Math.round(viewsPerHour * 10) / 10,
       engagementRate: Math.round(engagementRate * 100) / 100,
@@ -66,30 +92,30 @@ function generateReasoning(
 ): string {
   const parts: string[] = [];
 
-  if (viewsPerHour > 10000) {
+  if (viewsPerHour > VELOCITY_EXTREME_VPH) {
     parts.push("Extremely high velocity");
-  } else if (viewsPerHour > 1000) {
+  } else if (viewsPerHour > VELOCITY_VERY_HIGH_VPH) {
     parts.push("Very high velocity");
-  } else if (viewsPerHour > 100) {
+  } else if (viewsPerHour > VELOCITY_GOOD_VPH) {
     parts.push("Good velocity");
   }
 
-  if (engagementRate > 10) {
+  if (engagementRate > ENGAGEMENT_EXCEPTIONAL_PCT) {
     parts.push("exceptional engagement");
-  } else if (engagementRate > 5) {
+  } else if (engagementRate > ENGAGEMENT_HIGH_PCT) {
     parts.push("high engagement");
-  } else if (engagementRate > 2) {
+  } else if (engagementRate > ENGAGEMENT_GOOD_PCT) {
     parts.push("good engagement");
   }
 
-  if (ageInHours < 2) {
+  if (ageInHours < AGE_VERY_FRESH_HOURS) {
     parts.push("very fresh content");
-  } else if (ageInHours < 6) {
+  } else if (ageInHours < AGE_FRESH_HOURS) {
     parts.push("fresh content");
   }
 
   if (parts.length === 0) {
-    if (views > 100000) {
+    if (views > VIEWS_ESTABLISHED) {
       return "Established performance with steady views";
     }
     return "Moderate performance";

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -41,8 +41,6 @@ export const API_COSTS = {
 
 export const DEFAULT_DAILY_QUOTA = 10000;
 
-export const PLACEHOLDER_IMAGE = "https://picsum.photos/640/360";
-
 /**
  * Videos shorter than this threshold (in seconds) are classified as Shorts
  * and filtered out of channel/keyword results.

--- a/src/shared/lib/download.ts
+++ b/src/shared/lib/download.ts
@@ -1,0 +1,21 @@
+/**
+ * Browser download helpers.
+ */
+
+/**
+ * Trigger a browser download of a Blob under the given filename.
+ *
+ * Creates a temporary object URL + anchor, clicks it, and revokes the URL on
+ * the next tick. Throws if the DOM / URL APIs are unavailable (e.g. blocked
+ * environments) so callers can surface a failure state.
+ */
+export function downloadBlob(filename: string, blob: Blob): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}


### PR DESCRIPTION
Autonomous best-practice refactoring sweep — source-only, behavior-equivalent. Each finding is its own commit.

### Changes

1. **`refactor(videos): extract trend-scoring magic numbers into named constants`** — `trendAnalysisService.ts`: the scoring weights/multipliers/caps and reasoning thresholds are now named module constants. Same values → identical output.
2. **`refactor(shared): extract shared blob-download helper (DRY)`** — new `src/shared/lib/download.ts` (`downloadBlob(filename, blob)`); `App.tsx` and `AnalyserPage.tsx` (CSV + JSON export) now delegate the identical anchor-download sequence to it. Callers keep their own Blob construction + error handling, so behavior is unchanged.
3. **`refactor(shared): remove unused PLACEHOLDER_IMAGE constant`** — `config.ts`: dead export pointing at an external host (`picsum.photos`), never referenced.

### Not in this PR

- **Deferred:** German code comments in `FavoriteRow.tsx` (~55) + `InputSection.tsx` (~11) — English-comment convention violation; ~66 lines across 2 files exceeds this sweep's per-finding auto-fix budget. Suggested as a dedicated follow-up.
- Large-component splits (`FavoriteRow`, `InputSection`, `ApiQuotaIndicator`, `AnalyserPage`), `React.FC` style, and a minor duplicated storage-key literal — noted in the issue, left untouched.

### Verification

`tsc --noEmit` ✅ · `vite build` ✅ · Prettier-clean. No changes to `.claude/**`, `CLAUDE.md`, `agent_docs/**`, `docs/**`, lockfiles, or wrapper (Electron/Capacitor/Chrome-Extension) generated files.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxxdYihDvKZhFXAwHoV3eB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxxdYihDvKZhFXAwHoV3eB)_