### PR TITLE
docs(readme): document Chromebook build-from-source command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ These builds include `--no-sandbox` and Wayland auto-detection flags required fo
 sudo dpkg -i TubeTrend-*-Chromebook-*.deb
 ```
 
+To build from source:
+
+```bash
+npm install
+npm run build:chromebook
+```
+
+The `.deb` packages will be in `release-chromebook/`.
+
 ### Option 4: Android APK (Chromebook / ChromeOS)
 
 **No Linux (Crostini) required — runs natively on ChromeOS via ARCVM.**


### PR DESCRIPTION
## Description

The README Chromebook install section (Option 3) only documented the pre-built `.deb` download, unlike the sibling Android (Option 4) and Chrome Extension (Option 5) sections, which each include a "build from source" command. This adds the existing `npm run build:chromebook` command (output in `release-chromebook/`) so every platform option documents a source build.

Purely additive documentation — the command already exists in `package.json`; no code or behaviour change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable) — N/A (README only, no UI text)
- [ ] Tested locally — N/A (documentation-only; command verified present in `package.json`)

## Related Issues

N/A — proactive repo-quality maintenance (documentation parity across platform install sections). No tracked issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4an8e5DXQMEfFvDCrmUxt)_