### PR TITLE
ux: best-practice sweep (Vite + React)

### DIFF
--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -34,7 +34,7 @@ export function Header({
           <div className="bg-gradient-to-br from-red-600 to-red-700 p-2 rounded-lg shadow-lg shadow-red-500/20">
             <BarChart3 className="w-5 h-5 text-white" />
           </div>
-          <h1 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-100 to-slate-400 hidden sm:block">
+          <h1 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-700 to-slate-900 dark:from-slate-100 dark:to-slate-400 hidden sm:block">
             {t("appTitle")}
           </h1>
 


### PR DESCRIPTION
Automated UX/a11y best-practice sweep. One objective, in-scope finding fixed; behavior and dark-mode appearance preserved.

## Merged Findings
| # | Datei | Kategorie | Befund | Fix | Aufwand | Status |
|---|-------|-----------|--------|-----|---------|--------|
| 1 | src/shared/components/layout/Header.tsx | a11y (Kontrast) | App-Titel `<h1>` nutzte `text-transparent` + Gradient `from-slate-100 to-slate-400` ohne `dark:`-Variante → im Light-Mode hellgrauer Verlaufstext auf weißem Header, praktisch unsichtbar (WCAG 1.4.3, verfehlt auch die 3:1-Schwelle für großen Text). | Light-Gradient auf `dark:` gescopet + dunkle Light-Mode-Farben ergänzt (`from-slate-700 to-slate-900 dark:from-slate-100 dark:to-slate-400`); Dark-Mode bleibt pixelgleich. | S | gemerged |

## Verifikation
- `npm run typecheck` (tsc --noEmit): grün
- `npm run build` (Vite prod build): grün
- Prettier (geänderte Datei): grün
- ESLint: keine `eslint.config.*` im Repo (nicht konfiguriert) — reine Tailwind-className-Änderung, kann keinen Lint-Fehler einführen

Closes #305

---
_Generated by [Claude Code](https://claude.ai/code/session_017rLcWdDESgRXRvkNWM99RD)_