### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -235,6 +235,18 @@ export function AnalyserPage({
     );
   };
 
+  // Screen-reader announcement for the bulk export/share actions. Their result
+  // is otherwise only conveyed by a transient icon swap (checkmark / warning),
+  // which is silent to assistive tech — mirrors the per-video copy announcements
+  // in VideoCard / VideoListTable.
+  const bulkActionAnnouncement = copyAllFailed
+    ? t("results.copyAllFailed")
+    : copiedAll
+      ? t("results.copyAllDone")
+      : exportFailed || exportJsonFailed
+        ? t("results.exportFailed")
+        : "";
+
   return (
     <>
       <InputSection
@@ -250,6 +262,11 @@ export function AnalyserPage({
       {/* Screen-reader-only live region: announces loading / result count / no-results. */}
       <p className="sr-only" role="status" aria-live="polite">
         {resultsAnnouncement}
+      </p>
+
+      {/* Screen-reader-only live region: announces copy-all / export action results. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {bulkActionAnnouncement}
       </p>
 
       {/* Error Message */}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -223,7 +223,8 @@
       "step3": "Klicke auf \"Aktivieren\" um die API für dein Projekt zu aktivieren",
       "step4": "Gehe zu \"Anmeldedaten\" → \"Anmeldedaten erstellen\" → \"API-Schlüssel\"",
       "step5": "Kopiere den erstellten Schlüssel und füge ihn hier ein",
-      "keyFormat": "Der Schlüssel beginnt mit \"AIza\" und hat ca. 39 Zeichen."
+      "keyFormat": "Der Schlüssel beginnt mit \"AIza\" und hat ca. 39 Zeichen.",
+      "tooShort": "Dieser Schlüssel scheint zu kurz — bitte den vollständigen Schlüssel einfügen."
     }
   },
   "confirm": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -177,6 +177,7 @@
     },
     "copyAll": "Alle kopieren",
     "copyAllUrls": "Alle Video-URLs kopieren",
+    "copyAllDone": "Alle Video-URLs kopiert",
     "copyAllFailed": "Zwischenablage nicht verfügbar",
     "exportCsv": "Ergebnisse als CSV exportieren",
     "exportJson": "Ergebnisse als JSON exportieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -177,6 +177,7 @@
     },
     "copyAll": "Copy all",
     "copyAllUrls": "Copy all video URLs",
+    "copyAllDone": "All video URLs copied",
     "copyAllFailed": "Clipboard unavailable",
     "exportCsv": "Export results as CSV",
     "exportJson": "Export results as JSON",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -223,7 +223,8 @@
       "step3": "Click \"Enable\" to activate the API for your project",
       "step4": "Go to \"Credentials\" → \"Create credentials\" → \"API key\"",
       "step5": "Copy the generated key and paste it here",
-      "keyFormat": "The key starts with \"AIza\" and is about 39 characters long."
+      "keyFormat": "The key starts with \"AIza\" and is about 39 characters long.",
+      "tooShort": "This key looks too short — please paste the full key."
     }
   },
   "confirm": {

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -158,12 +158,19 @@ function KeyboardShortcutsHint({ activePage }: { activePage: PageType }) {
         title={t("keyboard.label")}
         aria-label={t("keyboard.label")}
         aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        aria-controls="keyboard-shortcuts-panel"
       >
         <Keyboard className="w-3.5 h-3.5" aria-hidden="true" />
       </button>
 
       {isOpen && (
-        <div className="absolute top-full right-0 mt-2 w-56 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl z-50 p-3 animate-fade-in">
+        <div
+          id="keyboard-shortcuts-panel"
+          role="dialog"
+          aria-label={t("keyboard.label")}
+          className="absolute top-full right-0 mt-2 w-56 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl z-50 p-3 animate-fade-in"
+        >
           <div className="text-xs font-semibold text-slate-600 dark:text-slate-300 mb-2">
             {t("keyboard.label")}
           </div>

--- a/src/shared/components/ui/ApiKeyModal.tsx
+++ b/src/shared/components/ui/ApiKeyModal.tsx
@@ -5,6 +5,12 @@ import { useTranslation } from "react-i18next";
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+// Minimum plausible length for a YouTube Data API key (real keys are ~39 chars).
+// Single source of truth for both the disabled state and the submit guard so the
+// two can't drift out of sync (they previously used <10 vs >10 — a dead state
+// where the button looked enabled but submit silently did nothing).
+const MIN_API_KEY_LENGTH = 10;
+
 interface ApiKeyModalProps {
   onSave: (key: string) => void;
 }
@@ -16,6 +22,11 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
   const [showKey, setShowKey] = useState(false);
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
+
+  const trimmedKey = inputKey.trim();
+  const isKeyLongEnough = trimmedKey.length >= MIN_API_KEY_LENGTH;
+  // Show the "too short" hint only once the user has typed something.
+  const showTooShortHint = inputKey.length > 0 && !isKeyLongEnough;
 
   // Focus trap: keep focus inside the modal while it is open (WCAG 2.4.3)
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -43,8 +54,8 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (inputKey.trim().length > 10) {
-      onSave(inputKey.trim());
+    if (isKeyLongEnough) {
+      onSave(trimmedKey);
     }
   };
 
@@ -89,6 +100,8 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
                   className="w-full pl-4 pr-11 py-3 bg-slate-50 dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-xl focus:ring-2 focus:ring-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 outline-none transition-all font-mono text-sm"
                   autoFocus
                   autoComplete="off"
+                  aria-invalid={showTooShortHint}
+                  aria-describedby={showTooShortHint ? "apikey-too-short" : undefined}
                 />
                 <button
                   type="button"
@@ -105,11 +118,20 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
                   )}
                 </button>
               </div>
+              {showTooShortHint && (
+                <p
+                  id="apikey-too-short"
+                  role="alert"
+                  className="mt-2 text-xs text-amber-600 dark:text-amber-400"
+                >
+                  {t("modal.apiKey.tooShort")}
+                </p>
+              )}
             </div>
 
             <button
               type="submit"
-              disabled={inputKey.length < 10}
+              disabled={!isKeyLongEnough}
               className="w-full py-3 px-4 bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white font-bold rounded-xl transition-all shadow-lg shadow-red-900/20 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Check className="w-5 h-5" />


### PR DESCRIPTION
Closes #307

Automated UX-refine-sweep — 3 small, additive A11y/validation refinements to existing TubeTrend features. No new features, no dependency changes. New i18n keys added to **en + de**.

| # | Feature | Datei | Kategorie | UX-Lücke | Verbesserung | Aufwand |
|---|---------|-------|-----------|----------|--------------|---------|
| 1 | Analyser result export/share bar | AnalyserPage.tsx + i18n | A11y/Polish | Bulk Copy-all/Export silent to screen readers | `sr-only aria-live=polite` announces copy-all/export success+failure | S |
| 2 | Keyboard-shortcuts popover | Header.tsx | A11y/Polish | Popover had no id/role/accessible name | `aria-haspopup`+`aria-controls` + `role=dialog`+`aria-label` | S |
| 3 | First-run API-key modal | ApiKeyModal.tsx + i18n | Qualität | Dead disabled state (`length<10` vs `trim>10`) + no short-key feedback | Unified predicate + inline "too short" hint (`aria-invalid`/`aria-describedby`/`role=alert`) | S |

**Verification:** `npm run typecheck` green · `vite build` green.

<!-- screenshot: optional -->

_Not auto-merged — ready for review._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kf4eW2guMFveggopuktqaL)_