### PR TITLE
chore(docs): document build:win Windows portable build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ For a quick preview without packaging:
 npm run electron:preview
 ```
 
+For a Windows-specific portable build:
+
+```bash
+npm run build:win
+```
+
+The portable `TubeTrend-<version>-Portable.exe` will be in the `release/` directory.
+
 **Chromebook (ChromeOS / Crostini):** Download the matching `.deb` for your architecture from [Releases](https://github.com/fo0/tubetrend/releases):
 
 - `TubeTrend-*-Chromebook-x64.deb` — Intel/AMD Chromebooks (e.g., ASUS Chromebook CX1, Flip CX5)


### PR DESCRIPTION
## Repo Quality Maintenance — Docs/Example only

Automated completeness/consistency QA sweep (Vite + React 19 + TS). **Docs only — no runtime config, no secrets, no functional code changes.**

Closes #309

### Change

| # | Pass | File | Finding | Fix | Effort |
| --- | --- | --- | --- | --- | --- |
| 1 | D (README script parity) | `README.md` | `build:win` (`electron-builder --win portable` → `release/TubeTrend-<version>-Portable.exe`) was undocumented, though Windows is a listed desktop platform | Documented in Electron option (Option 3), matching `package.json` script coverage | S |

Verified against `electron-builder.json` (`directories.output: "release"`, `portable.artifactName: "TubeTrend-${version}-Portable.exe"`) — the documented path and artifact name are accurate.

### Artefakt-Status

| Artefakt | Status |
| --- | --- |
| `.env.example` | ✅ Complete — all `VITE_` vars (`VITE_DEFAULT_SEARCH`, `VITE_GIT_COMMIT_HASH`, `VITE_GIT_BRANCH`, `VITE_DEV_SERVER_URL`) + `ELECTRON` present & well-commented |
| Dockerfile / docker-compose | ✅ Build args mapped to `VITE_*`; compose pulls prebuilt image |
| README onboarding | ⚠→✅ one script-parity gap fixed (this PR) |
| Referenced docs (`agent_docs/*`, `docs/ARCHITECTURE.mmd`, `docs/adr/`) | ✅ All exist, substantive (no stubs) |
| `BACKLOG.md` | ✅ Open table empty — nothing to reconcile |

### Backlog / Deferred

| Item | Reason |
| --- | --- |
| `cap:build` (release APK) undocumented | Requires a signing keystore not configured (CLAUDE.md: unsigned/debug key). Only `cap:build:debug` is documented — correct as-is. |
| `cap:open` / `cap:sync` / `electron:icon` undocumented | Internal/dev-helper scripts, not standalone distribution artifacts. |

### Notes
- Only `README.md` changed (8 additive lines). No `.env` / secret / active-config / `CLAUDE.md` / `.claude/**` files touched.
- No formatter/linter/test runs, no dependency bumps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJfCmntLs8S3oszVmjvrAT)_