### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -71,7 +71,10 @@ const App: React.FC = () => {
   }, []);
 
   const searchOptions = useMemo(() => ({ onApiKeyInvalid }), [onApiKeyInvalid]);
-  const { searchState, handleSearch, setSearchResult } = useSearch(apiKey, searchOptions);
+  const { searchState, handleSearch, setSearchResult, resetSearch } = useSearch(
+    apiKey,
+    searchOptions,
+  );
 
   // Sorted favorites
   const sortedFavorites = useMemo(() => sortFavorites(favorites), [favorites, sortFavorites]);
@@ -302,6 +305,7 @@ const App: React.FC = () => {
             externalInputValues={externalInputValues}
             onSearch={handleSearch}
             onPickExample={handlePickExample}
+            onClearResults={resetSearch}
           />
         )}
       </main>

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -8,6 +8,7 @@ import {
   FileJson,
   List,
   Loader2,
+  RotateCcw,
   Trophy,
 } from "lucide-react";
 import { Youtube } from "@/src/shared/components/ui/BrandIcons";
@@ -46,6 +47,8 @@ interface AnalyserPageProps {
   ) => void;
   /** Run a quick-start example from the welcome empty state (pre-fills the search box + searches). */
   onPickExample?: (query: string, searchType: SearchType) => void;
+  /** Clear the current analysis (and its persisted snapshot), returning to the welcome screen. */
+  onClearResults?: () => void;
 }
 
 export function AnalyserPage({
@@ -53,6 +56,7 @@ export function AnalyserPage({
   externalInputValues,
   onSearch,
   onPickExample,
+  onClearResults,
 }: AnalyserPageProps) {
   const { t } = useTranslation();
 
@@ -474,6 +478,20 @@ export function AnalyserPage({
                   <span>Top 6</span>
                 </button>
               </div>
+
+              {/* Clear results: drop the persisted snapshot and return to the welcome screen. */}
+              {onClearResults && (
+                <button
+                  type="button"
+                  onClick={onClearResults}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  title={t("results.clearTitle")}
+                  aria-label={t("results.clearTitle")}
+                >
+                  <RotateCcw className="w-4 h-4" aria-hidden="true" />
+                  <span className="hidden lg:inline">{t("results.clear")}</span>
+                </button>
+              )}
             </div>
           </div>
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -182,6 +182,8 @@
     "exportCsv": "Ergebnisse als CSV exportieren",
     "exportJson": "Ergebnisse als JSON exportieren",
     "exportFailed": "Export fehlgeschlagen",
+    "clear": "Zurücksetzen",
+    "clearTitle": "Ergebnisse zurücksetzen",
     "analyzedAgo": "Analysiert {{time}}",
     "announceLoading": "Ergebnisse werden geladen…",
     "announceResults_one": "{{count}} Video für {{channel}} gefunden.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -182,6 +182,8 @@
     "exportCsv": "Export results as CSV",
     "exportJson": "Export results as JSON",
     "exportFailed": "Export failed",
+    "clear": "Clear",
+    "clearTitle": "Clear results",
     "analyzedAgo": "Analyzed {{time}}",
     "announceLoading": "Loading results…",
     "announceResults_one": "{{count}} video found for {{channel}}.",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -215,3 +215,20 @@ textarea:focus-visible {
   outline-offset: 2px;
   border-radius: 3px;
 }
+
+/* ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────────
+   Respect the OS "reduce motion" preference: collapse animations/transitions to
+   near-instant so the spinners, pulses, glows, and fade-ins don't run at full
+   strength for motion-sensitive users. Durations are collapsed (not removed) so
+   animation end states (e.g. a completed fade-in) still apply.
+   ─────────────────────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
This PR adds two small, self-contained comfort features to TubeTrend, both verified green (Prettier, `tsc --noEmit`, `vite build`). The first exposes the existing-but-unwired `resetSearch` in `useSearch` as a "Clear results" button on the Analyser so the 24h-persisted analysis can be dismissed without a page reload; the second adds a `prefers-reduced-motion` media query so motion-sensitive users get near-instant animations instead of full-strength spinners, pulses, glows, and fade-ins. All new user-facing strings are i18next keys added to both `en` and `de`.

| # | Feature | Nutzen | Aufwand |
|---|---|---|---|
| 1 | Analyser "Clear results" button | Dismiss the persisted analysis and return to the welcome screen | S |
| 2 | `prefers-reduced-motion` support | Respects the OS reduce-motion preference across all animations | S |

Closes #314

---
_Generated by [Claude Code](https://claude.ai/code/session_0116W4QKhPapf1ebSm39Q3Lq)_