### PR TITLE
ux: best-practice sweep (Vite + React + i18next)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -290,7 +290,9 @@ export function AnalyserPage({
           {/* Control Bar */}
           <div className="flex flex-col sm:flex-row justify-between items-center bg-slate-100/50 dark:bg-slate-900/50 p-4 rounded-xl border border-slate-200 dark:border-slate-800 gap-4 backdrop-blur-sm">
             <div className="flex items-center gap-2">
-              <h3 className="font-semibold text-slate-700 dark:text-slate-200">
+              {/* h2: the page's <h1> (Header) otherwise skips straight to the
+                  <h3> section titles below (WCAG 1.3.1 — no skipped heading levels). */}
+              <h2 className="font-semibold text-slate-700 dark:text-slate-200">
                 {t("results.resultsFor")}{" "}
                 {channelUrl ? (
                   <a
@@ -307,7 +309,7 @@ export function AnalyserPage({
                     <Youtube className="w-4 h-4" aria-hidden="true" />@{searchState.channelName}
                   </span>
                 )}
-              </h3>
+              </h2>
               <span className="bg-slate-200 dark:bg-slate-700 text-xs px-2 py-0.5 rounded-full text-slate-600 dark:text-slate-300 border border-slate-300 dark:border-slate-600">
                 {t("results.videosCount", { count: sortedVideos.length })}
               </span>

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -123,9 +123,11 @@ export function DashboardPage({
         >
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 mb-3">
             <div>
-              <div className="text-xs font-extrabold uppercase tracking-wide text-indigo-700 dark:text-indigo-300">
+              {/* h2: the page's <h1> (Header) otherwise skips straight to each
+                  favorite row's <h3> (WCAG 1.3.1 — no skipped heading levels). */}
+              <h2 className="text-xs font-extrabold uppercase tracking-wide text-indigo-700 dark:text-indigo-300">
                 {t("dashboard.highlights.title")}
-              </div>
+              </h2>
               <div className="text-sm text-slate-600 dark:text-slate-400">
                 {t("dashboard.highlights.subtitle")}
               </div>

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { SearchType, TimeFrame, YouTubeVideoItem } from "@/src/shared/types";
 import { SearchType as ST } from "@/src/shared/types";
 import type { VideoData } from "@/src/features/videos/types";
@@ -87,6 +88,7 @@ interface UseSearchOptions {
 }
 
 export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
+  const { t } = useTranslation();
   const [searchState, setSearchState] = useState<SearchState>(restoreInitialSearchState);
 
   const handleSearch = useCallback(
@@ -170,7 +172,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
             ...prev,
             isLoading: false,
             step: "idle",
-            error: "The API key appears to be invalid. Please check it.",
+            error: t("errors.apiKeyInvalid"),
           }));
           options?.onApiKeyInvalid?.();
         } else {
@@ -183,7 +185,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
         }
       }
     },
-    [apiKey, options],
+    [apiKey, options, t],
   );
 
   const setSearchResult = useCallback(

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -240,6 +240,7 @@
     "importFailedStorage": "Import fehlgeschlagen (konnte nicht in den Browser-Speicher schreiben)."
   },
   "errors": {
+    "apiKeyInvalid": "Der API-Schlüssel scheint ungültig zu sein. Bitte überprüfe ihn.",
     "favoriteLoad": "Fehler beim Laden der Favoriten-Daten.",
     "somethingWentWrong": "Etwas ist schiefgelaufen",
     "tryAgain": "Erneut versuchen"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -240,6 +240,7 @@
     "importFailedStorage": "Import failed (could not write to browser storage)."
   },
   "errors": {
+    "apiKeyInvalid": "The API key appears to be invalid. Please check it.",
     "favoriteLoad": "Failed to load favorite data.",
     "somethingWentWrong": "Something went wrong",
     "tryAgain": "Try again"

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -455,6 +455,8 @@ export const ApiQuotaIndicator: React.FC = () => {
       {isOpen && (
         <div
           id="quota-history-panel"
+          role="dialog"
+          aria-label={t("quota.historyTitle")}
           className="absolute top-full right-0 mt-2 w-80 bg-slate-900 border border-slate-700 rounded-lg shadow-xl z-50"
         >
           {/* Header */}

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -511,11 +511,17 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
                 onMouseDown={(e) => e.stopPropagation()}
                 className="absolute z-50 mt-2 left-0 w-56 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl p-1"
               >
-                <div className="max-h-60 overflow-auto">
+                <div
+                  className="max-h-60 overflow-auto"
+                  role="listbox"
+                  aria-label={t("favorites.changeTimeFrame")}
+                >
                   {TIME_FRAMES.map((opt) => (
                     <button
                       key={opt.value}
                       type="button"
+                      role="option"
+                      aria-selected={opt.value === currentTimeFrame}
                       onClick={() => handleChangeTimeFrame(opt.value)}
                       className={`w-full text-left px-3 py-2 rounded-md text-sm ${opt.value === currentTimeFrame ? "bg-indigo-600 text-white" : "text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800"}`}
                     >
@@ -562,11 +568,17 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
                 onMouseDown={(e) => e.stopPropagation()}
                 className="absolute z-50 mt-2 left-44 w-56 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl p-1"
               >
-                <div className="max-h-60 overflow-auto">
+                <div
+                  className="max-h-60 overflow-auto"
+                  role="listbox"
+                  aria-label={t("favorites.changeMaxResults")}
+                >
                   {MAX_RESULTS_OPTIONS.map((opt) => (
                     <button
                       key={opt.value}
                       type="button"
+                      role="option"
+                      aria-selected={opt.value === currentMax}
                       onClick={() => handleChangeMax(opt.value)}
                       className={`w-full text-left px-3 py-2 rounded-md text-sm ${opt.value === currentMax ? "bg-indigo-600 text-white" : "text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800"}`}
                     >

--- a/src/shared/components/ui/FloatingScrollButton.tsx
+++ b/src/shared/components/ui/FloatingScrollButton.tsx
@@ -125,7 +125,7 @@ export function FloatingScrollButton() {
       className={`
         fixed bottom-8 left-1/2 translate-x-[60%]
         z-40
-        w-10 h-10
+        w-11 h-11
         flex items-center justify-center
         rounded-full
         bg-slate-200/30 dark:bg-slate-700/30


### PR DESCRIPTION
Additive a11y + i18n sweep. Verified green: `npm run typecheck` + `npm run build` (+ format:check clean).

## Merged findings
| # | Datei | Kategorie | Fix | Aufwand |
|---|-------|-----------|-----|---------|
| 1 | AnalyserPage.tsx, DashboardPage.tsx | a11y | Heading-Sprung h1→h3 behoben (h2 ergänzt) | S |
| 2 | FavoriteRow.tsx | a11y | listbox/option-Rollen + aria-selected für Dropdowns | S |
| 3 | ApiQuotaIndicator.tsx | a11y | role=dialog + aria-label für Quota-Panel | S |
| 4 | FloatingScrollButton.tsx | a11y | Touch-Target auf 44px (w-11/h-11) | S |
| 5 | useSearch.ts, en.json, de.json | microcopy | api-key-invalid-Fehler über i18n statt hartkodiert EN | S |

Betroffene Screens: Analyser + Dashboard (Headings), Favoriten-Dropdowns, Quota-Indikator, Scroll-Button, Such-Fehlermeldung. Rein additiv.

Closes #316

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUXkMBBwzJEmyqbU6LWNiB)_