### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -173,7 +173,8 @@
       "copyTitle": "Videotitel kopieren",
       "copyTitleAria": "Titel für {{title}} kopieren",
       "urlCopied": "Video-URL kopiert",
-      "titleCopied": "Videotitel kopiert"
+      "titleCopied": "Videotitel kopiert",
+      "copyFailed": "Zwischenablage nicht verfügbar"
     },
     "copyAll": "Alle kopieren",
     "copyAllUrls": "Alle Video-URLs kopieren",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -174,7 +174,13 @@
       "copyTitleAria": "Titel für {{title}} kopieren",
       "urlCopied": "Video-URL kopiert",
       "titleCopied": "Videotitel kopiert",
-      "copyFailed": "Zwischenablage nicht verfügbar"
+      "copyFailed": "Zwischenablage nicht verfügbar",
+      "filterPlaceholder": "Nach Titel filtern…",
+      "filterAria": "Videos nach Titel filtern",
+      "filterClear": "Filter zurücksetzen",
+      "filterCount_one": "{{count}} von {{total}} angezeigt",
+      "filterCount_other": "{{count}} von {{total}} angezeigt",
+      "filterNoMatches": "Kein Videotitel passt zu \"{{query}}\"."
     },
     "copyAll": "Alle kopieren",
     "copyAllUrls": "Alle Video-URLs kopieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -173,7 +173,8 @@
       "copyTitle": "Copy video title",
       "copyTitleAria": "Copy title for {{title}}",
       "urlCopied": "Video URL copied",
-      "titleCopied": "Video title copied"
+      "titleCopied": "Video title copied",
+      "copyFailed": "Clipboard unavailable"
     },
     "copyAll": "Copy all",
     "copyAllUrls": "Copy all video URLs",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -174,7 +174,13 @@
       "copyTitleAria": "Copy title for {{title}}",
       "urlCopied": "Video URL copied",
       "titleCopied": "Video title copied",
-      "copyFailed": "Clipboard unavailable"
+      "copyFailed": "Clipboard unavailable",
+      "filterPlaceholder": "Filter by title…",
+      "filterAria": "Filter videos by title",
+      "filterClear": "Clear filter",
+      "filterCount_one": "{{count}} of {{total}} shown",
+      "filterCount_other": "{{count}} of {{total}} shown",
+      "filterNoMatches": "No video title matches \"{{query}}\"."
     },
     "copyAll": "Copy all",
     "copyAllUrls": "Copy all video URLs",

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -87,6 +87,11 @@ export const InputSection: React.FC<InputSectionProps> = ({
   const [history, setHistory] = useState<string[]>([]);
   const [showHistory, setShowHistory] = useState(false);
 
+  // Index of the keyboard-highlighted entry in whichever dropdown is open
+  // (-1 = nothing highlighted, the input itself keeps the "value"). Both
+  // dropdowns are mutually exclusive, so one index is enough for both.
+  const [activeIndex, setActiveIndex] = useState(-1);
+
   const searchInputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -375,6 +380,64 @@ export const InputSection: React.FC<InputSectionProps> = ({
     setShowHistory(false);
   };
 
+  // Which dropdown is currently open (they are mutually exclusive) and how many
+  // entries it holds — the basis for arrow-key navigation and the ARIA wiring.
+  const openList: "suggestions" | "history" | null =
+    showSuggestions && suggestions.length > 0
+      ? "suggestions"
+      : showHistory && history.length > 0
+        ? "history"
+        : null;
+  const openListLength = openList === "suggestions" ? suggestions.length : history.length;
+  const activeOptionId =
+    openList && activeIndex >= 0 ? `search-${openList}-option-${activeIndex}` : undefined;
+
+  // Any change to the open list (opened, closed, or refreshed with new entries)
+  // invalidates the highlight — start again from "nothing highlighted".
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [openList, suggestions, history]);
+
+  // Keyboard navigation for the open dropdown: ArrowDown/ArrowUp cycle through
+  // the entries, Home/End jump to the ends, Enter picks the highlighted one.
+  // Without a highlight Enter falls through to the form's normal submit.
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!openList || openListLength === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((prev) => (prev + 1) % openListLength);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((prev) => (prev <= 0 ? openListLength - 1 : prev - 1));
+        break;
+      case "Home":
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActiveIndex(openListLength - 1);
+        break;
+      case "Enter": {
+        if (activeIndex < 0) return; // no highlight → let the form submit
+        e.preventDefault();
+        if (openList === "suggestions") {
+          const suggestion = suggestions[activeIndex];
+          if (suggestion) selectSuggestion(suggestion);
+        } else {
+          const item = history[activeIndex];
+          if (item !== undefined) selectHistoryItem(item);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
   // Escape behaviour (only while the search input itself is focused, so we never
   // hijack Escape from modals or other widgets):
   //   1. If a dropdown (suggestions / history) is open, close it.
@@ -454,6 +517,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
               value={inputValue}
               onChange={handleInputChange}
               onFocus={handleFocus}
+              onKeyDown={handleInputKeyDown}
               className="block w-full pl-11 pr-10 py-4 bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-xl focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 transition-all shadow-inner text-lg"
               placeholder={t("input.searchPlaceholder")}
               disabled={isLoading}
@@ -468,13 +532,8 @@ export const InputSection: React.FC<InputSectionProps> = ({
               aria-expanded={
                 (showSuggestions && suggestions.length > 0) || (showHistory && history.length > 0)
               }
-              aria-controls={
-                showSuggestions && suggestions.length > 0
-                  ? "search-suggestions-listbox"
-                  : showHistory && history.length > 0
-                    ? "search-history-listbox"
-                    : undefined
-              }
+              aria-controls={openList ? `search-${openList}-listbox` : undefined}
+              aria-activedescendant={activeOptionId}
               aria-haspopup="listbox"
             />
 
@@ -500,12 +559,19 @@ export const InputSection: React.FC<InputSectionProps> = ({
             {showSuggestions && suggestions.length > 0 && (
               <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in">
                 <ul id="search-suggestions-listbox" role="listbox">
-                  {suggestions.map((sug) => (
-                    <li key={sug.id} role="option" aria-selected="false">
+                  {suggestions.map((sug, idx) => (
+                    <li
+                      key={sug.id}
+                      id={`search-suggestions-option-${idx}`}
+                      role="option"
+                      aria-selected={activeIndex === idx}
+                    >
                       <button
                         type="button"
                         onClick={() => selectSuggestion(sug)}
-                        className="w-full text-left px-4 py-3 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors flex items-center gap-3 group/item"
+                        className={`w-full text-left px-4 py-3 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors flex items-center gap-3 group/item ${
+                          activeIndex === idx ? "bg-slate-100 dark:bg-slate-800" : ""
+                        }`}
                       >
                         <div className="w-8 h-8 rounded-full overflow-hidden bg-slate-100 dark:bg-slate-950 shrink-0 border border-slate-200 dark:border-slate-700">
                           <img
@@ -536,9 +602,12 @@ export const InputSection: React.FC<InputSectionProps> = ({
                   {history.map((item, idx) => (
                     <li
                       key={`${item}-${idx}`}
+                      id={`search-history-option-${idx}`}
                       role="option"
-                      aria-selected="false"
-                      className="group/item flex items-stretch hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                      aria-selected={activeIndex === idx}
+                      className={`group/item flex items-stretch hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors ${
+                        activeIndex === idx ? "bg-slate-100 dark:bg-slate-800" : ""
+                      }`}
                     >
                       <button
                         type="button"

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, Eye, Heart, TrendingUp, Type, Zap } from "lucide-react";
+import { AlertCircle, Check, Clock, Copy, Eye, Heart, TrendingUp, Type, Zap } from "lucide-react";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { useTranslation } from "react-i18next";
 
@@ -12,15 +12,26 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const [titleCopied, setTitleCopied] = useState(false);
+  // Which copy action last failed, so a blocked clipboard is visible feedback
+  // instead of a dead button (mirrors the bulk actions on the analyser page).
+  const [copyFailed, setCopyFailed] = useState<"url" | "title" | null>(null);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const resetTitleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
       if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
       if (resetTitleTimerRef.current) clearTimeout(resetTitleTimerRef.current);
+      if (resetFailedTimerRef.current) clearTimeout(resetFailedTimerRef.current);
     };
   }, []);
+
+  const flashCopyFailed = (kind: "url" | "title") => {
+    setCopyFailed(kind);
+    if (resetFailedTimerRef.current) clearTimeout(resetFailedTimerRef.current);
+    resetFailedTimerRef.current = setTimeout(() => setCopyFailed(null), 2500);
+  };
 
   const handleCopy = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -28,7 +39,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
     // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
     // Accessing .writeText on it throws synchronously, which the promise
     // rejection handler below would not catch — so guard the property first.
-    if (!navigator.clipboard) return;
+    if (!navigator.clipboard) {
+      flashCopyFailed("url");
+      return;
+    }
     navigator.clipboard.writeText(video.url).then(
       () => {
         setCopied(true);
@@ -36,7 +50,8 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
         resetTimerRef.current = setTimeout(() => setCopied(false), 1500);
       },
       () => {
-        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyFailed("url");
       },
     );
   };
@@ -44,7 +59,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
   const handleCopyTitle = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!navigator.clipboard) return;
+    if (!navigator.clipboard) {
+      flashCopyFailed("title");
+      return;
+    }
     navigator.clipboard.writeText(video.title).then(
       () => {
         setTitleCopied(true);
@@ -52,7 +70,8 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
         resetTitleTimerRef.current = setTimeout(() => setTitleCopied(false), 1500);
       },
       () => {
-        // Clipboard API unavailable
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyFailed("title");
       },
     );
   };
@@ -70,7 +89,13 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
       {/* Polite live region: announce copy success to assistive tech (the green
           checkmark alone is silent to screen readers). */}
       <span className="sr-only" role="status" aria-live="polite">
-        {copied ? t("results.table.urlCopied") : titleCopied ? t("results.table.titleCopied") : ""}
+        {copyFailed
+          ? t("results.table.copyFailed")
+          : copied
+            ? t("results.table.urlCopied")
+            : titleCopied
+              ? t("results.table.titleCopied")
+              : ""}
       </span>
       {/* Thumbnail Area */}
       <div className="relative h-40 overflow-hidden bg-slate-100 dark:bg-slate-900">
@@ -154,11 +179,23 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           <button
             type="button"
             onClick={handleCopyTitle}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700"
-            title={t("results.table.copyTitle")}
-            aria-label={t("results.table.copyTitleAria", { title: video.title })}
+            className={`inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all border border-slate-200 dark:border-slate-700 ${
+              copyFailed === "title"
+                ? "text-red-500 dark:text-red-400"
+                : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white"
+            }`}
+            title={
+              copyFailed === "title" ? t("results.table.copyFailed") : t("results.table.copyTitle")
+            }
+            aria-label={
+              copyFailed === "title"
+                ? t("results.table.copyFailed")
+                : t("results.table.copyTitleAria", { title: video.title })
+            }
           >
-            {titleCopied ? (
+            {copyFailed === "title" ? (
+              <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            ) : titleCopied ? (
               <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
             ) : (
               <Type className="w-3.5 h-3.5" aria-hidden="true" />
@@ -167,11 +204,23 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
           <button
             type="button"
             onClick={handleCopy}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700"
-            title={t("results.table.copyUrl")}
-            aria-label={t("results.table.copyUrlAria", { title: video.title })}
+            className={`inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all border border-slate-200 dark:border-slate-700 ${
+              copyFailed === "url"
+                ? "text-red-500 dark:text-red-400"
+                : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white"
+            }`}
+            title={
+              copyFailed === "url" ? t("results.table.copyFailed") : t("results.table.copyUrl")
+            }
+            aria-label={
+              copyFailed === "url"
+                ? t("results.table.copyFailed")
+                : t("results.table.copyUrlAria", { title: video.title })
+            }
           >
-            {copied ? (
+            {copyFailed === "url" ? (
+              <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            ) : copied ? (
               <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
             ) : (
               <Copy className="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/shared/components/ui/VideoListFilter.tsx
+++ b/src/shared/components/ui/VideoListFilter.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Search, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface VideoListFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Rows currently passing the filter. */
+  matchCount: number;
+  /** Rows in the unfiltered list. */
+  totalCount: number;
+}
+
+/**
+ * Compact title filter for the result table. Purely presentational — the table
+ * owns the filter value so the rows and this bar can never drift apart.
+ */
+export const VideoListFilter: React.FC<VideoListFilterProps> = ({
+  value,
+  onChange,
+  matchCount,
+  totalCount,
+}) => {
+  const { t } = useTranslation();
+  const isFiltering = value.trim().length > 0;
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
+      <div className="relative flex-1 min-w-0">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <Search className="w-4 h-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
+        </div>
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={t("results.table.filterPlaceholder")}
+          aria-label={t("results.table.filterAria")}
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="block w-full pl-9 pr-9 py-2 text-sm bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 transition-all [&::-webkit-search-cancel-button]:hidden"
+        />
+        {isFiltering && (
+          <button
+            type="button"
+            onClick={() => onChange("")}
+            title={t("results.table.filterClear")}
+            aria-label={t("results.table.filterClear")}
+            className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-400 dark:text-slate-600 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      {isFiltering && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap sm:pl-2"
+        >
+          {t("results.table.filterCount", { count: matchCount, total: totalCount })}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, ExternalLink, Heart, Type } from "lucide-react";
+import { AlertCircle, Check, Clock, Copy, ExternalLink, Heart, Type } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
@@ -13,22 +13,36 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
   const { t } = useTranslation();
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [copiedTitleId, setCopiedTitleId] = useState<string | null>(null);
+  // Which row/action last failed, so a blocked clipboard is visible feedback
+  // instead of a dead button (mirrors the bulk actions on the analyser page).
+  const [copyFailed, setCopyFailed] = useState<{ id: string; kind: "url" | "title" } | null>(null);
   const resetCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const resetCopiedTitleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clear pending copy-feedback timers on unmount to avoid setState after unmount
   useEffect(() => {
     return () => {
       if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
       if (resetCopiedTitleTimerRef.current) clearTimeout(resetCopiedTitleTimerRef.current);
+      if (resetFailedTimerRef.current) clearTimeout(resetFailedTimerRef.current);
     };
   }, []);
+
+  const flashCopyFailed = (id: string, kind: "url" | "title") => {
+    setCopyFailed({ id, kind });
+    if (resetFailedTimerRef.current) clearTimeout(resetFailedTimerRef.current);
+    resetFailedTimerRef.current = setTimeout(() => setCopyFailed(null), 2500);
+  };
 
   const handleCopy = (video: VideoData) => {
     // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
     // Accessing .writeText on it throws synchronously, which the promise
     // rejection handler below would not catch — so guard the property first.
-    if (!navigator.clipboard) return;
+    if (!navigator.clipboard) {
+      flashCopyFailed(video.id, "url");
+      return;
+    }
     navigator.clipboard.writeText(video.url).then(
       () => {
         setCopiedId(video.id);
@@ -36,13 +50,17 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
         resetCopiedTimerRef.current = setTimeout(() => setCopiedId(null), 1500);
       },
       () => {
-        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyFailed(video.id, "url");
       },
     );
   };
 
   const handleCopyTitle = (video: VideoData) => {
-    if (!navigator.clipboard) return;
+    if (!navigator.clipboard) {
+      flashCopyFailed(video.id, "title");
+      return;
+    }
     navigator.clipboard.writeText(video.title).then(
       () => {
         setCopiedTitleId(video.id);
@@ -50,7 +68,8 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
         resetCopiedTitleTimerRef.current = setTimeout(() => setCopiedTitleId(null), 1500);
       },
       () => {
-        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyFailed(video.id, "title");
       },
     );
   };
@@ -66,11 +85,13 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
       {/* Polite live region: announce copy success to assistive tech (the green
           checkmark alone is silent to screen readers). */}
       <span className="sr-only" role="status" aria-live="polite">
-        {copiedId
-          ? t("results.table.urlCopied")
-          : copiedTitleId
-            ? t("results.table.titleCopied")
-            : ""}
+        {copyFailed
+          ? t("results.table.copyFailed")
+          : copiedId
+            ? t("results.table.urlCopied")
+            : copiedTitleId
+              ? t("results.table.titleCopied")
+              : ""}
       </span>
       <div className="overflow-x-auto">
         <table className="w-full text-left border-collapse" aria-label={t("results.moreVideos")}>
@@ -188,11 +209,25 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                       <button
                         type="button"
                         onClick={() => handleCopyTitle(video)}
-                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
-                        title={t("results.table.copyTitle")}
-                        aria-label={t("results.table.copyTitleAria", { title: video.title })}
+                        className={`inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 ${
+                          copyFailed?.id === video.id && copyFailed.kind === "title"
+                            ? "text-red-500 dark:text-red-400"
+                            : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white"
+                        }`}
+                        title={
+                          copyFailed?.id === video.id && copyFailed.kind === "title"
+                            ? t("results.table.copyFailed")
+                            : t("results.table.copyTitle")
+                        }
+                        aria-label={
+                          copyFailed?.id === video.id && copyFailed.kind === "title"
+                            ? t("results.table.copyFailed")
+                            : t("results.table.copyTitleAria", { title: video.title })
+                        }
                       >
-                        {copiedTitleId === video.id ? (
+                        {copyFailed?.id === video.id && copyFailed.kind === "title" ? (
+                          <AlertCircle className="w-4 h-4" aria-hidden="true" />
+                        ) : copiedTitleId === video.id ? (
                           <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
                         ) : (
                           <Type className="w-4 h-4" aria-hidden="true" />
@@ -201,11 +236,25 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                       <button
                         type="button"
                         onClick={() => handleCopy(video)}
-                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
-                        title={t("results.table.copyUrl")}
-                        aria-label={t("results.table.copyUrlAria", { title: video.title })}
+                        className={`inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all border border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 ${
+                          copyFailed?.id === video.id && copyFailed.kind === "url"
+                            ? "text-red-500 dark:text-red-400"
+                            : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white"
+                        }`}
+                        title={
+                          copyFailed?.id === video.id && copyFailed.kind === "url"
+                            ? t("results.table.copyFailed")
+                            : t("results.table.copyUrl")
+                        }
+                        aria-label={
+                          copyFailed?.id === video.id && copyFailed.kind === "url"
+                            ? t("results.table.copyFailed")
+                            : t("results.table.copyUrlAria", { title: video.title })
+                        }
                       >
-                        {copiedId === video.id ? (
+                        {copyFailed?.id === video.id && copyFailed.kind === "url" ? (
+                          <AlertCircle className="w-4 h-4" aria-hidden="true" />
+                        ) : copiedId === video.id ? (
                           <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
                         ) : (
                           <Copy className="w-4 h-4" aria-hidden="true" />

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -1,8 +1,15 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
 import { AlertCircle, Check, Clock, Copy, ExternalLink, Heart, Type } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
+import { VideoListFilter } from "@/src/shared/components/ui/VideoListFilter";
+
+/**
+ * Below this many rows the list is short enough to scan by eye, so the filter
+ * bar would only add clutter.
+ */
+const FILTER_MIN_ROWS = 10;
 
 interface VideoListTableProps {
   videos: VideoData[];
@@ -11,6 +18,7 @@ interface VideoListTableProps {
 
 export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startIndex }) => {
   const { t } = useTranslation();
+  const [filter, setFilter] = useState("");
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [copiedTitleId, setCopiedTitleId] = useState<string | null>(null);
   // Which row/action last failed, so a blocked clipboard is visible feedback
@@ -74,6 +82,23 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
     );
   };
 
+  // Rank is assigned before filtering, so a row keeps its position in the full
+  // result set ("#42") instead of being renumbered inside the filtered view.
+  const rankedVideos = useMemo(
+    () => videos.map((video, index) => ({ video, rank: startIndex + index })),
+    [videos, startIndex],
+  );
+
+  const showFilter = videos.length >= FILTER_MIN_ROWS;
+  const normalizedFilter = filter.trim().toLowerCase();
+
+  const visibleVideos = useMemo(() => {
+    if (!showFilter || !normalizedFilter) return rankedVideos;
+    return rankedVideos.filter((entry) =>
+      entry.video.title.toLowerCase().includes(normalizedFilter),
+    );
+  }, [rankedVideos, showFilter, normalizedFilter]);
+
   const getScoreColor = (score: number) => {
     if (score >= 80) return "text-red-400 bg-red-400/10 border-red-400/20";
     if (score >= 50) return "text-amber-400 bg-amber-400/10 border-amber-400/20";
@@ -93,6 +118,14 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
               ? t("results.table.titleCopied")
               : ""}
       </span>
+      {showFilter && (
+        <VideoListFilter
+          value={filter}
+          onChange={setFilter}
+          matchCount={visibleVideos.length}
+          totalCount={rankedVideos.length}
+        />
+      )}
       <div className="overflow-x-auto">
         <table className="w-full text-left border-collapse" aria-label={t("results.moreVideos")}>
           <thead>
@@ -126,8 +159,7 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200/50 dark:divide-slate-800/50 text-sm">
-            {videos.map((video, index) => {
-              const rank = startIndex + index;
+            {visibleVideos.map(({ video, rank }) => {
               return (
                 <tr
                   key={video.id}
@@ -275,6 +307,22 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
                 </tr>
               );
             })}
+            {visibleVideos.length === 0 && (
+              <tr>
+                <td colSpan={8} className="p-8 text-center">
+                  <p className="text-slate-500 dark:text-slate-400 mb-3">
+                    {t("results.table.filterNoMatches", { query: filter.trim() })}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setFilter("")}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-300 dark:border-slate-700 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                  >
+                    {t("results.table.filterClear")}
+                  </button>
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Description

Autonomous comfort sweep — three end-user comfort/quality improvements, no refactorings and no dependency changes.

| # | Feature | Nutzen für User | Aufwand | Empfehlung |
|---|---------|-----------------|---------|------------|
| 1 | **Keyboard navigation for the search dropdowns** (`InputSection.tsx`) | The search box is the app's primary control, but its channel-autocomplete and recent-searches dropdowns could only be operated with the mouse. ArrowDown/ArrowUp now cycle entries, Home/End jump to the ends, Enter picks the highlighted one — and Enter without a highlight still submits the form as before. The highlight is mirrored into `aria-activedescendant` / `aria-selected` so assistive tech follows it, and it resets whenever the list opens, closes or refreshes. | M | auto-build |
| 2 | **Copy-failure feedback on video cards + table** (`VideoCard.tsx`, `VideoListTable.tsx`) | The per-video copy buttons bailed out silently when `navigator.clipboard` was missing (any insecure context — e.g. the Docker image reached over plain HTTP on a LAN IP) or when the write was rejected: clicking did nothing at all. They now flash a red warning icon for 2.5s, swap title/aria-label to a "clipboard unavailable" message, and announce it through the existing polite live region — the pattern the analyser's bulk copy/export actions already used. | M | auto-build |
| 3 | **Title filter for the result table** (new `VideoListFilter.tsx`, `VideoListTable.tsx`) | With "max results" set to all, an analysis pushes hundreds of rows into the "More videos" table and the only way to find a specific video was the browser's own page search. A compact filter bar narrows rows by title with a live "x of y shown" count, a clear button and a dedicated empty state. Ranks are assigned *before* filtering, so a row keeps its position in the full result set instead of being renumbered. Appears only from ten rows up, so short lists stay uncluttered. | M | auto-build |

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — 7 new keys in `en.json` + `de.json`
- [x] Tested locally — `npm ci` → `format:check` → `tsc --noEmit` → `npm run build`, all green (no test runner is configured in this repo)

## Related Issues

Closes #322

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01TvVPvgyJw1pdqJiutimf4L)_