### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,26 @@ npm run format:check  # Verify formatting (read-only, matches CI)
 
 Formatting is enforced in CI via `npm run format:check`. PRs with formatting drift will fail the check.
 
+### Verification Before Submitting
+
+Formatting is only the first of three gates. `.github/workflows/pr-checks.yml` runs all of the
+following on every pull request, so run them locally in this order to catch failures before CI does:
+
+```bash
+npm run format:check  # 1. Prettier verification (read-only)
+npm run typecheck     # 2. tsc --noEmit — strict mode, noUnusedLocals/noUnusedParameters are ON
+npm run build         # 3. Production build to dist/ — must succeed
+```
+
+Notes:
+
+- **Run `npm run format` first** if step 1 fails — it rewrites files in place, then re-check.
+- **Unused variables are type errors, not warnings** (`noUnusedLocals` / `noUnusedParameters`), so a
+  leftover import fails step 2.
+- **There is no test suite yet.** No test framework is configured, so the three commands above are the
+  complete quality gate. See `agent_docs/testing.md` for the planned Vitest setup and priority targets.
+- CI additionally runs `npm audit --audit-level=high`, but that job is advisory and does not block.
+
 ### Project Structure
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,12 @@ The app uses localStorage for persistence. When debugging, you may need to clear
 - Translations are in `src/i18n/locales/`
 - Currently supported: English (en), German (de)
 - When adding UI text, add translations for all supported languages
+- **`supportedLngs` declares 13 locales, but only two have translation files.** `src/i18n/config.ts`
+  lists `en, de, fr, es, it, pt, nl, pl, tr, ru, ja, zh, ko`; the other eleven resolve through
+  `fallbackLng: "en"`. So adding a key to `en.json` + `de.json` is enough — there is no third locale
+  file to keep in sync, and a missing key silently renders the English string rather than the raw key.
+- **Never hardcode UI strings.** All user-facing text goes through `t('key')`; the single namespace is
+  `common`. Language detection order is `localStorage` → `navigator` → `htmlTag`.
 
 ### No External AI APIs
 

--- a/agent_docs/env-vars.md
+++ b/agent_docs/env-vars.md
@@ -11,8 +11,44 @@ Vite exposes **only** `VITE_`-prefixed variables to the client bundle. Copy `.en
 | `VITE_DEFAULT_SEARCH`  | Default search input value on app load  | Dev: `TEDx`, Prod: `""` |
 | `VITE_GIT_COMMIT_HASH` | Full git commit hash (Docker build arg) | Auto-detected from git  |
 | `VITE_GIT_BRANCH`      | Git branch name (Docker build arg)      | Auto-detected from git  |
+| `ELECTRON`             | Activates the Electron build pipeline   | unset (web build)       |
+| `VITE_DEV_SERVER_URL`  | Dev-server URL the Electron shell loads | Auto-injected by Vite   |
 
 Authoritative template: `.env.example`.
+
+### Build-time-only variables (never reach the client bundle)
+
+The last two rows are **not** client variables despite the `VITE_` prefix on one of them — both are read
+through `process.env` outside the browser bundle, so Vite never inlines them into `dist/`.
+
+- `ELECTRON` — read in `vite.config.ts` (`process.env.ELECTRON === "true"`). Set automatically by every
+  `electron:*` / `build:win` / `build:chromebook` npm script; it toggles `vite-plugin-electron`, which
+  compiles `electron/main.ts` + `electron/preload.ts` into `dist-electron/`. Do **not** put it in
+  `.env.local` — a stray `ELECTRON=true` makes plain web and Docker builds emit Electron artifacts.
+  Format: the literal string `true` (any other value counts as unset).
+- `VITE_DEV_SERVER_URL` — read in `electron/main.ts` (Electron main process, Node side). Injected by
+  `vite-plugin-electron` during `npm run electron:dev` so the desktop shell loads the hot-reload dev
+  server instead of the bundled `dist/index.html`. Never set it manually; production Electron builds
+  must leave it unset. Format: absolute http URL, e.g. `http://localhost:3000`.
+
+## Docker build arguments
+
+`Dockerfile` takes three `ARG`s and maps two of them onto the `VITE_*` variables above before running
+`npm run build`. They are build-time only — nothing is read from the environment at container runtime.
+
+| Build arg         | Description                               | Default     | Maps to                |
+| ----------------- | ----------------------------------------- | ----------- | ---------------------- |
+| `NODE_VERSION`    | Base image tag for the builder stage      | `22-alpine` | — (image tag only)     |
+| `GIT_COMMIT_HASH` | Commit stamped into the build-info footer | `unknown`   | `VITE_GIT_COMMIT_HASH` |
+| `GIT_BRANCH`      | Branch stamped into the build-info footer | `unknown`   | `VITE_GIT_BRANCH`      |
+
+`.github/workflows/docker-publish.yml` passes `GIT_COMMIT_HASH=${{ github.sha }}` and
+`GIT_BRANCH=${{ github.ref_name }}`. For a local image build, pass them yourself or accept `unknown`:
+
+```bash
+docker build --build-arg GIT_COMMIT_HASH="$(git rev-parse HEAD)" \
+             --build-arg GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" -t tubetrend .
+```
 
 ## Secrets Locations
 


### PR DESCRIPTION
## Description

Repo-artefact maintenance sweep: closes documentation gaps where the docs had drifted behind the code. **Documentation only** — no runtime config, no `.env*` files, no secrets, no functional code. The entire diff is purely additive: **62 insertions, 0 deletions** across two `.md` files.

Headline: `.env.example` itself was already at full parity with the code (all 5 keys present, each with purpose, required/optional and format). The gaps were in the docs that mirror it and in the contributor onboarding path.

| # | Pass | Datei(en) | Befund | Fix | Aufwand | Empfehlung |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | A — ENV-Parität | `agent_docs/env-vars.md` | Declares itself the authoritative full list but documents only 3 of 5 env vars; `ELECTRON` and `VITE_DEV_SERVER_URL` missing, Dockerfile `ARG`s undocumented | Both vars added to the table; new "Build-time-only variables" section (why neither reaches the client bundle + the "don't set in `.env.local`" caveat); new "Docker build arguments" section with `NODE_VERSION` / `GIT_COMMIT_HASH` / `GIT_BRANCH`, defaults and their mapping onto `VITE_GIT_*` | M | auto-fix |
| 2 | D — Onboarding | `CONTRIBUTING.md` | "Before submitting a PR" named only Prettier, while `pr-checks.yml` gates on `format:check` → `tsc --noEmit` → `build` | New "Verification Before Submitting" section with all three commands in CI order, the `noUnusedLocals`/`noUnusedParameters` gotcha, the "no test suite yet" pointer to `agent_docs/testing.md`, and the advisory `npm audit` job | S | auto-fix |
| 3 | D — Onboarding | `CONTRIBUTING.md` | i18n notes listed only `en`/`de` without the fallback model — `src/i18n/config.ts` declares 13 locales in `supportedLngs` but only two translation files exist | Documented that `en.json` + `de.json` are the complete set, that the other eleven resolve via `fallbackLng: "en"`, and that a missing key renders English rather than the raw key; recorded the `t('key')` rule, the `common` namespace and the detection order | S | auto-fix |

Every value is derived from the code — `vite.config.ts:10,14,15`, `electron/main.ts:49`, `Dockerfile:4,8,9,21,22`, `docker-publish.yml:97-99`, `pr-checks.yml`, `src/i18n/config.ts:20-21`. Nothing was guessed.

### Artefakt-Status

| Artefakt | Vorhanden | Code-Parität |
| --- | --- | --- |
| `.env.example` | ja | **ja** — all 5 code keys present, documented |
| Config-Example | n.a. | n.a. — no runtime config loading; config is static |
| README-Onboarding | ja | ja — prerequisites, install, env setup, dev/build, scripts table |
| Referenzierte Docs | ja | ja — every referenced `.md` exists and is non-stub |
| `BACKLOG.md` | ja | aufgeräumt — `## Open` already empty |

### Backlog-Aufarbeitung

Pass F ran and produced **no changes**: `## Open` is already empty, so nothing to remove, extract or consolidate. `## Done` and `## Obsolete / Accepted Tradeoffs` are a deliberate historical record and were left intact. No issues extracted.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no UI text changed
- [x] Tested locally — `npx prettier --check` passes on both changed files; no source, config or example files touched, so typecheck and build are unaffected (`pr-checks.yml` also skips `**.md`-only changes via `paths-ignore`)

Verification performed: whitelist check (only `.md` files changed), additive-only check (no removed or reworded lines outside `BACKLOG.md`, which is untouched), secret-pattern scan on all added lines (clean), and the CI-equivalent Prettier gate on the changed files.

## Related Issues

Closes #324

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX1ncfPhXkzjQgcEv9B1Tw)_