### PR TITLE
refactor: best-practice sweep (Vite + React + TypeScript)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,6 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: both jobs only check out the code and run npm. Without this
+# block the GITHUB_TOKEN inherits the repository default, which can be
+# read/write. Every other workflow here already declares its scope.
+permissions:
+  contents: read
+
 jobs:
   # Format, typecheck, lint and build in a single job so dependencies are
   # installed once per run instead of once per check (previously 4 jobs each

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -86,7 +86,11 @@ export function DashboardPage({
       return a.sourceLabel.localeCompare(b.sourceLabel, getLocale(), { sensitivity: "base" });
     });
 
-    const visible = sorted.filter((item) => !hiddenHighlightsService.isHidden(item.video.id));
+    // Read the hidden list once. `isHidden()` re-reads localStorage, JSON-parses
+    // it and re-validates every entry on each call, so calling it inside the
+    // filter did that work once per highlight item.
+    const hiddenIds = new Set(hiddenHighlightsService.list().map((h) => h.videoId));
+    const visible = sorted.filter((item) => !hiddenIds.has(item.video.id));
     const hiddenCount = sorted.length - visible.length;
 
     return { visible, hiddenCount };

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,4 +1,12 @@
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { STORAGE_KEYS } from "@shared/constants";
 
 type Theme = "light" | "dark" | "system";
@@ -38,7 +46,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return stored === "system" ? getSystemTheme() : stored;
   });
 
-  const setTheme = (newTheme: Theme) => {
+  // Stable identity: `setTheme` is a dependency of consumer callbacks
+  // (e.g. the global theme hotkey in App), so it must not change per render.
+  const setTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme);
     if (typeof window !== "undefined") {
       try {
@@ -47,7 +57,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         // Ignore storage errors — the in-memory theme still applies
       }
     }
-  };
+  }, []);
 
   // Apply theme to document
   useEffect(() => {
@@ -76,11 +86,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return () => mediaQuery.removeEventListener("change", handler);
   }, [theme]);
 
-  return (
-    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
-      {children}
-    </ThemeContext.Provider>
+  // Memoized so an unrelated re-render of this provider does not hand every
+  // consumer a new context object and force them all to re-render.
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme],
   );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export function useTheme(): ThemeContextValue {

--- a/src/shared/components/ui/FavoriteAvatar.tsx
+++ b/src/shared/components/ui/FavoriteAvatar.tsx
@@ -108,6 +108,7 @@ export const FavoriteAvatar: React.FC<FavoriteAvatarProps> = ({
             src={avatarUrl}
             alt={channelTitle}
             className="w-full h-full rounded-full object-cover"
+            loading="lazy"
           />
         ) : (
           <span className="select-none">{initials}</span>

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -143,6 +143,7 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
                       src={item.thumbnailUrl}
                       alt={item.videoTitle}
                       className="w-20 h-12 rounded-lg object-cover shrink-0 border border-slate-200 dark:border-slate-700"
+                      loading="lazy"
                     />
                   )}
 

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -23,17 +23,17 @@ interface InputSectionProps {
     searchType: SearchType,
   ) => void;
   isLoading: boolean;
-  // Optional: Externe Werte zum Synchronisieren (z.B. von Favoriten)
+  // Optional: external values to sync in (e.g. from a favorite)
   externalQuery?: string;
   externalTimeFrame?: TimeFrame;
   externalMaxResults?: number;
   externalSearchType?: SearchType;
-  // Ändert sich bei jedem externen Sync, um useEffect-Trigger zu garantieren
+  // Changes on every external sync so the useEffect below always fires
   externalSyncToken?: number;
 }
 
-// Hilfsfunktion: Ermittelt den SearchType aus dem Input-Präfix
-// # am Anfang = Keyword-Suche, sonst Kanal-Suche
+// Helper: derive the SearchType from the input prefix.
+// Leading # = keyword search, otherwise channel search.
 const detectSearchType = (input: string): SearchType => {
   const trimmed = input.trim();
   if (trimmed.startsWith("#")) {
@@ -42,7 +42,7 @@ const detectSearchType = (input: string): SearchType => {
   return SearchType.CHANNEL;
 };
 
-// Hilfsfunktion: Entfernt das Präfix-Zeichen (#) vom Input
+// Helper: strip the prefix character (#) from the input
 const stripSearchPrefix = (input: string): string => {
   const trimmed = input.trim();
   if (trimmed.startsWith("#")) {
@@ -75,7 +75,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
   const [timeFrame, setTimeFrame] = useState<TimeFrame>(TimeFrame.LAST_MONTH);
   const [maxResults, setMaxResults] = useState<number>(-1);
 
-  // SearchType wird dynamisch aus dem Input-Präfix ermittelt
+  // SearchType is derived dynamically from the input prefix
   const searchType = detectSearchType(inputValue);
 
   // Autocomplete State
@@ -152,13 +152,14 @@ export const InputSection: React.FC<InputSectionProps> = ({
     }
   }, []);
 
-  // Synchronisiere externe Werte (z.B. von Favoriten-Analyse)
-  // externalSyncToken als Dependency sorgt dafür, dass auch bei gleichem Favoriten die Werte aktualisiert werden
+  // Sync externally supplied values (e.g. from analysing a favorite).
+  // externalSyncToken is a dependency so re-picking the same favorite still
+  // re-applies the values.
   useEffect(() => {
     if (externalQuery !== undefined && externalSyncToken !== undefined) {
       // The synced value replaces whatever was typed — drop pending lookups.
       cancelSuggestionLookup();
-      // Bei Keyword-Suche: Präfix # hinzufügen, falls nicht vorhanden
+      // Keyword search: add the # prefix when it is missing
       const prefix =
         externalSearchType === SearchType.KEYWORD && !externalQuery.startsWith("#") ? "#" : "";
       setInputValue(prefix + externalQuery);
@@ -249,7 +250,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
     // The input changed — a lookup scheduled for the previous value is stale.
     cancelSuggestionLookup();
 
-    // Autocomplete nur bei Kanal-Suche (basierend auf neuem Wert)
+    // Autocomplete only for channel search (based on the new value)
     const newSearchType = detectSearchType(val);
     if (newSearchType !== SearchType.CHANNEL) {
       setSuggestions([]);
@@ -309,16 +310,16 @@ export const InputSection: React.FC<InputSectionProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (inputValue.trim()) {
-      // Präfix entfernen und Query extrahieren
+      // Strip the prefix and extract the query
       const strippedInput = stripSearchPrefix(inputValue);
-      // Bei Kanal-Suche: Extract clean identifier (handle or ID) from URL if present
-      // Bei Keyword-Suche: Direkt den Suchbegriff verwenden
+      // Channel search: extract a clean identifier (handle or ID) from a URL if present.
+      // Keyword search: use the search term as typed.
       const query =
         searchType === SearchType.CHANNEL ? extractChannelIdentifier(strippedInput) : strippedInput;
       onSearch(query, timeFrame, maxResults, searchType);
       setShowSuggestions(false);
       setShowHistory(false);
-      // Save typed value to history (what the user entered, inkl. Präfix)
+      // Save typed value to history (what the user entered, including the prefix)
       addToHistory(inputValue);
     }
   };
@@ -352,7 +353,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
       inputValue.length >= 2 &&
       !inputValue.includes("http")
     ) {
-      // Autocomplete-Suggestions nur bei Kanal-Suche
+      // Autocomplete suggestions only for channel search
       setShowSuggestions(true);
       setShowHistory(false);
     }
@@ -462,7 +463,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
     return () => document.removeEventListener("keydown", handleEsc);
   }, [showSuggestions, showHistory, inputValue]);
 
-  // Synchronisiere Favoriten-Status, wenn Eingabe/Zeitfenster/MaxErgebnisse/SearchType sich ändern
+  // Re-sync the favorite state whenever query, time frame, max results or search type change
   useEffect(() => {
     const strippedInput = stripSearchPrefix(inputValue || "");
     const q =

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -578,6 +578,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
                             src={sug.thumbnailUrl}
                             alt=""
                             className="w-full h-full object-cover"
+                            loading="lazy"
                           />
                         </div>
                         <div className="min-w-0">


### PR DESCRIPTION
Best-practice sweep across the Vite + React 19 + TypeScript stack. Behaviour-equivalent only — no feature changes, no style-only diffs outside the findings. One commit per finding.

## Merged findings

| # | Datei | Kategorie | Befund | Fix | Aufwand | Empfehlung |
|---|-------|-----------|--------|-----|---------|------------|
| 1 | `.github/workflows/pr-checks.yml` | Security | Only workflow of six without a top-level `permissions:` block, so `GITHUB_TOKEN` inherited the repository default scope | Declare `permissions: contents: read` — both jobs only checkout and run npm | S | auto-fix |
| 2 | `src/app/routes/DashboardPage.tsx` | Performance | `hiddenHighlightsService.isHidden()` was called from inside `.filter()`; every call re-reads `localStorage`, `JSON.parse`s it and re-validates each entry — once per highlight item, per dashboard render | Build the hidden-id `Set` once from `list()` and test against it | S | auto-fix |
| 3 | `FavoriteAvatar.tsx`, `HiddenHighlightsModal.tsx`, `InputSection.tsx` | Performance | Three remote `<img>` lacked `loading="lazy"` although `VideoCard`, `HighlightVideoCard` and `VideoListTable` already set it | Add `loading="lazy"` so off-screen avatars/thumbnails are no longer fetched eagerly | S | auto-fix |
| 4 | `src/providers/ThemeProvider.tsx` | Maintainability | The context value object and `setTheme` were re-created on every render; `App`'s global theme hotkey lists `setTheme` in its `useCallback` deps | `useCallback` for `setTheme` + `useMemo` for the context value | S | auto-fix |
| 5 | `src/shared/components/ui/InputSection.tsx` | Maintainability | 16 German code comments, against `CLAUDE.md → Coding Conventions` ("code comments in English") | Translate to English — comment-only change | M | auto-fix |

## Verification

`npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. This repo has no test runner by design (`CLAUDE.md → Testing`), so none was run or introduced.

Findings, deferred items and out-of-scope notes: Refs #185


---
_Generated by [Claude Code](https://claude.ai/code/session_0134KhyTZ15wfbKLCvoDyHKe)_