### PR TITLE
ux: best-practice sweep (Vite + React)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -284,6 +284,17 @@ const App: React.FC = () => {
         onClose={() => setIsHiddenHighlightsModalOpen(false)}
       />
 
+      {/* Skip link (WCAG 2.4.1 Bypass Blocks): the sticky header carries ~8 tab
+          stops (nav, shortcuts, API key, quota, language, theme) that keyboard
+          users would otherwise traverse on every interaction. Visually hidden
+          until focused. */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[70] focus:px-4 focus:py-2 focus:rounded-md focus:bg-indigo-600 focus:text-white focus:font-medium focus:shadow-lg"
+      >
+        {t("nav.skipToContent")}
+      </a>
+
       <Header
         activePage={activePage}
         onPageChange={setActivePage}
@@ -293,7 +304,11 @@ const App: React.FC = () => {
         onResetApiKey={handleResetKey}
       />
 
-      <main className="flex-1 max-w-[101.2rem] mx-auto px-4 sm:px-6 lg:px-8 py-8 w-full">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex-1 max-w-[101.2rem] mx-auto px-4 sm:px-6 lg:px-8 py-8 w-full outline-none"
+      >
         {activePage === "dashboard" ? (
           <DashboardPage
             favorites={favorites}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -34,8 +34,16 @@ i18n
 
 // Sync <html lang> attribute with the active language so screen readers
 // announce content in the correct language (WCAG 3.1.1).
+//
+// `supportedLngs` lists 13 languages but only `en` and `de` ship resource
+// bundles, so selecting e.g. "Français" renders English text via fallbackLng.
+// Tagging that page `lang="fr"` makes screen readers pronounce English words
+// with French phonetics — worse than no tag at all. `resolvedLanguage` is the
+// first language in the fallback chain that actually has translations, i.e.
+// the language the user really sees, so tag that instead.
 function syncHtmlLang(lng: string) {
-  const short = (lng || "en").split("-")[0].toLowerCase();
+  const effective = i18n.resolvedLanguage || lng;
+  const short = (effective || "en").split("-")[0].toLowerCase();
   document.documentElement.lang = short;
 }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -17,6 +17,7 @@
   },
   "nav": {
     "main": "Hauptnavigation",
+    "skipToContent": "Zum Hauptinhalt springen",
     "dashboard": "Dashboard",
     "analyser": "Analyser"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
   },
   "nav": {
     "main": "Main navigation",
+    "skipToContent": "Skip to main content",
     "dashboard": "Dashboard",
     "analyser": "Analyser"
   },

--- a/src/shared/components/feedback/ErrorBoundary.tsx
+++ b/src/shared/components/feedback/ErrorBoundary.tsx
@@ -52,7 +52,10 @@ interface DefaultErrorFallbackProps {
 function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps) {
   const { t } = useTranslation();
   return (
-    <div className="min-h-[200px] flex items-center justify-center p-8">
+    // role="alert" (implicit aria-live="assertive"): the fallback silently
+    // replaces a crashed subtree, so without a live region a screen reader user
+    // gets no signal that the content they were on is gone.
+    <div role="alert" className="min-h-[200px] flex items-center justify-center p-8">
       <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-6 max-w-md text-center">
         <div className="flex justify-center mb-4">
           <div className="bg-red-100 dark:bg-red-900/40 p-3 rounded-full">

--- a/src/shared/components/ui/ApiKeyModal.tsx
+++ b/src/shared/components/ui/ApiKeyModal.tsx
@@ -52,6 +52,16 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
+  // Lock background scrolling while this blocking dialog is up, so the page
+  // behind the backdrop cannot be scrolled out from under the user.
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (isKeyLongEnough) {

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -56,10 +56,17 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
 
   useEffect(() => {
     if (!isOpen) return;
+    // Remember what had focus so it can be restored on close (WCAG 2.4.3).
+    // Without this, closing the dialog drops focus to <body> and keyboard users
+    // resume tabbing from the top of the page instead of the trigger button.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     document.addEventListener("keydown", handleTabKey);
     // Move focus into the dialog on open so the trap has a starting point.
     dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
-    return () => document.removeEventListener("keydown", handleTabKey);
+    return () => {
+      document.removeEventListener("keydown", handleTabKey);
+      previouslyFocused?.focus?.();
+    };
   }, [isOpen, handleTabKey]);
 
   const handleUnhide = (videoId: string) => {

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -69,6 +69,18 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
     };
   }, [isOpen, handleTabKey]);
 
+  // Lock background scrolling while the dialog is open. Without this, scrolling
+  // past the end of the modal list chains to the page behind the backdrop, which
+  // moves content the user cannot see and loses their place on close.
+  useEffect(() => {
+    if (!isOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
   const handleUnhide = (videoId: string) => {
     hiddenHighlightsService.show(videoId);
     setHiddenItems(hiddenHighlightsService.listChronological());


### PR DESCRIPTION
Autonomous UX best-practice sweep. Five additive fixes — four a11y, one interaction. No feature changes, no restyling beyond the findings.

| # | Kategorie | Fix | Aufwand | Empfehlung |
|---|-----------|-----|---------|------------|
| 1 | a11y | Skip link to bypass the sticky header (WCAG 2.4.1); `<main>` gets `id` + `tabIndex={-1}` so focus really moves | M | auto-fix |
| 2 | a11y | `<html lang>` now tags the **rendered** language (`resolvedLanguage`), not the requested one (WCAG 3.1.1) | S | auto-fix |
| 3 | a11y | Hidden-highlights modal restores focus to its trigger on close (WCAG 2.4.3) | S | auto-fix |
| 4 | a11y | `ErrorBoundary` fallback announced via `role="alert"` | S | auto-fix |
| 5 | interaction | Background scroll locked while a modal is open | S | auto-fix |

### Affected screens

- **App shell / every screen** — skip link (visible only on keyboard focus, sits above the sticky header at `z-70`); `<html lang>`.
- **Header → language switcher** — selecting one of the 11 untranslated languages no longer mislabels the document language. `supportedLngs` lists 13 languages but only `en`/`de` ship bundles, so those selections render English via `fallbackLng`; tagging that page `lang="fr"` made screen readers pronounce English with French phonetics.
- **Dashboard → "hidden highlights" modal** — focus restore + scroll lock.
- **API-key modal** (first run / after reset) — scroll lock.
- **Any crashed subtree** — `ErrorBoundary` fallback.

### Verification

`npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. No test runner is configured in this repo, so there is no test gate.

Two behaviours were verified empirically rather than assumed:

- **i18next fallback resolution** — confirmed against the real `supportedLngs` + `nonExplicitSupportedLngs` config that `resolvedLanguage` is `en` for `fr`/`ja`/`zh` and `de` for `de`, and that it is already current inside the `languageChanged` handler (the actual code path).
- **Tailwind output** — confirmed all 11 skip-link `focus:` utilities compiled into `dist/`, and that the cascade order makes `focus:not-sr-only` override `sr-only` while `focus:absolute` in turn overrides its `position:static`.

Deferred findings (quota panel theme-lock, 9 native `alert`/`confirm` calls, untranslated language entries, ghost scroll button, and the duplicate `handleDelete`/`handleUnhide` already tracked in #185) are documented in the issue.

Closes #327


---
_Generated by [Claude Code](https://claude.ai/code/session_01L88b39wHKPkDvwjKTZQc2f)_