### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,11 +7,20 @@
 # Notes:
 # - Vite only exposes variables prefixed with "VITE_" to the client.
 # - If a variable is left empty, the app may use its own internal fallback.
+# - "Left empty" is not the same as "unset": `KEY=` makes the value the empty
+#   string "". A fallback written with `??` (nullish coalescing) therefore does
+#   NOT kick in — see VITE_DEFAULT_SEARCH below. Comment the line out to unset.
 
 # Default search value shown in the input field when the app loads.
-# Optional. If not set, the app will use these fallbacks:
+# Optional. If the variable is UNSET, the app uses these fallbacks:
 #   - Dev mode: "TEDx"
 #   - Production: "" (empty)
+# CAVEAT: the line below ships empty, and Vite reads `VITE_DEFAULT_SEARCH=` as
+# the empty string, not as unset. Since the code is
+# `import.meta.env.VITE_DEFAULT_SEARCH ?? (import.meta.env.DEV ? "TEDx" : "")`
+# (src/shared/components/ui/InputSection.tsx), copying this file verbatim to
+# .env.local suppresses the dev-mode "TEDx" default and starts with an empty
+# input. To get the "TEDx" default back, comment the line out entirely.
 # Format: free-text search query string.
 # Example: VITE_DEFAULT_SEARCH=TEDx
 VITE_DEFAULT_SEARCH=

--- a/README.md
+++ b/README.md
@@ -107,12 +107,20 @@ Download the `.apk` from [Releases](https://github.com/fo0/tubetrend/releases).
 
 To build from source:
 
+**Prerequisites:** Node.js v22+, JDK 21 (Temurin), and the Android SDK (Android Studio or
+`cmdline-tools` with `ANDROID_HOME` set). The Gradle build needs all three — Node alone is not
+enough. See `.github/workflows/android-release.yml` for the exact toolchain CI uses.
+
 ```bash
 npm install
 npm run cap:build:debug
 ```
 
 The APK will be in `android/app/build/outputs/apk/debug/`.
+
+For an unsigned release APK instead, use `npm run cap:build` (output:
+`android/app/build/outputs/apk/release/`). Play Store distribution additionally requires your own
+signing keystore.
 
 ### Option 5: Chrome Extension
 

--- a/agent_docs/env-vars.md
+++ b/agent_docs/env-vars.md
@@ -16,6 +16,21 @@ Vite exposes **only** `VITE_`-prefixed variables to the client bundle. Copy `.en
 
 Authoritative template: `.env.example`.
 
+### `VITE_DEFAULT_SEARCH`: empty ≠ unset
+
+The `Dev: TEDx` default above applies only when the variable is **unset**. `.env.example` ships the
+key as `VITE_DEFAULT_SEARCH=`, and Vite reads that as the empty string `""`, not as absent. The read
+site is `src/shared/components/ui/InputSection.tsx`:
+
+```ts
+import.meta.env.VITE_DEFAULT_SEARCH ?? (import.meta.env.DEV ? "TEDx" : "");
+```
+
+`??` only falls back on `null`/`undefined`, so `""` wins and the dev-mode `TEDx` default is
+suppressed. Copying `.env.example` verbatim to `.env.local` therefore yields an empty search input in
+dev. Comment the line out to restore the fallback. The other four variables are read with `||` or a
+plain truthiness check, so an empty value behaves the same as unset for them.
+
 ### Build-time-only variables (never reach the client bundle)
 
 The last two rows are **not** client variables despite the `VITE_` prefix on one of them — both are read

--- a/agent_docs/platform_builds.md
+++ b/agent_docs/platform_builds.md
@@ -60,6 +60,12 @@ docker-compose up         # Run production image at http://localhost:8889
 
 - **Alternative to the Electron Chromebook `.deb`** — a native Android APK that runs on ChromeOS via ARCVM.
 - **Zero changes to `src/`** — wraps the same `dist/` web build output.
+- **Toolchain prerequisites** — unlike every other target, the `cap:build*` scripts need more than Node:
+  **JDK 21 (Temurin)** and the **Android SDK** (`ANDROID_HOME`), because the last step is a Gradle
+  build inside `android/`. `.github/workflows/android-release.yml` sets both up via
+  `actions/setup-java@v5` (`java-version: "21"`) and `android-actions/setup-android@v4`; the same
+  requirement applies to the `build-android` job in `electron-release.yml`. Without them
+  `npm run cap:build:debug` fails at `./gradlew`, not at the Vite build.
 - **ChromeOS-optimized `AndroidManifest.xml`** — resizable activity, freeform window support.
 - **Icon** — uses the same `build/icon.png` as Electron.
 - **Signing** — currently unsigned (debug key). Production Play Store distribution requires a signing keystore.


### PR DESCRIPTION
## Description

Repo-quality-maintenance sweep: two forgotten documentation/example artefacts pulled back in line with the code. Docs and example artefacts only — no runtime config, no secrets, no functional code change.

| # | Pass | Datei(en) | Befund | Fix | Aufwand | Empfehlung |
|---|------|-----------|--------|-----|---------|------------|
| 1 | D — README-Vollständigkeit | `README.md`, `agent_docs/platform_builds.md` | "Option 4: Android APK → To build from source" listed only `npm install` + `npm run cap:build:debug`. The final step is a Gradle build inside `android/`, which needs **JDK 21 + the Android SDK** — Node alone fails at `./gradlew`, not at the Vite build. The prerequisites were documented nowhere. | Added the prerequisites block (JDK 21 Temurin, Android SDK / `ANDROID_HOME`), derived from `.github/workflows/android-release.yml` (`actions/setup-java@v5` `java-version: "21"` + `android-actions/setup-android@v4`). Also documented the previously unmentioned release-APK script `npm run cap:build`. | S | auto-fix |
| 2 | C — Defaults/Doku in Examples | `.env.example`, `agent_docs/env-vars.md` | `.env.example` documented "If not set → Dev mode: `TEDx`" while shipping the key as `VITE_DEFAULT_SEARCH=`. Vite reads that as the **empty string**, not as unset, and the read site is `import.meta.env.VITE_DEFAULT_SEARCH ?? (import.meta.env.DEV ? "TEDx" : "")` (`src/shared/components/ui/InputSection.tsx:16`) — `??` only falls back on `null`/`undefined`. Copying the example verbatim to `.env.local`, exactly as the file instructs, silently suppresses the documented dev default. | Comment-only clarification in `.env.example` (empty ≠ unset; comment the line out to keep the fallback) plus a matching section in `agent_docs/env-vars.md`. No value changes. The other four variables use `||`/truthiness, so empty behaves as unset for them — no action needed. | S | auto-fix |

## Artefakt-Status

| Artefakt | Vorhanden | Code-Parität |
|----------|-----------|--------------|
| .env.example | ja | ja — 5/5 Keys (`VITE_DEFAULT_SEARCH`, `VITE_GIT_COMMIT_HASH`, `VITE_GIT_BRANCH`, `ELECTRON`, `VITE_DEV_SERVER_URL`), keine Waisen |
| Config-Example | n.a. | n.a. — kein Config-Loader, keine `config.example.*` |
| README-Onboarding | ja | ja (nach Fix 1) |
| Referenzierte Docs | ja | ja — 25/25 vorhanden, kein Stub |
| BACKLOG.md | ja | n.a. — "Open"-Sektion leer, Pass F nicht ausgelöst |

## Backlog-Aufarbeitung

| Eintrag (Kurzform) | Aktion | Beleg |
|--------------------|--------|-------|
| — | Pass F nicht ausgelöst — `BACKLOG.md` "Open" ist leer, keine Einträge zum Entfernen, Extrahieren oder Konsolidieren. Keine Issues extrahiert. | — |

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines (`prettier --check` green on all touched `.md`)
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no UI strings touched
- [x] Tested locally — whitelist diff check + Prettier verification; no source or code-config file touched, so no typecheck/build gate applies

## Scope

Only doc/example artefacts were written: `README.md`, `.env.example`, `agent_docs/env-vars.md`, `agent_docs/platform_builds.md`. **No runtime config, no secrets** — the missing-key source was always the code scan, never a real `.env` (none exists in the repo). Destructive edits are restricted to `BACKLOG.md` with evidence, and Pass F did not fire here, so this diff is purely additive apart from one corrected comment line in `.env.example` (39 insertions, 1 deletion).

Housekeeping (formatter/linter/test-runner as an end in itself, unused deps, dead links, MD syntax), dependency bumps and bot PRs are out of scope — separate routines own those.

## Related Issues

Closes #329

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWnvjEhyUZgq9vcGDb5CeF)_