### PR TITLE
refine: ux sweep (Vite + React)

### DIFF
--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -373,7 +373,12 @@ export function DashboardPage({
       ) : (
         <div className="space-y-10">
           {sortedFavorites.map((fav, idx) => (
-            <div key={fav.id} id={`favorite-${fav.id}`}>
+            // scroll-mt-20 (5rem) clears the sticky header (h-16 = 4rem) plus a
+            // little breathing room. Without it the avatar quick-jump below
+            // aligns the row flush with the viewport top, where the header
+            // covers the favorite's own title — the user lands on a row whose
+            // heading they cannot see.
+            <div key={fav.id} id={`favorite-${fav.id}`} className="scroll-mt-20">
               <FavoriteRow
                 favorite={fav}
                 onRemove={onRemoveFavorite}

--- a/src/shared/components/ui/FloatingScrollButton.tsx
+++ b/src/shared/components/ui/FloatingScrollButton.tsx
@@ -6,7 +6,8 @@ import { useTranslation } from "react-i18next";
  * A floating scroll button that appears based on scroll direction.
  * - Shows "scroll to top" when user scrolled down
  * - Shows "scroll to bottom" when user is near the top
- * - Very subtle/transparent, becomes visible on hover or mouse proximity
+ * - Very subtle/transparent, becomes visible on hover, mouse proximity or
+ *   keyboard focus
  * - Positioned center-right of the viewport
  */
 export function FloatingScrollButton() {
@@ -137,6 +138,12 @@ export function FloatingScrollButton() {
         hover:border-indigo-400/50 hover:dark:border-indigo-500/50
         hover:shadow-lg hover:shadow-indigo-500/20
         hover:scale-110
+        focus-visible:opacity-100
+        focus-visible:bg-indigo-500/90 dark:focus-visible:bg-indigo-600/90
+        focus-visible:text-white dark:focus-visible:text-white
+        focus-visible:border-indigo-400/50 dark:focus-visible:border-indigo-500/50
+        focus-visible:shadow-lg focus-visible:shadow-indigo-500/20
+        focus-visible:scale-110
         transition-all duration-500 ease-out
         backdrop-blur-sm
         cursor-pointer

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { VideoData } from "@/src/features/videos";
-import { Check, Clock, Copy, Eye, EyeOff, Sparkles, Zap } from "lucide-react";
+import { AlertCircle, Check, Clock, Copy, Eye, EyeOff, Sparkles, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 
@@ -31,18 +31,38 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
+  // A blocked clipboard used to make this button a dead control: it neither
+  // copied nor said anything. That is the normal case whenever the app is
+  // reached over plain HTTP (e.g. the Docker image on a LAN address), where
+  // navigator.clipboard does not exist at all. Surface it instead — same
+  // feedback pattern as VideoCard / VideoListTable.
+  const [copyFailed, setCopyFailed] = useState(false);
   const resetCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
       if (resetCopiedTimerRef.current) clearTimeout(resetCopiedTimerRef.current);
+      if (resetFailedTimerRef.current) clearTimeout(resetFailedTimerRef.current);
     };
   }, []);
+
+  const flashCopyFailed = () => {
+    setCopyFailed(true);
+    if (resetFailedTimerRef.current) clearTimeout(resetFailedTimerRef.current);
+    resetFailedTimerRef.current = setTimeout(() => setCopyFailed(false), 2500);
+  };
 
   const handleCopy = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!navigator.clipboard) return;
+    // navigator.clipboard is undefined in insecure contexts (HTTP, some
+    // iframes). Reading .writeText off it throws synchronously, which the
+    // rejection handler below would not catch — so guard the property first.
+    if (!navigator.clipboard) {
+      flashCopyFailed();
+      return;
+    }
     navigator.clipboard.writeText(video.url).then(
       () => {
         setCopied(true);
@@ -50,7 +70,8 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
         resetCopiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
       },
       () => {
-        // Clipboard API unavailable
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyFailed();
       },
     );
   };
@@ -68,7 +89,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
       {/* Polite live region: announce copy success to assistive tech (the green
           checkmark alone is silent to screen readers). Mirrors VideoCard. */}
       <span className="sr-only" role="status" aria-live="polite">
-        {copied ? t("results.table.urlCopied") : ""}
+        {copyFailed ? t("results.table.copyFailed") : copied ? t("results.table.urlCopied") : ""}
       </span>
 
       {/* Thumbnail Area */}
@@ -171,11 +192,21 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
           <button
             type="button"
             onClick={handleCopy}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white transition-all border border-slate-200 dark:border-slate-700"
-            title={t("results.table.copyUrl")}
-            aria-label={t("results.table.copyUrlAria", { title: video.title })}
+            className={`inline-flex items-center justify-center w-7 h-7 rounded-md bg-slate-100 dark:bg-slate-900/60 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all border border-slate-200 dark:border-slate-700 ${
+              copyFailed
+                ? "text-red-500 dark:text-red-400"
+                : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-white"
+            }`}
+            title={copyFailed ? t("results.table.copyFailed") : t("results.table.copyUrl")}
+            aria-label={
+              copyFailed
+                ? t("results.table.copyFailed")
+                : t("results.table.copyUrlAria", { title: video.title })
+            }
           >
-            {copied ? (
+            {copyFailed ? (
+              <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            ) : copied ? (
               <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
             ) : (
               <Copy className="w-3.5 h-3.5" aria-hidden="true" />


### PR DESCRIPTION
## Description

UX-refine sweep: three small screwdriver interventions on **existing** features (dashboard quick-jump, highlight-card copy, floating scroll button). No new features, no dependency changes, no refactors. 3 files, +53/-10.

| # | Existing feature | File | Kategorie | UX gap | Improvement |
| - | ---------------- | ---- | --------- | ------ | ----------- |
| 1 | Dashboard → favorite avatar quick-jump | `src/app/routes/DashboardPage.tsx` | Komfort | `scrollIntoView({ block: "start" })` aligns the row flush with the viewport top, but the header is `sticky top-0 h-16` — it covered the favorite's own title, so the jump landed on a row whose heading was hidden. | `scroll-mt-20` (5rem) on the `id="favorite-…"` anchor wrapper, so the browser offsets the scroll target past the header. |
| 2 | Dashboard → Highlights → copy video URL | `src/shared/components/ui/HighlightVideoCard.tsx` | Qualität | `handleCopy` returned silently when `navigator.clipboard` was absent and swallowed a rejected write. Over plain HTTP — the default for the Docker image on a LAN address — the Clipboard API does not exist, so the button did nothing and said nothing. `VideoCard` / `VideoListTable` already report this; only this card did not. | Mirror the established pattern: red `AlertCircle` for 2.5s, `title`/`aria-label` swapped to the failure text, state routed through the card's existing polite live region, timer cleared on unmount. Reuses `results.table.copyFailed` — **no new strings**. |
| 3 | Floating scroll-to-top/bottom button | `src/shared/components/ui/FloatingScrollButton.tsx` | A11y/Polish | The button idles at `opacity-20`. CSS `opacity` applies to the element *including its outline*, so the global `:focus-visible` ring from `index.css` was painted at 20% too — tabbing onto it showed almost nothing (WCAG 2.4.7). | `focus-visible` gets the same treatment `hover` already has: full opacity, indigo fill, white icon, scale. Mouse/proximity behaviour unchanged. |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no new strings; #2 reuses the existing `results.table.copyFailed` key
- [x] Tested locally — `npm ci` → `format:check` → `typecheck` → `build` all green; `npm run test --if-present` is a no-op (no test runner configured). Additionally verified in the built CSS that `scroll-mt-20`, `focus-visible:opacity-100` and `focus-visible:scale-110` are emitted and ordered after their base utilities.

## Related Issues

Closes #331


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZ4PCgy393Au8BBYZHZ5Ec)_