### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@
 # - "Left empty" is not the same as "unset": `KEY=` makes the value the empty
 #   string "". A fallback written with `??` (nullish coalescing) therefore does
 #   NOT kick in — see VITE_DEFAULT_SEARCH below. Comment the line out to unset.
+#
+# NOT HERE: the YouTube Data API v3 key.
+# It is deliberately not an environment variable and must never be added to this
+# file, to CI secrets or to the Docker image. The end user pastes it into the
+# app's API-key modal at runtime; it is stored only in that browser's
+# localStorage under the key "yt_api_key" (STORAGE_KEYS.API_KEY,
+# src/shared/constants/config.ts) and read back in
+# src/features/youtube/services/youtubeApiClient.ts. Every variable below is
+# build-time configuration only — none of them carries a credential.
 
 # Default search value shown in the input field when the app loads.
 # Optional. If the variable is UNSET, the app uses these fallbacks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,13 @@ Before submitting a bug report:
 ### Code Style Guidelines
 
 - **TypeScript**: Use strict typing, avoid `any`
-- **Imports**: Use path aliases (`@features/`, `@shared/`, etc.)
+- **Imports**: Cross-module imports use the `@/src/…` alias — write
+  `@/src/shared/lib/storage`, not `@shared/lib/storage`. Relative paths (`./`, `../`) stay inside a
+  single feature or component folder. Use `import type` for type-only imports.
+  - The `@features/`, `@shared/`, `@providers/` and `@i18n/` aliases are configured in
+    `tsconfig.json` + `vite.config.ts` and still resolve, but the codebase settled on `@/src/…`
+    (~132 sites vs. 1). Don't introduce new usages — full table in
+    `agent_docs/coding_conventions.md`.
 - **Components**: Functional components with hooks
 - **Naming**:
   - PascalCase for components and types

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ npm run preview  # Preview production build
 
 React 19 | TypeScript | Vite 8 | Tailwind CSS 4 | i18next | Electron | YouTube Data API v3
 
+## Contributing
+
+Contributions are welcome. [`CONTRIBUTING.md`](CONTRIBUTING.md) covers the development setup, the
+code style guidelines, the i18n rules and the three local checks that mirror CI
+(`npm run format:check` → `npm run typecheck` → `npm run build`) — run them before opening a PR.
+
+- **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- **Reporting a vulnerability:** [`SECURITY.md`](SECURITY.md) — please use GitHub's private
+  vulnerability reporting, not a public issue.
+- **Bug reports / feature requests:** [open an issue](https://github.com/fo0/tubetrend/issues) using
+  the matching template.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Description

Repo-quality maintenance sweep — pulls forgotten/incomplete repo artefacts back in line with the code. Three commits, all documentation/example targets, no functional code change.

Closes #335

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Findings

| # | Pass | Datei(en) | Befund | Fix | Aufwand | Status |
|---|------|-----------|--------|-----|---------|--------|
| 1 | C — Defaults & Doku in Examples | `.env.example` | Documented all five build-time variables but nothing about the one credential the app uses. A contributor copying it to `.env.local` had no signal that the YouTube Data API v3 key does **not** belong there, nor in CI secrets or the Docker image. | `NOT HERE:` block naming the runtime path — app modal → `localStorage` key `yt_api_key` (`STORAGE_KEYS.API_KEY`, `src/shared/constants/config.ts`), read in `src/features/youtube/services/youtubeApiClient.ts`. | S (+9) | gemerged |
| 2 | D — README-Onboarding | `README.md` | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` all exist; the README linked to none. Onboarding ended at "Run from Source" with no route to the contribution rules, the private vulnerability-reporting channel or the issue templates. | `## Contributing` section before `## License` pointing at all three plus the issue tracker, naming the three local checks that mirror CI. | S (+12) | gemerged |
| 3 | D — Onboarding-Doku | `CONTRIBUTING.md` | Code Style Guidelines said *"Use path aliases (`@features/`, `@shared/`, etc.)"* — the opposite of the real convention. Verified: `@/src/…` = **132** imports, `@shared/` = **1**, `@features/`/`@providers/`/`@i18n/` = **0**. `CLAUDE.md` and `agent_docs/coding_conventions.md` both say not to use the short aliases; only the file new contributors read said otherwise. | Restated the bullet to `@/src/…`, kept the legacy aliases documented as resolving-but-not-to-be-extended, pointed at the full alias table. | S (+7/−1) | gemerged |

## Artefakt-Status

| Artefakt | Vorhanden | Vollständig (Code-Parität) |
|----------|-----------|----------------------------|
| .env.example | ja | ja |
| Config-Example | n.a. | n.a. |
| README-Onboarding | ja | teilweise |
| Referenzierte Docs | ja | ja |
| BACKLOG.md | ja | aufgeräumt |

- **Pass A (ENV parity): clean.** Code scan yields exactly the five keys `.env.example` ships — no missing keys, no orphans.
- **Pass B (Config parity): n.a.** No `*.example.*` config counterparts exist; active runtime configs are out of scope by policy.
- **Pass E (referenced docs): clean.** Every referenced `.md`/`.mmd` resolves; the apparent misses are template placeholders inside fenced example blocks.
- **Pass F (backlog): no finding.** `BACKLOG.md` → `## Open` is empty; the `Done` / `Obsolete` tables are dated historical records. Nothing removed, extracted or consolidated.

## Backlog-Aufarbeitung

Not applicable this run — no open backlog entries, so no destructive edit was made to `BACKLOG.md`.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable) — n/a, no UI text changed
- [x] Tested locally — `npm run format:check` green; `npm run typecheck` not required (no source file touched, docs/example only)

## Scope-Hinweis

Housekeeping (Format/Lint/Test/Deps/Dead-Code), Dependency-Bumps und Bot-PRs sind out-of-scope — dafür existieren separate Routinen. Diese Routine schreibt ausschließlich Doku-/Example-Artefakte (keine aktive Runtime-Config, keine Secrets). Destruktive Edits nur in `BACKLOG.md` (Pass F, mit Beleg-Pflicht) — dieser Lauf hat keine gemacht.

Note: `pr-checks.yml` has `paths-ignore` for `**.md`, `docs/**` and `.env.example`, so a docs-only PR legitimately produces zero CI runs. That is configuration, not breakage.

## Related Issues

Closes #335

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc4QHSfhU9j2ZdBg4ndxVu)_