### PR TITLE
security: hardening sweep (Vite + React SPA)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,6 +21,13 @@ server {
     # is non-breaking. It only governs window.opener relationships — fetch() to the
     # YouTube API and cross-origin thumbnails/subresources are unaffected.
     add_header Cross-Origin-Opener-Policy "same-origin" always;
+    # Cross-Origin-Resource-Policy: complements the COOP header above by refusing
+    # to be embedded as a subresource by another origin. Every distribution target
+    # (Docker, Electron, Capacitor, Chrome extension) bundles its own copy of
+    # dist/, so nothing legitimately loads these files cross-origin — and the app
+    # loading YouTube thumbnails FROM other origins is unaffected, since CORP only
+    # governs who may load OUR responses.
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
     # HSTS: only honored by browsers over HTTPS (ignored on plain HTTP), so it is
     # a no-op for the HTTP-only container yet hardens deployments fronted by TLS.
     add_header Strict-Transport-Security "max-age=31536000" always;
@@ -61,6 +68,7 @@ server {
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-jruAVbleMoklzXIdqjOgmlFQ78IckrHmADK/VuUAO/U='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,11 +19,20 @@ server {
     # a no-op for the HTTP-only container yet hardens deployments fronted by TLS.
     add_header Strict-Transport-Security "max-age=31536000" always;
     # Content-Security-Policy: scoped to what the SPA actually loads.
-    # - script-src allows 'unsafe-inline' for the inline FOUC theme script in index.html
-    #   (the Vite app bundle itself is external under /assets/).
+    # - script-src pins the inline FOUC theme script in index.html by its sha256
+    #   hash instead of allowing 'unsafe-inline'. Dropping 'unsafe-inline' means an
+    #   injected <script> can no longer execute, which is the whole point of the CSP
+    #   for a client-only SPA. The Vite app bundle is external under /assets/ and is
+    #   already covered by 'self'.
+    #   IMPORTANT: the hash covers the exact text content of the <script> block in
+    #   index.html (Vite copies it verbatim into dist/index.html). If that script is
+    #   edited or reformatted, recompute the hash and update BOTH occurrences below:
+    #     node -e "const f=require('fs'),c=require('crypto');const b=f.readFileSync('dist/index.html','utf8').match(/<script>([\s\S]*?)<\/script>/)[1];console.log('sha256-'+c.createHash('sha256').update(b,'utf8').digest('base64'))"
+    #   A stale hash only blocks the theme pre-paint script (brief flash of the wrong
+    #   theme) — the app itself keeps working.
     # - connect-src allows the YouTube Data API; img-src allows YouTube thumbnail CDNs
     #   (i.ytimg.com, *.ggpht.com, *.googleusercontent.com) via the generic https: source.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-jruAVbleMoklzXIdqjOgmlFQ78IckrHmADK/VuUAO/U='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     # Gzip compression for text assets
     gzip on;
@@ -45,6 +54,6 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-jruAVbleMoklzXIdqjOgmlFQ78IckrHmADK/VuUAO/U='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Do not advertise the exact nginx version in the Server header or on the
+    # built-in error pages. Version disclosure hands an attacker a free lookup of
+    # which known nginx CVEs apply to this deployment. "nginx" is still sent as
+    # the Server value, only the version is withheld.
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -58,6 +58,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-jruAVbleMoklzXIdqjOgmlFQ78IckrHmADK/VuUAO/U='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;


### PR DESCRIPTION
## Description

Security hardening sweep of the **web-app surface**. TubeTrend has no backend — the only externally reachable server component is the nginx static host inside the Docker image, so all four fixes land in `nginx.conf`. Each is a mechanical, non-breaking configuration change; no application code was touched.

| # | Kategorie | Severity | Datei:Zeile | Fix |
|---|-----------|----------|-------------|-----|
| 1 | Security Misconfiguration (CSP) | Medium | `nginx.conf:35,57` | Replaced `script-src 'unsafe-inline'` with a pinned `sha256` hash of the single legitimate inline theme script |
| 2 | Sensitive Data Exposure (version disclosure) | Medium | `nginx.conf:8` | `server_tokens off;` — nginx version no longer advertised |
| 3 | Security Misconfiguration (header inheritance) | Low | `nginx.conf:66` | Restored `Permissions-Policy` on `/assets/`, which nginx was silently dropping |
| 4 | Security Misconfiguration (isolation headers) | Low | `nginx.conf:23,70` | Added `Cross-Origin-Resource-Policy: same-origin`, completing the COOP pair from #296 |

### Notes on the CSP change (#1)

Dropping `'unsafe-inline'` from `script-src` is the substantive fix here: for a client-only SPA the CSP *is* the second line of defence against injected scripts, and `'unsafe-inline'` neutralised it. The inline FOUC theme script in `index.html` is now pinned by hash instead.

Verified that Vite copies that script **byte-identically** into `dist/index.html` (no inline minification), so the hash is stable across builds, and the hash was re-checked against a clean rebuild after all commits. The recompute command is documented inline in `nginx.conf` for future edits. A stale hash would only suppress the pre-paint theme script (brief flash of the wrong theme) — it cannot break the app.

Header parity between the server block and the `/assets/` block is now verified: all seven security headers present in both.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no UI strings changed
- [x] Tested locally

## Verification

`npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. This repo has no test runner configured, so no tests were run and none were added.

## Not changed (deliberately)

- **API key transport** (`youtubeApiClient.ts:57-58`) — moving the key from the `?key=` query parameter to the `X-goog-api-key` header would keep the secret out of the request URL, but it triggers CORS preflight on every Data API call and touches the documented key-storage model. Flagged for a manual decision rather than changed autonomously; no leak exists today.
- **`img-src https:`** and **`style-src 'unsafe-inline'`** — narrowing either risks breaking YouTube thumbnails/avatars or Tailwind runtime styles. Deferred with rationale on the issue.

Scope excluded Electron, Capacitor/Android and the Chrome extension — single-user or separate distribution shells, not web-server hardening.

## Related Issues

Refs #295

---
_Generated by [Claude Code](https://claude.ai/code/session_015j32RLAFK9ebyPz3sZoXoR)_