### PR TITLE
chore: quality &amp; housekeeping sweep (Vite + React)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ When a session begins, read in this order. Stop early if a file is missing.
 | "rollback" / "revert" / "undo" / "/rollback"     | `.claude/skills/rollback/SKILL.md`                       |
 | "CI" / "fix CI" / "check the build" / "/ci"      | `.claude/skills/ci/SKILL.md`                             |
 | "stuck" / "loop" / "going in circles" / "/stuck" | `.claude/skills/stuck/SKILL.md`                          |
+| "check dependencies" / "update deps" / "/beacon" | `.claude/skills/beacon/SKILL.md`                         |
 | Diagram request                                  | `agent_docs/diagram_prompt.md` → `docs/ARCHITECTURE.mmd` |
 
 > Review runs via the `review` skill — done-skill does NOT auto-run it. Unresolved findings → `BACKLOG.md` (`agent_docs/backlog_process.md`). Long-term knowledge → `MEMORY.md`, temporary → `SCRATCHPAD.md` (`agent_docs/memory_process.md`).

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Open http://localhost:3000
 | `npm run format`       | Auto-format with Prettier         |
 | `npm run format:check` | Verify formatting (CI-equivalent) |
 
-> **Tests:** No test framework is configured yet. A Vitest setup is planned — see `agent_docs/refactoring_guidelines.md`.
+> **Tests:** No test framework is configured yet. A Vitest setup is planned — see `agent_docs/testing.md`.
 
 ---
 

--- a/agent_docs/project_structure.md
+++ b/agent_docs/project_structure.md
@@ -40,7 +40,7 @@ tubetrend/
 ├── agent_docs/                       # Agent process docs (review, backlog, memory, ADR, MCP, hooks, API ref, refactoring, context budget)
 ├── .claude/
 │   ├── settings.json                 # Tier-1 hooks + trigger permissions
-│   └── skills/                       # done / pr / review / security-review / rollback / ci / stuck / gitnexus/
+│   └── skills/                       # done / pr / review / security-review / rollback / ci / stuck / beacon / gitnexus/
 ├── .github/                          # Workflows + dependabot + templates
 ├── .junie/                           # JetBrains Junie agent guidelines
 ├── capacitor.config.ts               # Capacitor config


### PR DESCRIPTION
Autonomous quality & housekeeping pass over `fo0/tubetrend` (Vite 8 + React 19 + TypeScript SPA). Two documentation findings, both merged here. **Documentation only — no source file, no config and no dependency was touched.**

## Merged findings

| # | Pass | Datei(en) | Befund | Fix | Aufwand | Empfehlung |
|---|------|-----------|--------|-----|---------|------------|
| 1 | E — Docs | `CLAUDE.md`, `agent_docs/project_structure.md` | `.claude/skills/beacon/SKILL.md` exists but appears in no doc: missing from the Workflow Triggers table and from the `.claude/skills/` listing, so its trigger phrases (`/beacon`, "check dependencies", "update deps") are undiscoverable from the primary guide | Added the trigger row + the `beacon` entry in the skills listing | S | auto-fix |
| 2 | E — Docs | `README.md` | The "Tests" note pointed at `agent_docs/refactoring_guidelines.md` for the planned Vitest setup, but that file never mentions Vitest — the recommended framework and the priority targets live in `agent_docs/testing.md`, which is also where `CONTRIBUTING.md` already sends readers | Repointed the note to `agent_docs/testing.md` | S | auto-fix |

Diff: 3 files, +3 / −2 lines.

## Tooling-Status

| Tool | Aktiv | Konfiguriert in | Lief grün |
|------|-------|-----------------|-----------|
| Prettier (`format:check`) | ja | `.prettierrc.json` + `.prettierignore`, `format:check` script | ✅ green (0 drift) |
| TypeScript (`tsc --noEmit`) | ja | `tsconfig.json`, `typecheck` script | ✅ green |
| Build (`vite build`) | ja | `vite.config.ts`, `build` script | ✅ green |
| ESLint / Biome | **nein** | — | n/a — no linter in this repo (deferred, see the issue) |
| Test runner | **nein** | — | n/a — no test framework configured (deferred, see the issue) |

Verification ran the full `CLAUDE.md` gate after all commits: `npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green, working tree clean.

## Deferred (not in this PR)

- **No linter configured** (`L`) — adding ESLint + typescript-eslint + the React plugins is a devDependency, config, script and CI change plus the first round of fixes; out of proportion for this routine.
- **No test framework configured** (`L`) — Vitest setup is already tracked in `agent_docs/testing.md`; this routine does not write tests itself.

Both are documented in the issue.

## Out of scope

**No version bumps.** `package.json` and `package-lock.json` are untouched. Bot-PRs (12 open Dependabot PRs) were not touched, reviewed, merged or closed — they belong to the separate dependency routine.

Closes #343

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9ofyDMpLYgQNfVf5sTsc5)_