### PR TITLE
feat: comfort sweep (Vite + React SPA)

### DIFF
--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Activity, BarChart3, Download, EyeOff, RefreshCw, Trash2, Upload } from "lucide-react";
 import { FavoriteRow } from "@/src/shared/components/ui/FavoriteRow";
 import { FavoriteAvatar } from "@/src/shared/components/ui/FavoriteAvatar";
+import { FavoritesFilter } from "@/src/shared/components/ui/FavoritesFilter";
 import { HighlightVideoCard } from "@/src/shared/components/ui/HighlightVideoCard";
 import { FloatingScrollButton } from "@/src/shared/components/ui/FloatingScrollButton";
 import { useTranslation } from "react-i18next";
@@ -14,6 +15,12 @@ import {
 } from "@/src/features/dashboard";
 import { getLocale } from "@/src/shared/lib/locale";
 import type { DashboardSortMode } from "@/src/shared/types";
+
+/**
+ * Below this many favorites the list fits on screen, so the filter bar would
+ * only add clutter (mirrors FILTER_MIN_ROWS in VideoListTable).
+ */
+const FAVORITES_FILTER_MIN_ROWS = 5;
 
 interface DashboardPageProps {
   favorites: FavoriteConfig[];
@@ -61,10 +68,33 @@ export function DashboardPage({
 }: DashboardPageProps) {
   const { t } = useTranslation();
   const importRef = useRef<HTMLInputElement | null>(null);
+  const [favoriteFilter, setFavoriteFilter] = useState("");
 
   const handleImportPick = () => {
     importRef.current?.click();
   };
+
+  const showFavoriteFilter = favorites.length >= FAVORITES_FILTER_MIN_ROWS;
+  const normalizedFavoriteFilter = showFavoriteFilter ? favoriteFilter.trim().toLowerCase() : "";
+
+  // `null` means "no filter active" — every favorite stays visible. Matching
+  // covers the saved label, the raw query and the resolved channel title from
+  // the cache, so "@mkbhd" and "Marques Brownlee" both find the same row.
+  const matchingFavoriteIds = useMemo<Set<string> | null>(() => {
+    if (!normalizedFavoriteFilter) return null;
+    const ids = new Set<string>();
+    for (const fav of sortedFavorites) {
+      const channelTitle = favoritesService.getCache(fav.id)?.meta?.channelTitle ?? "";
+      const haystack = `${fav.label ?? ""} ${fav.query} ${channelTitle}`.toLowerCase();
+      if (haystack.includes(normalizedFavoriteFilter)) ids.add(fav.id);
+    }
+    return ids;
+    // cacheTick: a refresh can resolve a channel title that was unknown before.
+  }, [sortedFavorites, normalizedFavoriteFilter, cacheTick]);
+
+  const visibleFavorites = matchingFavoriteIds
+    ? sortedFavorites.filter((fav) => matchingFavoriteIds.has(fav.id))
+    : sortedFavorites;
 
   const highlightVideosData = useMemo(() => {
     const raw = selectHighlightVideosFromFavorites(
@@ -313,10 +343,11 @@ export function DashboardPage({
               </button>
             </div>
 
-            {/* Favorite Avatars */}
-            {sortedFavorites.length > 0 && (
+            {/* Favorite Avatars — filtered-out favorites are dropped here too,
+                otherwise their quick-jump would scroll to a hidden row. */}
+            {visibleFavorites.length > 0 && (
               <div className="flex items-center gap-1.5 ml-2 pl-3 border-l border-slate-300 dark:border-slate-700">
-                {sortedFavorites.map((fav) => (
+                {visibleFavorites.map((fav) => (
                   <FavoriteAvatar
                     key={fav.id}
                     favorite={fav}
@@ -371,24 +402,60 @@ export function DashboardPage({
           </button>
         </div>
       ) : (
-        <div className="space-y-10">
-          {sortedFavorites.map((fav, idx) => (
-            // scroll-mt-20 (5rem) clears the sticky header (h-16 = 4rem) plus a
-            // little breathing room. Without it the avatar quick-jump below
-            // aligns the row flush with the viewport top, where the header
-            // covers the favorite's own title — the user lands on a row whose
-            // heading they cannot see.
-            <div key={fav.id} id={`favorite-${fav.id}`} className="scroll-mt-20">
-              <FavoriteRow
-                favorite={fav}
-                onRemove={onRemoveFavorite}
-                onAnalyze={onAnalyzeFavorite}
-                globalRefreshToken={refreshToken}
-                staggerIndex={idx}
-              />
+        <>
+          {showFavoriteFilter && (
+            <FavoritesFilter
+              value={favoriteFilter}
+              onChange={setFavoriteFilter}
+              matchCount={visibleFavorites.length}
+              totalCount={sortedFavorites.length}
+            />
+          )}
+
+          {matchingFavoriteIds && visibleFavorites.length === 0 && (
+            <div className="bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-800 rounded-xl p-8 text-center flex flex-col items-center gap-3">
+              <p className="text-slate-600 dark:text-slate-400">
+                {t("dashboard.filter.noMatches", { query: favoriteFilter.trim() })}
+              </p>
+              <button
+                type="button"
+                onClick={() => setFavoriteFilter("")}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-300 dark:border-slate-700 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+              >
+                {t("dashboard.filter.clear")}
+              </button>
             </div>
-          ))}
-        </div>
+          )}
+
+          <div className="space-y-10">
+            {sortedFavorites.map((fav, idx) => {
+              // Filtered-out rows are hidden, not unmounted: a FavoriteRow
+              // re-fetches from the YouTube API when its cache is stale, so
+              // unmounting on every keystroke would burn API quota.
+              const isVisible = !matchingFavoriteIds || matchingFavoriteIds.has(fav.id);
+              return (
+                // scroll-mt-20 (5rem) clears the sticky header (h-16 = 4rem) plus a
+                // little breathing room. Without it the avatar quick-jump below
+                // aligns the row flush with the viewport top, where the header
+                // covers the favorite's own title — the user lands on a row whose
+                // heading they cannot see.
+                <div
+                  key={fav.id}
+                  id={`favorite-${fav.id}`}
+                  className={isVisible ? "scroll-mt-20" : "hidden"}
+                >
+                  <FavoriteRow
+                    favorite={fav}
+                    onRemove={onRemoveFavorite}
+                    onAnalyze={onAnalyzeFavorite}
+                    globalRefreshToken={refreshToken}
+                    staggerIndex={idx}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </>
       )}
 
       {/* Floating scroll button - subtle, appears based on scroll direction */}

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -11,7 +11,7 @@ import {
   searchVideosByKeyword,
   YouTubeApiError,
 } from "@/src/features/youtube";
-import { CACHE_TTL, STORAGE_KEYS } from "@/src/shared/constants";
+import { CACHE_TTL, STORAGE_KEYS, TIME_FRAMES } from "@/src/shared/constants";
 import { safeRead, safeRemove, safeWrite } from "@/src/shared/lib/storage";
 
 export interface SearchState {
@@ -142,7 +142,13 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
         }
 
         if (apiVideos.length === 0) {
-          throw new Error(`No videos found in time frame "${timeFrame}".`);
+          // Translate the time-frame label here: the catch block only sees the
+          // error, and the raw enum value ("last_month") is not user-facing text.
+          const timeFrameLabelKey = TIME_FRAMES.find((tf) => tf.value === timeFrame)?.labelKey;
+          throw new YouTubeApiError(`No videos found in time frame "${timeFrame}".`, 404, false, {
+            key: "errors.api.noVideosInTimeFrame",
+            params: { timeFrame: timeFrameLabelKey ? t(timeFrameLabelKey) : String(timeFrame) },
+          });
         }
 
         setSearchState((prev) => ({ ...prev, step: "analyzing_ai" }));
@@ -162,7 +168,15 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
         persistResult({ data: analyzedVideos, channelName: displayName, channelId, savedAt });
       } catch (err: unknown) {
         if (import.meta.env.DEV) console.error(err);
-        const errorMessage = err instanceof Error ? err.message : "Analysis failed.";
+        // Services carry an i18n descriptor instead of a ready-made sentence —
+        // resolve it here so the alert speaks the user's language. The raw
+        // message stays the fallback for errors from outside our own layer.
+        const errorMessage =
+          err instanceof YouTubeApiError && err.i18n
+            ? t(err.i18n.key, err.i18n.params)
+            : err instanceof Error
+              ? err.message
+              : t("errors.analysisFailed");
 
         const isApiKeyInvalid =
           err instanceof YouTubeApiError && err.status === 403 && !err.isQuotaError;

--- a/src/features/youtube/services/channelService.ts
+++ b/src/features/youtube/services/channelService.ts
@@ -22,7 +22,7 @@ import type {
   YoutubeVideoListResponse,
 } from "../types";
 
-import { fetchFromApi, getApiKey } from "./youtubeApiClient";
+import { fetchFromApi, getApiKey, YouTubeApiError } from "./youtubeApiClient";
 
 interface AutocompleteCacheEntry {
   results: ChannelSuggestion[];
@@ -263,14 +263,20 @@ export async function findChannelInfo(
   );
 
   if (!searchData.items || searchData.items.length === 0) {
-    throw new Error(`Channel "${channelName}" not found.`);
+    throw new YouTubeApiError(`Channel "${channelName}" not found.`, 404, false, {
+      key: "errors.api.channelNotFound",
+      params: { channel: channelName },
+    });
   }
 
   const firstSnippet = searchData.items[0].snippet;
   const channelId = firstSnippet?.channelId;
   const channelTitle = firstSnippet?.channelTitle;
   if (!channelId || !channelTitle) {
-    throw new Error(`Channel "${channelName}" not found.`);
+    throw new YouTubeApiError(`Channel "${channelName}" not found.`, 404, false, {
+      key: "errors.api.channelNotFound",
+      params: { channel: channelName },
+    });
   }
 
   // Get channel details
@@ -284,12 +290,16 @@ export async function findChannelInfo(
   );
 
   if (!channelDetails.items || channelDetails.items.length === 0) {
-    throw new Error("Channel details could not be loaded.");
+    throw new YouTubeApiError("Channel details could not be loaded.", 502, false, {
+      key: "errors.api.channelDetails",
+    });
   }
 
   const uploadsPlaylistId = channelDetails.items[0].contentDetails?.relatedPlaylists?.uploads;
   if (!uploadsPlaylistId) {
-    throw new Error("Channel details could not be loaded.");
+    throw new YouTubeApiError("Channel details could not be loaded.", 502, false, {
+      key: "errors.api.channelDetails",
+    });
   }
 
   const result: ChannelInfo = {

--- a/src/features/youtube/services/youtubeApiClient.ts
+++ b/src/features/youtube/services/youtubeApiClient.ts
@@ -32,11 +32,23 @@ export function getApiKey(): string {
   }
 }
 
+/**
+ * i18n descriptor carried alongside the technical error message. Services have
+ * no access to `t` (they are not React), so they name the key and the UI layer
+ * resolves it in the active language. The plain `message` stays the developer /
+ * console text and the fallback when a descriptor is missing.
+ */
+export interface ErrorTranslation {
+  readonly key: string;
+  readonly params?: Record<string, string | number>;
+}
+
 export class YouTubeApiError extends Error {
   constructor(
     message: string,
     public readonly status: number,
     public readonly isQuotaError: boolean = false,
+    public readonly i18n?: ErrorTranslation,
   ) {
     super(message);
     this.name = "YouTubeApiError";
@@ -51,7 +63,9 @@ export async function fetchFromApi<T>(
 ): Promise<T> {
   const apiKey = getApiKey();
   if (!apiKey) {
-    throw new YouTubeApiError("YouTube API key missing.", 401);
+    throw new YouTubeApiError("YouTube API key missing.", 401, false, {
+      key: "errors.api.keyMissing",
+    });
   }
 
   const url = new URL(`https://www.googleapis.com/youtube/v3/${endpoint}`);
@@ -71,12 +85,16 @@ export async function fetchFromApi<T>(
       const lower = msg.toLowerCase();
 
       if (lower.includes("api key not valid")) {
-        throw new YouTubeApiError("The provided API key is invalid.", 403);
+        throw new YouTubeApiError("The provided API key is invalid.", 403, false, {
+          key: "errors.apiKeyInvalid",
+        });
       }
 
       if (lower.includes("quota")) {
         quotaService.markExhausted();
-        throw new YouTubeApiError("YouTube API quota exceeded.", 403, true);
+        throw new YouTubeApiError("YouTube API quota exceeded.", 403, true, {
+          key: "errors.api.quotaExceeded",
+        });
       }
 
       // 4xx errors still cost quota
@@ -87,6 +105,10 @@ export async function fetchFromApi<T>(
       throw new YouTubeApiError(
         msg ? `YouTube API error: ${msg}` : `YouTube API error (${response.status})`,
         response.status,
+        false,
+        msg
+          ? { key: "errors.api.generic", params: { message: msg } }
+          : { key: "errors.api.genericStatus", params: { status: response.status } },
       );
     }
 
@@ -94,11 +116,16 @@ export async function fetchFromApi<T>(
       quotaService.track(cost, endpoint, context);
     }
 
-    throw new YouTubeApiError(`HTTP error: ${response.status}`, response.status);
+    throw new YouTubeApiError(`HTTP error: ${response.status}`, response.status, false, {
+      key: "errors.api.http",
+      params: { status: response.status },
+    });
   }
 
   if (data === null) {
-    throw new YouTubeApiError("Invalid response from YouTube API.", response.status);
+    throw new YouTubeApiError("Invalid response from YouTube API.", response.status, false, {
+      key: "errors.api.invalidResponse",
+    });
   }
 
   // Track successful request

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -184,6 +184,7 @@
       "urlCopied": "Video-URL kopiert",
       "titleCopied": "Videotitel kopiert",
       "copyFailed": "Zwischenablage nicht verfügbar",
+      "sortBy": "Nach {{column}} sortieren",
       "filterPlaceholder": "Nach Titel filtern…",
       "filterAria": "Videos nach Titel filtern",
       "filterClear": "Filter zurücksetzen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -128,6 +128,14 @@
       "delete": "Löschen",
       "empty": "Noch keine Highlights verfügbar. Highlights erscheinen, sobald deine Favoriten Videos geladen haben."
     },
+    "filter": {
+      "placeholder": "Favoriten filtern…",
+      "aria": "Favoriten nach Name filtern",
+      "clear": "Filter zurücksetzen",
+      "count_one": "{{count}} von {{total}} angezeigt",
+      "count_other": "{{count}} von {{total}} angezeigt",
+      "noMatches": "Kein Favorit passt zu \"{{query}}\"."
+    },
     "sorting": {
       "label": "Sortierung:",
       "alphaTitle": "Alphabetisch sortieren (erneut klicken: Reihenfolge umkehren)",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -259,8 +259,20 @@
   "errors": {
     "apiKeyInvalid": "Der API-Schlüssel scheint ungültig zu sein. Bitte überprüfe ihn.",
     "favoriteLoad": "Fehler beim Laden der Favoriten-Daten.",
+    "analysisFailed": "Analyse fehlgeschlagen. Bitte versuche es erneut.",
     "somethingWentWrong": "Etwas ist schiefgelaufen",
-    "tryAgain": "Erneut versuchen"
+    "tryAgain": "Erneut versuchen",
+    "api": {
+      "keyMissing": "Kein YouTube-API-Schlüssel hinterlegt. Trage deinen Schlüssel ein, um zu suchen.",
+      "quotaExceeded": "Das tägliche YouTube-API-Kontingent ist aufgebraucht. Reset um Mitternacht Pacific Time.",
+      "channelNotFound": "Kein YouTube-Kanal zu \"{{channel}}\" gefunden. Prüfe den Namen oder das @Handle.",
+      "channelDetails": "Der Kanal wurde gefunden, aber YouTube hat keine Videoliste geliefert. Bitte versuche es erneut.",
+      "noVideosInTimeFrame": "Im gewählten Zeitraum ({{timeFrame}}) wurden keine Videos veröffentlicht. Wähle einen längeren Zeitraum.",
+      "invalidResponse": "YouTube hat eine unlesbare Antwort geliefert. Bitte versuche es erneut.",
+      "http": "YouTube ist gerade nicht erreichbar (HTTP {{status}}). Prüfe deine Verbindung und versuche es erneut.",
+      "generic": "YouTube-API-Fehler: {{message}}",
+      "genericStatus": "YouTube-API-Fehler (HTTP {{status}})."
+    }
   },
   "loading": "Lädt…",
   "loadingState": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -184,6 +184,7 @@
       "urlCopied": "Video URL copied",
       "titleCopied": "Video title copied",
       "copyFailed": "Clipboard unavailable",
+      "sortBy": "Sort by {{column}}",
       "filterPlaceholder": "Filter by title…",
       "filterAria": "Filter videos by title",
       "filterClear": "Clear filter",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -128,6 +128,14 @@
       "delete": "Delete",
       "empty": "No highlights available yet. Highlights will appear once your favorites have loaded videos."
     },
+    "filter": {
+      "placeholder": "Filter favorites…",
+      "aria": "Filter favorites by name",
+      "clear": "Clear filter",
+      "count_one": "{{count}} of {{total}} shown",
+      "count_other": "{{count}} of {{total}} shown",
+      "noMatches": "No favorite matches \"{{query}}\"."
+    },
     "sorting": {
       "label": "Sorting:",
       "alphaTitle": "Sort alphabetically (click again to reverse order)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -259,8 +259,20 @@
   "errors": {
     "apiKeyInvalid": "The API key appears to be invalid. Please check it.",
     "favoriteLoad": "Failed to load favorite data.",
+    "analysisFailed": "Analysis failed. Please try again.",
     "somethingWentWrong": "Something went wrong",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "api": {
+      "keyMissing": "No YouTube API key configured. Add your key to start searching.",
+      "quotaExceeded": "Daily YouTube API quota used up. It resets at midnight Pacific Time.",
+      "channelNotFound": "No YouTube channel found for \"{{channel}}\". Check the name or @handle.",
+      "channelDetails": "The channel was found, but YouTube did not return its video list. Please try again.",
+      "noVideosInTimeFrame": "No videos published in the selected time frame ({{timeFrame}}). Try a longer one.",
+      "invalidResponse": "YouTube returned an unreadable response. Please try again.",
+      "http": "YouTube is not reachable right now (HTTP {{status}}). Check your connection and try again.",
+      "generic": "YouTube API error: {{message}}",
+      "genericStatus": "YouTube API error (HTTP {{status}})."
+    }
   },
   "loading": "Loading…",
   "loadingState": {

--- a/src/shared/components/ui/FavoritesFilter.tsx
+++ b/src/shared/components/ui/FavoritesFilter.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Search, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface FavoritesFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Favorites currently passing the filter. */
+  matchCount: number;
+  /** Favorites in the unfiltered list. */
+  totalCount: number;
+}
+
+/**
+ * Compact name filter for the dashboard favorites list. Purely presentational —
+ * the dashboard owns the filter value so the rows and this bar can never drift
+ * apart (mirrors VideoListFilter on the analyser page).
+ */
+export const FavoritesFilter: React.FC<FavoritesFilterProps> = ({
+  value,
+  onChange,
+  matchCount,
+  totalCount,
+}) => {
+  const { t } = useTranslation();
+  const isFiltering = value.trim().length > 0;
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-4">
+      <div className="relative flex-1 min-w-0">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <Search className="w-4 h-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
+        </div>
+        <input
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={t("dashboard.filter.placeholder")}
+          aria-label={t("dashboard.filter.aria")}
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="block w-full pl-9 pr-9 py-2 text-sm bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 transition-all [&::-webkit-search-cancel-button]:hidden"
+        />
+        {isFiltering && (
+          <button
+            type="button"
+            onClick={() => onChange("")}
+            title={t("dashboard.filter.clear")}
+            aria-label={t("dashboard.filter.clear")}
+            className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-400 dark:text-slate-600 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      {isFiltering && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap sm:pl-2"
+        >
+          {t("dashboard.filter.count", { count: matchCount, total: totalCount })}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/shared/components/ui/VideoListSortHeader.tsx
+++ b/src/shared/components/ui/VideoListSortHeader.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { VideoData } from "@/src/features/videos";
+
+/**
+ * Sorting primitives for the analyser result table: the column contract, the
+ * numeric comparator and the clickable header cell. Kept beside the table so
+ * VideoListTable stays within the file-size guideline.
+ */
+
+export type TableSortKey = "rank" | "upload" | "views" | "velocity" | "engagement" | "score";
+export type SortDirection = "asc" | "desc";
+
+export interface TableSort {
+  key: TableSortKey;
+  dir: SortDirection;
+}
+
+/** Rank ascending reproduces the order the analyser handed the rows over in. */
+export const DEFAULT_TABLE_SORT: TableSort = { key: "rank", dir: "asc" };
+
+/** Direction a column starts in on its first click — biggest/newest first. */
+export const NATURAL_DIRECTION: Record<TableSortKey, SortDirection> = {
+  rank: "asc",
+  upload: "desc",
+  views: "desc",
+  velocity: "desc",
+  engagement: "desc",
+  score: "desc",
+};
+
+/** Guard for the persisted value — storage is untrusted input. */
+export function isTableSort(value: unknown): value is TableSort {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.key === "string" && v.key in NATURAL_DIRECTION && (v.dir === "asc" || v.dir === "desc")
+  );
+}
+
+/**
+ * Numeric sort key for a column. Missing optional metrics sort below zero so
+ * they end up last on a descending sort instead of tying with a real 0.
+ */
+export function sortValue(video: VideoData, rank: number, key: TableSortKey): number {
+  switch (key) {
+    case "upload":
+      return video.publishedTimestamp;
+    case "views":
+      return video.views;
+    case "velocity":
+      return Number.isFinite(Number(video.viewsPerHour)) ? Number(video.viewsPerHour) : -1;
+    case "engagement":
+      return video.engagementRate ?? -1;
+    case "score":
+      return video.trendingScore;
+    case "rank":
+    default:
+      return rank;
+  }
+}
+
+const ALIGN_CLASS: Record<"left" | "center" | "right", string> = {
+  left: "justify-start",
+  center: "justify-center",
+  right: "justify-end",
+};
+
+interface SortableHeaderProps {
+  sortKey: TableSortKey;
+  /** Visible column label — also the accessible name of the sort button. */
+  label: string;
+  activeSort: TableSort;
+  onSort: (key: TableSortKey) => void;
+  /** Width / responsive-visibility classes for the <th> itself. */
+  thClassName?: string;
+  align?: "left" | "center" | "right";
+  /** Overrides the button tooltip (used to keep the score explanation). */
+  title?: string;
+}
+
+/**
+ * Column header that sorts the table. `aria-sort` on the <th> carries the
+ * current state to assistive tech; the arrow icon carries it visually.
+ */
+export const SortableHeader: React.FC<SortableHeaderProps> = ({
+  sortKey,
+  label,
+  activeSort,
+  onSort,
+  thClassName = "",
+  align = "left",
+  title,
+}) => {
+  const { t } = useTranslation();
+  const isActive = activeSort.key === sortKey;
+  const Icon = !isActive ? ArrowUpDown : activeSort.dir === "asc" ? ArrowUp : ArrowDown;
+
+  return (
+    <th
+      scope="col"
+      className={`p-0 ${thClassName}`}
+      aria-sort={isActive ? (activeSort.dir === "asc" ? "ascending" : "descending") : "none"}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        title={title ?? t("results.table.sortBy", { column: label })}
+        aria-label={t("results.table.sortBy", { column: label })}
+        className={`w-full p-4 inline-flex items-center gap-1.5 uppercase tracking-wider font-semibold transition-colors hover:text-slate-700 dark:hover:text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 ${
+          ALIGN_CLASS[align]
+        } ${isActive ? "text-slate-700 dark:text-slate-200" : ""}`}
+      >
+        <span>{label}</span>
+        <Icon
+          className={`w-3 h-3 shrink-0 ${isActive ? "opacity-100" : "opacity-40"}`}
+          aria-hidden="true"
+        />
+      </button>
+    </th>
+  );
+};

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -4,6 +4,16 @@ import { AlertCircle, Check, Clock, Copy, ExternalLink, Heart, Type } from "luci
 import { useTranslation } from "react-i18next";
 import { formatNumber, formatTimeAgo } from "@/src/shared/lib/formatters";
 import { VideoListFilter } from "@/src/shared/components/ui/VideoListFilter";
+import {
+  DEFAULT_TABLE_SORT,
+  isTableSort,
+  NATURAL_DIRECTION,
+  SortableHeader,
+  sortValue,
+} from "@/src/shared/components/ui/VideoListSortHeader";
+import type { TableSort, TableSortKey } from "@/src/shared/components/ui/VideoListSortHeader";
+import { STORAGE_KEYS } from "@/src/shared/constants";
+import { safeRead, safeWrite } from "@/src/shared/lib/storage";
 
 /**
  * Below this many rows the list is short enough to scan by eye, so the filter
@@ -82,22 +92,52 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
     );
   };
 
-  // Rank is assigned before filtering, so a row keeps its position in the full
-  // result set ("#42") instead of being renumbered inside the filtered view.
+  // Rank is assigned before sorting/filtering, so a row keeps its position in
+  // the full result set ("#42") instead of being renumbered inside the view.
   const rankedVideos = useMemo(
     () => videos.map((video, index) => ({ video, rank: startIndex + index })),
     [videos, startIndex],
   );
 
+  // Column sort, persisted so the preferred view survives a reload.
+  const [sort, setSort] = useState<TableSort>(() => {
+    const stored = safeRead<unknown>(STORAGE_KEYS.ANALYSER_TABLE_SORT, null);
+    return isTableSort(stored) ? stored : DEFAULT_TABLE_SORT;
+  });
+
+  useEffect(() => {
+    safeWrite(STORAGE_KEYS.ANALYSER_TABLE_SORT, sort);
+  }, [sort]);
+
+  /** Click a column: activate it in its natural direction, or flip it. */
+  const handleSort = (key: TableSortKey) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: NATURAL_DIRECTION[key] },
+    );
+  };
+
+  const sortedVideos = useMemo(() => {
+    const factor = sort.dir === "asc" ? 1 : -1;
+    return [...rankedVideos].sort((a, b) => {
+      const av = sortValue(a.video, a.rank, sort.key);
+      const bv = sortValue(b.video, b.rank, sort.key);
+      if (av !== bv) return (av - bv) * factor;
+      // Stable tie-break: fall back to the original result order.
+      return a.rank - b.rank;
+    });
+  }, [rankedVideos, sort]);
+
   const showFilter = videos.length >= FILTER_MIN_ROWS;
   const normalizedFilter = filter.trim().toLowerCase();
 
   const visibleVideos = useMemo(() => {
-    if (!showFilter || !normalizedFilter) return rankedVideos;
-    return rankedVideos.filter((entry) =>
+    if (!showFilter || !normalizedFilter) return sortedVideos;
+    return sortedVideos.filter((entry) =>
       entry.video.title.toLowerCase().includes(normalizedFilter),
     );
-  }, [rankedVideos, showFilter, normalizedFilter]);
+  }, [sortedVideos, showFilter, normalizedFilter]);
 
   const getScoreColor = (score: number) => {
     if (score >= 80) return "text-red-400 bg-red-400/10 border-red-400/20";
@@ -130,29 +170,55 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
         <table className="w-full text-left border-collapse" aria-label={t("results.moreVideos")}>
           <thead>
             <tr className="bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800 text-xs uppercase tracking-wider text-slate-500 font-semibold">
-              <th scope="col" className="p-4 w-16 text-center">
-                {t("results.table.rank")}
-              </th>
+              <SortableHeader
+                sortKey="rank"
+                label={t("results.table.rank")}
+                activeSort={sort}
+                onSort={handleSort}
+                thClassName="w-16"
+                align="center"
+              />
               <th scope="col" className="p-4">
                 {t("results.table.video")}
               </th>
-              <th scope="col" className="p-4 hidden sm:table-cell">
-                {t("results.table.upload")}
-              </th>
-              <th scope="col" className="p-4 text-right">
-                {t("results.table.views")}
-              </th>
-              <th scope="col" className="p-4 text-right hidden md:table-cell">
-                {t("results.table.velocity")}
-              </th>
-              <th scope="col" className="p-4 text-right hidden lg:table-cell">
-                {t("results.table.engagement")}
-              </th>
-              <th scope="col" className="p-4 text-center">
-                <span className="cursor-help" title={t("results.table.scoreTooltip")}>
-                  {t("results.table.score")}
-                </span>
-              </th>
+              <SortableHeader
+                sortKey="upload"
+                label={t("results.table.upload")}
+                activeSort={sort}
+                onSort={handleSort}
+                thClassName="hidden sm:table-cell"
+              />
+              <SortableHeader
+                sortKey="views"
+                label={t("results.table.views")}
+                activeSort={sort}
+                onSort={handleSort}
+                align="right"
+              />
+              <SortableHeader
+                sortKey="velocity"
+                label={t("results.table.velocity")}
+                activeSort={sort}
+                onSort={handleSort}
+                thClassName="hidden md:table-cell"
+                align="right"
+              />
+              <SortableHeader
+                sortKey="engagement"
+                label={t("results.table.engagement")}
+                activeSort={sort}
+                onSort={handleSort}
+                thClassName="hidden lg:table-cell"
+                align="right"
+              />
+              <SortableHeader
+                sortKey="score"
+                label={t("results.table.score")}
+                activeSort={sort}
+                onSort={handleSort}
+                align="center"
+                title={t("results.table.scoreTooltip")}
+              />
               <th scope="col" className="p-4 w-16 text-center">
                 <span className="sr-only">{t("results.table.copyUrl")}</span>
               </th>

--- a/src/shared/constants/config.ts
+++ b/src/shared/constants/config.ts
@@ -20,6 +20,7 @@ export const STORAGE_KEYS = {
   HIDDEN_HIGHLIGHTS: "tt.dashboard.hiddenHighlights.v1",
   ANALYSER_SORT_MODE: "tt.analyser.sortMode",
   ANALYSER_TOP_N: "tt.analyser.topN",
+  ANALYSER_TABLE_SORT: "tt.analyser.tableSort.v1",
   ANALYSER_LAST_RESULT: "tt.analyser.lastResult.v1",
   ACTIVE_PAGE: "tt.activePage",
   THEME: "tt.theme",


### PR DESCRIPTION
Three small, self-contained comfort/quality improvements found by reading the app end to end. One commit per feature, no dependency changes, no refactor-only diffs.

| # | Area / file | Category | Feature | User benefit | Effort |
|---|---|---|---|---|---|
| 1 | `app/routes/DashboardPage.tsx`, `ui/FavoritesFilter.tsx` | Comfort | Quick filter for the favorites list (from 5 favorites up), matching label, raw query and cached channel title | Long dashboards stop being a scroll hunt; `@mkbhd` and `Marques Brownlee` find the same row. Filtered rows are hidden rather than unmounted, so filtering never re-triggers a YouTube fetch and never costs API quota | M |
| 2 | `ui/VideoListTable.tsx`, `ui/VideoListSortHeader.tsx` | Comfort | Sortable result-table columns (rank, upload, views, velocity, engagement, score), persisted through the storage adapter | The table showed five metrics but could only be ordered by the global trend/views toggle. First click sorts in the column's natural direction, second flips it; rank stays the position in the full result set and doubles as the stable tie-break; `aria-sort` reports the state to assistive tech | M |
| 3 | `youtube/services/youtubeApiClient.ts`, `channelService.ts`, `search/hooks/useSearch.ts` | Quality | Analyser errors resolved through i18n instead of hardcoded English, with actionable wording | Failures printed English regardless of language (`Channel "x" not found.`, `No videos found in time frame "last_month"` — the raw enum was never user-facing). The quota error now names the midnight-PT reset, channel-not-found points at the @handle, an empty time frame suggests widening it | M |

**Implementation note (#3):** `YouTubeApiError` gained an optional i18n descriptor (`key` + `params`). Services are not React and have no access to `t`, so they name the key and `useSearch` resolves it. Errors originating outside our own layer still fall back to their raw message, and the existing invalid-API-key branch is unchanged.

All new UI strings were added to both the `en` and `de` bundles.

## Verification

`npm ci` → `npm run format` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. No test runner is configured in this repo (see `agent_docs/testing.md`), so there are no tests to run.

Closes #346

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01DX5Qt6ju68WnNmDregFfxE)_