### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Open http://localhost:3000
 | `npm run format`       | Auto-format with Prettier         |
 | `npm run format:check` | Verify formatting (CI-equivalent) |
 
+> **Platform build scripts** (`electron:*`, `build:win`, `build:chromebook`, `cap:*`,
+> `build:extension`) are not listed above — they belong to Options 3–5. The complete list with
+> descriptions is in [`agent_docs/platform_builds.md`](agent_docs/platform_builds.md).
+
 > **Tests:** No test framework is configured yet. A Vitest setup is planned — see `agent_docs/testing.md`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ docker run -d -p 8889:80 ghcr.io/fo0/tubetrend:latest
 
 Open http://localhost:8889
 
+To build the image from source instead:
+
+```bash
+git clone https://github.com/fo0/tubetrend.git
+cd tubetrend
+docker build --build-arg GIT_COMMIT_HASH="$(git rev-parse HEAD)" \
+             --build-arg GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
+             -t tubetrend .
+docker run -d -p 8889:80 tubetrend
+```
+
+The two `--build-arg` values only stamp the build-info footer — omit them and they default to
+`unknown`. A third arg, `NODE_VERSION` (default `22-alpine`), selects the builder base image. The
+container serves the static build through Nginx on port `80` and reads **no** environment variables
+at runtime. Full build-arg table: [`agent_docs/env-vars.md`](agent_docs/env-vars.md).
+
 ### Option 2: Docker Compose
 
 **Linux / macOS:**

--- a/agent_docs/platform_builds.md
+++ b/agent_docs/platform_builds.md
@@ -16,8 +16,12 @@ npm run build:win         # Build + package Windows portable
 
 # Capacitor (Android APK for ChromeOS)
 npm run cap:sync          # Build + sync to Android project
+npm run cap:open          # Open android/ in Android Studio (no build)
 npm run cap:build         # Build + sync + assemble release APK
 npm run cap:build:debug   # Build + sync + assemble debug APK
+
+# Electron icon generation (invoked by electron:dist / build:chromebook)
+npm run electron:icon     # Regenerate build/icon.png via scripts/generate-icon.mjs
 
 # Chrome Extension
 npm run build:extension   # Build to dist-extension/

--- a/agent_docs/project_structure.md
+++ b/agent_docs/project_structure.md
@@ -28,6 +28,7 @@ tubetrend/
 │   ├── providers/                    # React context providers (ThemeProvider)
 │   ├── i18n/                         # Internationalization (en, de + 11 fallbacks)
 │   ├── styles/                       # Global CSS (themes, scrollbars, animations)
+│   ├── assets/                       # Bundled static assets (icon.svg)
 │   └── main.tsx                      # React entry point
 ├── android/                          # Capacitor Android project (ChromeOS APK)
 ├── chrome-extension/                 # Chrome Extension source files (Manifest V3)
@@ -42,12 +43,21 @@ tubetrend/
 │   ├── settings.json                 # Tier-1 hooks + trigger permissions
 │   └── skills/                       # done / pr / review / security-review / rollback / ci / stuck / beacon / gitnexus/
 ├── .github/                          # Workflows + dependabot + templates
+├── index.html / index.css            # Vite HTML entry + theme base styles
 ├── capacitor.config.ts               # Capacitor config
 ├── vite.config.ts                    # Vite config
 ├── tsconfig.json                     # TypeScript strict config with path aliases
+├── electron-builder.json             # electron-builder targets (win/mac/linux → release/)
+├── electron-builder.chromebook.json  # electron-builder .deb targets (x64/arm64)
 ├── Dockerfile / docker-compose.yml   # Container build + run
+├── nginx.conf                        # Nginx config baked into the runtime image
 └── README.md / CONTRIBUTING.md / SECURITY.md / LICENSE
 ```
+
+> Root config files map 1:1 to the build channels: `electron-builder*.json` are consumed by the
+> `electron:dist` / `build:win` / `build:chromebook` scripts, `nginx.conf` is copied into the runner
+> stage by the `Dockerfile`, and `capacitor.config.ts` drives the `cap:*` scripts. Per-channel
+> behaviour: `agent_docs/platform_builds.md`.
 
 ## Feature Module Pattern
 


### PR DESCRIPTION
## Description

Autonomous repo-quality-maintenance sweep (2026-08-03). Three additive documentation fixes for forgotten repo artefacts. **Documentation only — 34 insertions, 0 deletions, 3 `.md` files.** No runtime config, no secrets, no functional code.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Findings

| # | Pass | Datei | Befund | Fix | Aufwand | Empfehlung |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | D (README) | `README.md` | Options 3–6 each document a from-source build; Option 1 (Docker, the *recommended* channel) only documented consuming the published GHCR image. | `docker build` invocation with the two git build args the `Dockerfile` declares, the `NODE_VERSION` arg, the "reads no env vars at runtime" note, pointer to `agent_docs/env-vars.md`. | S | auto-fix |
| 2 | D (README) | `README.md`, `agent_docs/platform_builds.md` | "Available scripts" table covers 6 of 17 `package.json` scripts with no pointer to the rest; `cap:open` and `electron:icon` were documented nowhere. | Pointer note under the table + the two missing rows in the canonical platform-script list. | S | auto-fix |
| 3 | B (Config-Doku) | `agent_docs/project_structure.md` | `electron-builder.json`, `electron-builder.chromebook.json`, `nginx.conf` are active configs consumed by npm scripts / the `Dockerfile` but absent from the structure tree; `index.html`, `index.css`, `src/assets/` missing too. | Added the entries + one line mapping each root config to its build channel. | S | auto-fix |

## Artefakt-Status

| Artefakt | Vorhanden | Vollständig |
| --- | --- | --- |
| `.env.example` | yes | yes — all 5 code-referenced keys documented, no orphans |
| Config example (`*.example.*`) | n/a | n/a — no user-supplied config exists |
| README onboarding | yes | no → fixed by findings 1 + 2 |
| Referenced docs | yes | yes — all 36 referenced paths exist, no stubs |
| `BACKLOG.md` | yes | yes — `Open` table empty, Pass F produced no finding |

## Backlog-Aufarbeitung

Pass F ran and produced no changes: `BACKLOG.md → Open` is empty; `Done` / `Obsolete` are historical records. **0 entries removed, 0 extracted to issues, 0 consolidated.** No backlog-extracted issue numbers.

## Verification

- Whitelist diff check: all 3 changed paths are `.md` — no runtime artefact, no source file.
- `npx prettier --check` on all three edited files: clean.
- No JSON/YAML example changed → no syntax check needed. No source/code-config touched → `tsc --noEmit` not applicable.
- Secret heuristic scan over all added lines: no matches.

`pr-checks.yml` has `paths-ignore: **.md, docs/**` — a docs-only PR legitimately produces zero check runs; that is configuration, not breakage.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable) — n/a, no UI change
- [x] Tested locally (Prettier check on the changed files)

## Related Issues

Closes #348

---
_Generated by [Claude Code](https://claude.ai/code/session_01PW4HA1bqk5AxSVx4qoSfB9)_