### PR TITLE
refactor: best-practice sweep (Vite + React + TypeScript)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Build-context exclusions for the Dockerfile's `COPY . .`.
+#
+# Two reasons this file matters:
+#   1. Reproducibility — without it the build context carries `.git`, so the
+#      in-container `git rev-parse` in vite.config.ts sees a repo and competes
+#      with the GIT_COMMIT_HASH / GIT_BRANCH build args CI passes in.
+#   2. Speed — a host `node_modules/` or `android/` tree would be uploaded to
+#      the daemon and then copied over the `npm ci` layer.
+#
+# Only paths the web build (`npm run build`) does not read are listed. Keep
+# index.html, index.css, src/, vite.config.ts, tsconfig.json and package*.json
+# out of this list — the build needs them.
+
+# VCS + CI
+.git
+.gitignore
+.git-blame-ignore-revs
+.github
+.gitlab-ci.yml
+
+# Dependencies and build output
+node_modules
+dist
+dist-ssr
+dist-electron
+dist-extension
+release
+release-chromebook
+*.tsbuildinfo
+
+# Other distribution targets (not part of the web/Docker build)
+android
+build
+
+# Local environment files — never bake secrets into an image layer
+.env
+.env.local
+.env.*.local
+
+# Docker's own files
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker-compose.override.yml
+
+# Docs and agent tooling
+docs
+agent_docs
+.claude
+.junie
+.gitnexus
+*.md
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+*.log

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -7,7 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { STORAGE_KEYS } from "@shared/constants";
+import { STORAGE_KEYS } from "@/src/shared/constants";
 
 type Theme = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";

--- a/src/shared/lib/dateUtils.ts
+++ b/src/shared/lib/dateUtils.ts
@@ -20,11 +20,22 @@ export function getTodayDateString(): string {
 }
 
 /**
- * Get a date N months ago
+ * Get a date N months ago.
+ *
+ * `setMonth` alone overflows when the current day does not exist in the target
+ * month: on 2026-03-31, `setMonth(month - 1)` asks for "2026-02-31" and JS rolls
+ * it forward to 2026-03-03 — the cutoff would land *after* the intended one and
+ * silently shrink every LAST_*_MONTHS time frame on the 29th–31st of a month.
+ * Pinning the day to 1 before shifting the month, then clamping to the target
+ * month's last day, keeps the result inside the intended month.
  */
 export function getDateMonthsAgo(n: number): Date {
   const d = new Date();
+  const day = d.getDate();
+  d.setDate(1);
   d.setMonth(d.getMonth() - n);
+  const lastDayOfTargetMonth = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+  d.setDate(Math.min(day, lastDayOfTargetMonth));
   return d;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,17 +9,35 @@ import { execSync } from "child_process";
 // This keeps the web app (dev server, Docker build) completely unaffected.
 const isElectron = process.env.ELECTRON === "true";
 
-// Get build information
-function getBuildInfo() {
-  let commitHash = process.env.VITE_GIT_COMMIT_HASH || "unknown";
-  let branch = process.env.VITE_GIT_BRANCH || "unknown";
+// Explicitly provided build info wins over local git detection. The Dockerfile
+// passes the CI-supplied GIT_COMMIT_HASH / GIT_BRANCH build args through as
+// these env vars, and its `COPY . .` may drag a `.git` directory into the build
+// context — so shelling out unconditionally would silently discard what CI said
+// the build is. "unknown" is the Dockerfile's ARG default, i.e. "not provided".
+function fromEnv(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed !== "unknown" ? trimmed : null;
+}
 
+// stderr is discarded so a non-git build context does not print
+// "fatal: not a git repository" into the build log.
+function gitOutput(command: string): string | null {
   try {
-    commitHash = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
-    branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf-8" }).trim();
+    return execSync(command, { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
   } catch {
     // Not a git repo or git not available
+    return null;
   }
+}
+
+// Get build information
+function getBuildInfo() {
+  const commitHash =
+    fromEnv(process.env.VITE_GIT_COMMIT_HASH) ?? gitOutput("git rev-parse HEAD") ?? "unknown";
+  const branch =
+    fromEnv(process.env.VITE_GIT_BRANCH) ??
+    gitOutput("git rev-parse --abbrev-ref HEAD") ??
+    "unknown";
 
   const now = new Date();
   const version =


### PR DESCRIPTION
## Description

Best-practice sweep over the Vite + React + TypeScript SPA. Four behaviour-preserving fixes, one commit each. Two are genuine correctness bugs (date arithmetic, build-info precedence), one is Docker build hygiene, one is a convention outlier.

| #   | Datei                            | Kategorie       | Befund                                                                                                                                    | Fix                                                                                                    | Aufwand | Empfehlung |
| --- | -------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ---------- |
| 1   | `src/shared/lib/dateUtils.ts`     | Correctness     | `getDateMonthsAgo` used a bare `setMonth(month - n)` — 2026-03-31 minus 1 month rolled forward to 2026-03-03 instead of 2026-02-28.        | Pin the day to 1 before shifting the month, then clamp to the target month's last day.                     | S       | auto-fix   |
| 2   | `vite.config.ts`                  | Correctness     | `VITE_GIT_COMMIT_HASH` / `VITE_GIT_BRANCH` were seeded and then unconditionally overwritten by `git rev-parse`, so the override never won. | Env first (`unknown` = the Dockerfile ARG default = not provided), git as fallback; git stderr discarded.   | S       | auto-fix   |
| 3   | `.dockerignore` (new)             | Performance     | `COPY . .` with no ignore file pulled `.git`, host `node_modules/`, `android/`, `release*/`, docs and agent tooling into the build context. | Add a `.dockerignore` listing only what `npm run build` does not read.                                      | S       | auto-fix   |
| 4   | `src/providers/ThemeProvider.tsx` | Maintainability | The single file importing through the legacy `@shared/*` alias, against the `@/src/…` convention in CLAUDE.md.                             | Switch that one import to `@/src/shared/constants`.                                                        | S       | auto-fix   |

Findings 1 and 2 fix real misbehaviour: the month-overflow made every `LAST_*_MONTHS` time frame (and the `publishedAfter` API parameter derived from it) cover a shorter window whenever the app ran on the 29th–31st, and the build stamp could come from a `.git` copied into the image instead of from the CI build args.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — no UI strings touched
- [x] Tested locally

Verification after all four commits: `npm run format:check` → `npm run typecheck` → `npm run build`, all green. No test runner is configured in this repo, so no test gate ran. Finding 1 was additionally checked against a standalone date-arithmetic harness (2026-03-31, 2026-01-31, 2026-05-31, 2026-12-31 and non-overflowing control dates).

Deferred items (Chrome-extension `tabs` permission, `AbortController` wiring, oversized components, `P1DT…` duration parsing) are documented in the issue comment.

## Related Issues

Closes #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRjcnMRoobLudTb7BDA15a)_