### PR TITLE
fix(extension): declare tabs permission so the focus-existing path works

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -18,5 +18,6 @@
   },
   "background": {
     "service_worker": "background.js"
-  }
+  },
+  "permissions": ["tabs"]
 }


### PR DESCRIPTION
Resolves the Spike deferred from #185 — the finding flagged that the extension's "focus the existing tab" path probably never fires, and asked for real-browser verification before changing anything. That verification is done and the finding is confirmed.

## Problem

`chrome-extension/background.js` dedupes on `tab.url`:

```js
const tabs = await chrome.tabs.query({});
const existing = tabs.find((tab) => tab.url && tab.url.startsWith(extensionUrl));
```

MV3 strips `url` / `title` / `favIconUrl` from `tabs.query` results unless the extension declares the `tabs` permission or holds a matching host permission — and a host permission is not expressible for `chrome-extension://` URLs, so there is no way around it. The manifest declared no `permissions` at all, so `tab.url` was `undefined` for **every** tab including the extension's own page, `find()` never matched, and each toolbar click opened another TubeTrend tab.

## Change

| Datei | Änderung | Aufwand |
| --- | --- | --- |
| `chrome-extension/manifest.json` | Add `"permissions": ["tabs"]` | S |

No code change — `background.js` already implements the intended behaviour correctly and only lacked the permission to observe it.

## Verification

Built the real bundle (`npm run build:extension`) and loaded `dist-extension/` in Chromium, once with the permission and once with it stripped, driving the exact listener body from `background.js` twice:

| Variante | Klick 1 | Klick 2 | TubeTrend-Tabs | Ergebnis |
| --- | --- | --- | --- | --- |
| ohne `tabs` (Ist-Zustand) | `created-new` | `created-new` | 2 | dedupe broken |
| mit `tabs` (dieser PR) | `created-new` | `focused-existing` | 1 | dedupe works |

Also confirmed separately that `tab.url` is `undefined` even for the extension's own page without the permission — there is no own-page exemption.

Repo chain: `npm run format:check`, `npm run typecheck`, `npm run build` — all clean.

## Trade-off

`tabs` triggers the "Read your browsing history" warning on install. That is the cost of this feature working at all; the alternative is dropping the dedupe branch and always opening a new tab. Flagging it explicitly since it changes the install prompt — reverting is a one-line change if the warning is not worth it.

Refs #185

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRjcnMRoobLudTb7BDA15a)_