### PR TITLE
ux: best-practice sweep (React/Vite/TypeScript/Tailwind)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -229,6 +229,7 @@
     "apiKey": {
       "title": "YouTube API-Schlüssel",
       "description": "Gib deinen YouTube Data API-Schlüssel ein, um fortzufahren.",
+      "fieldLabel": "YouTube Data API v3-Schlüssel",
       "save": "Speichern",
       "cancel": "Abbrechen",
       "showKey": "API-Key anzeigen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -229,6 +229,7 @@
     "apiKey": {
       "title": "YouTube API key",
       "description": "Enter your YouTube Data API key to continue.",
+      "fieldLabel": "YouTube Data API v3 Key",
       "save": "Save",
       "cancel": "Cancel",
       "showKey": "Show API key",

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -34,7 +34,10 @@ export function Header({
           <div className="bg-gradient-to-br from-red-600 to-red-700 p-2 rounded-lg shadow-lg shadow-red-500/20">
             <BarChart3 className="w-5 h-5 text-white" />
           </div>
-          <h1 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-700 to-slate-900 dark:from-slate-100 dark:to-slate-400 hidden sm:block">
+          {/* sr-only (not `hidden`) below `sm`: the only <h1> on the page must stay
+              in the accessibility tree on mobile even though it's visually hidden
+              there for layout reasons — `hidden` would remove it from both. */}
+          <h1 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-700 to-slate-900 dark:from-slate-100 dark:to-slate-400 sr-only sm:not-sr-only sm:block">
             {t("appTitle")}
           </h1>
 

--- a/src/shared/components/ui/ApiKeyModal.tsx
+++ b/src/shared/components/ui/ApiKeyModal.tsx
@@ -98,7 +98,7 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
                 htmlFor="apiKey"
                 className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2"
               >
-                YouTube Data API v3 Key
+                {t("modal.apiKey.fieldLabel")}
               </label>
               <div className="relative">
                 <input


### PR DESCRIPTION
## Description

Two additive UX fixes from an autonomous best-practice sweep.

| Kategorie | Aufwand | Empfehlung | Befund |
|-----------|---------|------------|--------|
| a11y | S | auto-fix | `Header.tsx`: the page's sole `<h1>` used `hidden sm:block` (`display:none`), dropping it from the accessibility tree entirely below `sm` — switched to `sr-only sm:not-sr-only sm:block` so it's still exposed to assistive tech while staying visually hidden on mobile exactly as before |
| microcopy | S | auto-fix | `ApiKeyModal.tsx`: the API key field label was a hardcoded literal English string while the rest of the modal is fully translated — added `modal.apiKey.fieldLabel` to both `en` and `de` bundles and wired it through `t()` |

No visible layout change on desktop (≥640px) for either fix; the `<h1>` stays invisible below 640px exactly as before (now via `sr-only` instead of `display:none`), and the API key label text is unchanged in English, now correctly translated in German.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable)
- [x] Tested locally (`npm run format:check` && `npm run typecheck` && `npm run build` all green; no test runner configured in this repo)

## Related Issues

Closes #352


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxfyWUXtEesbTj6JBXrUyq)_