### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/agent_docs/api-reference.md
+++ b/agent_docs/api-reference.md
@@ -79,8 +79,13 @@ All storage access goes through the type-safe `StorageAdapter` in `src/shared/li
 
 ### Analyser
 
-| Key                         | Purpose                                     | Used by            |
-| --------------------------- | ------------------------------------------- | ------------------ |
-| `tt.analyser.sortMode`      | Analyser result sort mode                   | `AnalyserPage.tsx` |
-| `tt.analyser.topN`          | Analyser top-N result count                 | `AnalyserPage.tsx` |
-| `tt.analyser.lastResult.v1` | Cached last analyser result (TTL: 24 hours) | `useSearch.ts`     |
+| Key                         | Purpose                                      | Used by              |
+| --------------------------- | -------------------------------------------- | -------------------- |
+| `tt.analyser.sortMode`      | Analyser result sort mode                    | `AnalyserPage.tsx`   |
+| `tt.analyser.topN`          | Analyser top-N result count                  | `AnalyserPage.tsx`   |
+| `tt.analyser.tableSort.v1`  | Result-table column sort (field + direction) | `VideoListTable.tsx` |
+| `tt.analyser.lastResult.v1` | Cached last analyser result (TTL: 24 hours)  | `useSearch.ts`       |
+
+> The tables above mirror `STORAGE_KEYS` in `src/shared/constants/config.ts` — that constant is the
+> single source of truth. Adding a key there means adding a row here; a stale list here is what made
+> the old `.junie/` guidelines drift (see `MEMORY.md`).

--- a/agent_docs/deployment.md
+++ b/agent_docs/deployment.md
@@ -4,14 +4,30 @@ Offloaded from `CLAUDE.md` (2026-07-26) per `agent_docs/context_budget.md` ladde
 
 ## Triggers
 
-| Event           | Workflow               | Result                                                      |
-| --------------- | ---------------------- | ----------------------------------------------------------- |
-| Push to `main`  | `docker-publish.yml`   | Builds and pushes `ghcr.io/fo0/tubetrend:latest`            |
-| Tag push (`v*`) | `electron-release.yml` | Builds + uploads all platform artifacts to a GitHub Release |
-| Pull request    | `pr-checks.yml`        | Verification only (format:check, typecheck, build)          |
-| Scheduled       | `cleanup-ghcr.yml`     | Prunes old container images                                 |
+All six workflow files, with every trigger each one actually declares:
 
-Additional workflows: `android-release.yml`, `extension-release.yml` — both fold into the tag-push release pipeline.
+| Workflow                | Triggers                                                           | Result                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `docker-publish.yml`    | push to `main`/`master` · `workflow_dispatch`                      | Checks code, then builds and pushes `ghcr.io/fo0/tubetrend:latest`                                           |
+| `electron-release.yml`  | push to `main`/`master` · tag push `v*` · `workflow_dispatch`      | Builds win/mac/linux + Chromebook `.deb` + Chrome Extension + Android APK, then **creates a GitHub Release** |
+| `android-release.yml`   | push to `main`/`master` · `workflow_dispatch`                      | Standalone APK build, uploaded as a workflow artifact (no release)                                           |
+| `extension-release.yml` | push to `main`/`master` · `workflow_dispatch`                      | Standalone `dist-extension/` zip, uploaded as a workflow artifact (no release)                               |
+| `pr-checks.yml`         | `pull_request` → `main`/`master` (opened / synchronize / reopened) | `format:check` → `tsc --noEmit` → optional lint → `build`, plus an advisory `npm audit` job                  |
+| `cleanup-ghcr.yml`      | weekly cron (Sun 04:00 UTC) · `workflow_dispatch`                  | Prunes untagged GHCR image versions, keeps the newest 10                                                     |
+
+Three consequences worth knowing before merging anything into `main`:
+
+- **A merge to `main` is a release, not just a container push.** `electron-release.yml` fires on the
+  same push as `docker-publish.yml`; on a non-tag ref it synthesizes the tag `vYYYYMMDD.HHMM.0` and
+  publishes a full GitHub Release with every platform artifact. Tag pushes reuse the tag name instead.
+  `android-release.yml` and `extension-release.yml` additionally run their own standalone builds, so
+  the same artifacts also exist as workflow artifacts.
+- **Docs-only changes trigger nothing.** All five push/PR workflows share the same `paths-ignore`
+  list (`**.md`, `docs/**`, `.env.example`, `.gitignore`, `.editorconfig`, `LICENSE*`, `.vscode/**`).
+  A markdown-only PR legitimately shows **zero** checks — that is configuration, not a broken CI.
+- **The PR gate has two jobs, one of them advisory.** The `security` job runs
+  `npm audit --audit-level=high` with `continue-on-error: true`, so a high-severity advisory is
+  reported but never blocks the merge. Only the `checks` job is a real gate.
 
 ## Environments
 

--- a/agent_docs/platform_builds.md
+++ b/agent_docs/platform_builds.md
@@ -80,6 +80,15 @@ docker-compose up         # Run production image at http://localhost:8889
 - **Zero changes to `src/`** — wraps the same `dist/` output.
 - **Manifest V3** — background service worker, no inline scripts (CSP-compliant).
 - **CSP compliance** — the inline FOUC-prevention script is extracted to an external `theme-init.js`.
+- **Declared permissions — exactly one: `tabs`** (`chrome-extension/manifest.json`). `background.js`
+  calls `chrome.tabs.query({})` to find an already-open TubeTrend tab and focus it instead of opening
+  a duplicate; without the permission that query returns tab objects with no `url`, so the lookup
+  silently fails and every click opens a new tab (#351). `chrome.tabs.create` / `.update` and
+  `chrome.windows.update` need no permission of their own. Keep the list at one entry — the store
+  review surfaces every added permission to users, and no other Chrome API is used.
+- **Assembled, not hand-maintained** — `scripts/build-extension.mjs` copies `dist/` plus the three
+  files in `chrome-extension/` (`manifest.json`, `background.js`, `theme-init.js`) into
+  `dist-extension/` and rewrites `index.html`. A new source file there must be added to that copy list.
 - **Build** — `npm run build:extension` produces `dist-extension/`.
 
 ## Build info


### PR DESCRIPTION
Completeness QA between code reality and documented reality, 2026-08-05. Three findings, three commits, docs only.

Closes #354

## Merged findings

| #   | Pass                | File                            | Finding                                                                                                                                                                 |
| --- | ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| 1   | C — Defaults & docs | `agent_docs/api-reference.md`   | `tt.analyser.tableSort.v1` (`STORAGE_KEYS.ANALYSER_TABLE_SORT`, used by `VideoListTable.tsx`) was missing from the localStorage tables — 19 of 20 keys were documented   |
| 2   | B — Config parity   | `agent_docs/platform_builds.md` | The Chrome Extension's `"permissions": ["tabs"]` (#351) and the hard-coded copy list in `scripts/build-extension.mjs` were undocumented                                  |
| 3   | B — Config parity   | `agent_docs/deployment.md`      | The Triggers table covered 4 of 6 workflows and understated what a merge to `main` sets off                                                                              |

### Why finding 3 matters

`electron-release.yml` declares both `on.push.branches: [main, master]` and `on.push.tags: ["v*"]`. On a non-tag ref its `prepare` job synthesizes `vYYYYMMDD.HHMM.0` and the `release` job runs `gh release create` with every platform artifact — so **a merge to `main` publishes a GitHub Release**, not just the GHCR image the doc described. `android-release.yml` and `extension-release.yml` likewise run standalone on push rather than folding into the tag-push pipeline. Also documented: the shared `paths-ignore` list (a markdown-only PR legitimately shows zero checks) and the advisory `npm audit` job in `pr-checks.yml` that reports but never blocks.

## Artefact status

| Artefact             | Present | Code parity                                                                            |
| -------------------- | ------- | -------------------------------------------------------------------------------------- |
| `.env.example`       | yes     | complete — all 5 keys used anywhere in the tree documented, none orphaned              |
| Config example files | n/a     | no user-editable runtime config file exists (settings live in `localStorage`)          |
| README onboarding    | yes     | complete — prerequisites, install, env setup, dev, build, test note, full script parity |
| Referenced docs      | yes     | all 34 linked `.md` files exist, none a stub                                            |
| `BACKLOG.md`         | yes     | "Open" section empty                                                                   |

## Backlog processing

| Entry | Action | Evidence |
| ----- | ------ | -------- |
| —     | none   | —        |

0 removed, 0 extracted to issues, 0 consolidated, 0 left in place — the "Open" table is empty and the "Done" / "Obsolete" tables are intentional history.

## Verification

- `npm run format:check` — clean (repo-wide, matches CI)
- All changed paths inside the sweep whitelist: three `.md` files under `agent_docs/`, nothing else
- No source, no config, no example artefact changed → no typecheck needed
- Note: this PR only touches `**.md`, which every workflow's `paths-ignore` excludes, so zero CI runs are expected here — that is configuration, not breakage

## Safety

Documentation only — no runtime config, no secrets, no functional code diff. Destructive edits would have been confined to `BACKLOG.md` with evidence; none were needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2jVud1wuoe6qTRDHFFELY)_