### PR TITLE
ci: add md-only Prettier job for docs changes

### DIFF
--- a/.github/workflows/docs-format.yml
+++ b/.github/workflows/docs-format.yml
@@ -1,0 +1,59 @@
+name: Docs Format
+
+# Counterpart to pr-checks.yml. That workflow carries `paths-ignore: "**.md"`
+# so documentation-only PRs don't pay for the full typecheck/lint/build chain —
+# but `npm run format:check` is `prettier --check .`, which DOES cover
+# Markdown. That left a blind spot: Markdown formatting drift could never fail
+# a check, and a docs-only PR could merge a red `format:check` onto main.
+#
+# This workflow closes exactly that gap and nothing more: it runs on the paths
+# pr-checks.yml ignores, and checks only the files Prettier can parse there
+# (`*.md`). Deliberately no `npm ci` — Prettier is pinned to the version in
+# package.json and fetched standalone, so the gate stays cheap enough to
+# justify running on every docs change. It also runs on push to main, which
+# pr-checks.yml does not.
+
+on:
+  pull_request:
+    branches: [main, master]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**.md"
+  push:
+    branches: [main]
+    paths:
+      - "**.md"
+
+# Cancel in-progress runs for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this job only checks out the code and runs Prettier. Without
+# this block the GITHUB_TOKEN inherits the repository default, which can be
+# read/write. Every other workflow here already declares its scope.
+permissions:
+  contents: read
+
+jobs:
+  format:
+    name: Prettier (Markdown)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      # Read the pinned version out of package.json rather than hardcoding it,
+      # so this job can never drift from the Prettier `npm run format` applies.
+      - name: Resolve pinned Prettier version
+        id: prettier
+        run: echo "version=$(node -p "require('./package.json').devDependencies.prettier.replace(/^[^0-9]*/,'')")" >> "$GITHUB_OUTPUT"
+
+      - name: Check Markdown formatting
+        run: npx --yes prettier@${{ steps.prettier.outputs.version }} --check "**/*.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Significant decisions are recorded as ADRs under `docs/adr/`. Triggers + format:
 - **Branch Naming:** `feat/X`, `fix/X`, `refactor/X`, `chore/X`, `docs/X`, `dependabot/**`
 - **Commit Messages:** Conventional Commits — `type(scope): description`. Reference issue numbers (`fix: resolve crash #42`).
 - **Merge Strategy:** Squash (default). Reflected in the `pr` skill's merge phase.
-- **CI/CD:** GitHub Actions — `pr-checks`, `docker-publish`, `electron-release`, `android-release`, `extension-release`, `cleanup-ghcr`.
+- **CI/CD:** GitHub Actions — `pr-checks` (skips `**.md` / `docs/**`), `docs-format` (Prettier-Markdown on exactly those paths, so docs-only changes stay gated — `format:check` is `prettier --check .` and includes Markdown), `docker-publish`, `electron-release`, `android-release`, `extension-release`, `cleanup-ghcr`.
 - **Formatting guard:** staged files can be auto-formatted on commit (husky + lint-staged). Setup + pitfalls: `agent_docs/ci_formatting_guard.md`. Never bypass with `--no-verify`.
 
 ## Dependency Management


### PR DESCRIPTION
## Problem

`pr-checks.yml` carries `paths-ignore: "**.md"` and `docs/**`, but `npm run format:check` is `prettier --check .` — which covers Markdown. Those two facts contradict each other: the only check that can catch Markdown drift never runs when Markdown changes, so a docs-only PR can merge a red `format:check` onto `main` unnoticed.

This is not hypothetical — it happened in the sibling repo `ai-hub-group-manager` (docs-only PR merged with zero CI runs, `format:check` red on `main` afterwards). Same workflow shape here.

## Change

New `.github/workflows/docs-format.yml` — the inverse of `pr-checks.yml`'s ignore list.

| Aspect | Choice | Why |
| --- | --- | --- |
| Trigger | `paths: ["**.md"]` on PR (`main`, `master`) **and push to `main`** | the PR gate has no push trigger, so drift arriving another way would still go unseen |
| Scope | `prettier --check "**/*.md"` | the wider `docs/**` tree holds `.mmd` and similar files Prettier has no parser for and errors on |
| Install | none; `npx prettier@<version from package.json>` (currently 3.8.4) | keeps a docs PR off `npm ci` + typecheck + lint + build |
| Version | read from `devDependencies.prettier` at runtime | cannot drift from what `npm run format` applies locally |
| Runner | `ubuntu-latest`, matching `pr-checks.yml` | hosted runner — no fork guard needed |
| Timeout | 5 min | it is one Prettier invocation |

`CLAUDE.md` § Git Conventions updated — the workflow list did not mention it.

## Verification

| Check | Result |
| --- | --- |
| YAML parses, triggers `[pull_request, push]`, job `format` | ok |
| `prettier --check "**/*.md"` on this branch | green |
| `prettier --check` on the new workflow + `CLAUDE.md` | green |

Note on the push trigger: `docker-publish.yml` also fires on push to `main` but has its own `paths-ignore: "**.md"`, so a docs-only merge still publishes nothing to GHCR — this workflow does not change that.

Rolled out identically to `ai-hub-group-manager`, `competitive-analysis-app` and `contract-manager`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2jVud1wuoe6qTRDHFFELY)_