### PR TITLE
refine: ux sweep (Vite + React + TypeScript + Tailwind)

### DIFF
--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -311,7 +311,7 @@ export function DashboardPage({
       {/* Sorting controls */}
       <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3 mb-4">
         {favorites.length > 0 ? (
-          <div className="flex items-center gap-3 text-xs font-medium">
+          <div className="flex flex-wrap items-center gap-3 text-xs font-medium min-w-0">
             <span className="text-slate-600 dark:text-slate-400">
               {t("dashboard.sorting.label")}
             </span>
@@ -359,9 +359,19 @@ export function DashboardPage({
             </div>
 
             {/* Favorite Avatars — filtered-out favorites are dropped here too,
-                otherwise their quick-jump would scroll to a hidden row. */}
+                otherwise their quick-jump would scroll to a hidden row.
+                flex-wrap + min-w-0: the avatars are shrink-0, so an unwrapped
+                strip grew past the page container once a user had ~15 favorites
+                and pushed the whole layout into a horizontal scroll.
+                role/aria-label: without them the strip is an unnamed run of
+                buttons whose only accessible name is a channel title, giving no
+                hint that activating one jumps to that favorite. */}
             {visibleFavorites.length > 0 && (
-              <div className="flex items-center gap-1.5 ml-2 pl-3 border-l border-slate-300 dark:border-slate-700">
+              <div
+                role="group"
+                aria-label={t("dashboard.quickJump")}
+                className="flex flex-wrap items-center gap-1.5 ml-2 pl-3 border-l border-slate-300 dark:border-slate-700 min-w-0"
+              >
                 {visibleFavorites.map((fav) => (
                   <FavoriteAvatar
                     key={fav.id}

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -77,20 +77,35 @@ export function DashboardPage({
   const showFavoriteFilter = favorites.length >= FAVORITES_FILTER_MIN_ROWS;
   const normalizedFavoriteFilter = showFavoriteFilter ? favoriteFilter.trim().toLowerCase() : "";
 
-  // `null` means "no filter active" — every favorite stays visible. Matching
+  // Searchable text per favorite, built once per list/cache change. Matching
   // covers the saved label, the raw query and the resolved channel title from
   // the cache, so "@mkbhd" and "Marques Brownlee" both find the same row.
+  //
+  // This must stay out of the keystroke path: getCache() re-reads and
+  // re-JSON-parses the whole favorites cache blob on every call, so building
+  // the haystacks inside the filter did that work once per favorite for every
+  // single character typed (same reason the hidden list is read once below).
+  const favoriteHaystacks = useMemo(() => {
+    const haystacks = new Map<string, string>();
+    for (const fav of sortedFavorites) {
+      const channelTitle = favoritesService.getCache(fav.id)?.meta?.channelTitle ?? "";
+      haystacks.set(fav.id, `${fav.label ?? ""} ${fav.query} ${channelTitle}`.toLowerCase());
+    }
+    return haystacks;
+    // cacheTick: a refresh can resolve a channel title that was unknown before.
+  }, [sortedFavorites, cacheTick]);
+
+  // `null` means "no filter active" — every favorite stays visible. Typing only
+  // runs substring checks against the precomputed haystacks above.
   const matchingFavoriteIds = useMemo<Set<string> | null>(() => {
     if (!normalizedFavoriteFilter) return null;
     const ids = new Set<string>();
     for (const fav of sortedFavorites) {
-      const channelTitle = favoritesService.getCache(fav.id)?.meta?.channelTitle ?? "";
-      const haystack = `${fav.label ?? ""} ${fav.query} ${channelTitle}`.toLowerCase();
+      const haystack = favoriteHaystacks.get(fav.id) ?? "";
       if (haystack.includes(normalizedFavoriteFilter)) ids.add(fav.id);
     }
     return ids;
-    // cacheTick: a refresh can resolve a channel title that was unknown before.
-  }, [sortedFavorites, normalizedFavoriteFilter, cacheTick]);
+  }, [sortedFavorites, favoriteHaystacks, normalizedFavoriteFilter]);
 
   const visibleFavorites = matchingFavoriteIds
     ? sortedFavorites.filter((fav) => matchingFavoriteIds.has(fav.id))

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -110,6 +110,7 @@
   "dashboard": {
     "noFavorites": "Noch keine Favoriten. Lege im Analyser eine Suche als Favorit an.",
     "openAnalyser": "Analyser öffnen",
+    "quickJump": "Zu Favorit springen",
     "highlights": {
       "title": "Highlights",
       "subtitle": "Top-Videos aus allen Favoriten (klickbar)",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -132,6 +132,7 @@
     "filter": {
       "placeholder": "Favoriten filtern…",
       "aria": "Favoriten nach Name filtern",
+      "shortcutHint": "Favoriten nach Name filtern — mit / fokussieren",
       "clear": "Filter zurücksetzen",
       "count_one": "{{count}} von {{total}} angezeigt",
       "count_other": "{{count}} von {{total}} angezeigt",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -110,6 +110,7 @@
   "dashboard": {
     "noFavorites": "No favorites yet. Create a favorite from the analyzer.",
     "openAnalyser": "Open Analyser",
+    "quickJump": "Jump to favorite",
     "highlights": {
       "title": "Highlights",
       "subtitle": "Top videos across all favorites (click to open)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -132,6 +132,7 @@
     "filter": {
       "placeholder": "Filter favorites…",
       "aria": "Filter favorites by name",
+      "shortcutHint": "Filter favorites by name — press / to focus",
       "clear": "Clear filter",
       "count_one": "{{count}} of {{total}} shown",
       "count_other": "{{count}} of {{total}} shown",

--- a/src/shared/components/ui/FavoritesFilter.tsx
+++ b/src/shared/components/ui/FavoritesFilter.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { Search, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useEventListener } from "@/src/shared/hooks";
 
 interface FavoritesFilterProps {
   value: string;
@@ -24,6 +25,27 @@ export const FavoritesFilter: React.FC<FavoritesFilterProps> = ({
 }) => {
   const { t } = useTranslation();
   const isFiltering = value.trim().length > 0;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // "/" focuses this filter — the dashboard counterpart to the analyser's search
+  // box, which registers the same key. The shortcuts popover advertises "/" as a
+  // global "focus search", but nothing on the dashboard listened for it, so the
+  // key was dead on half the app. Dashboard and analyser are mutually exclusive
+  // pages, so the two inputs can never claim the key at the same time.
+  const handleFocusHotkey = useCallback((e: KeyboardEvent) => {
+    if (e.key !== "/") return;
+    const target = e.target as HTMLElement | null;
+    if (
+      target?.tagName === "INPUT" ||
+      target?.tagName === "TEXTAREA" ||
+      target?.isContentEditable
+    ) {
+      return;
+    }
+    e.preventDefault();
+    inputRef.current?.focus();
+  }, []);
+  useEventListener("keydown", handleFocusHotkey, document);
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-4">
@@ -32,18 +54,20 @@ export const FavoritesFilter: React.FC<FavoritesFilterProps> = ({
           <Search className="w-4 h-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
         </div>
         <input
+          ref={inputRef}
           type="search"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={t("dashboard.filter.placeholder")}
           aria-label={t("dashboard.filter.aria")}
+          title={t("dashboard.filter.shortcutHint")}
           autoComplete="off"
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck={false}
           className="block w-full pl-9 pr-9 py-2 text-sm bg-white dark:bg-slate-950 border border-slate-300 dark:border-slate-700 rounded-lg focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-600 transition-all [&::-webkit-search-cancel-button]:hidden"
         />
-        {isFiltering && (
+        {isFiltering ? (
           <button
             type="button"
             onClick={() => onChange("")}
@@ -53,6 +77,18 @@ export const FavoritesFilter: React.FC<FavoritesFilterProps> = ({
           >
             <X className="w-4 h-4" aria-hidden="true" />
           </button>
+        ) : (
+          /* Discoverability for the "/" hotkey — decorative, the title attribute
+             above carries the same information for assistive tech. Shares the
+             right slot with the clear button, which only exists while filtering. */
+          <span
+            aria-hidden="true"
+            className="absolute inset-y-0 right-0 pr-3 hidden sm:flex items-center pointer-events-none"
+          >
+            <kbd className="px-1.5 py-0.5 rounded border border-slate-200 bg-slate-100 font-mono text-[10px] leading-none text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500">
+              /
+            </kbd>
+          </span>
         )}
       </div>
 


### PR DESCRIPTION
## Description

Comfort/UX sweep over three existing dashboard features. No new features, no dependency changes, strictly local and additive edits.

| # | Bestehendes Feature | UX-Lücke | Verbesserung | Aufwand | Empfehlung |
|---|---|---|---|---|---|
| 1 | Dashboard favorites filter | Every keystroke rebuilt each favorite's search text via `favoritesService.getCache()`, which re-reads and re-JSON-parses the whole favorites cache blob per call — N full parses per typed character | Haystacks precomputed in a `useMemo` keyed on the favorites list + `cacheTick`; typing now only does substring checks | S | auto-refine |
| 2 | Favorite quick-jump avatar strip | One `shrink-0` button per favorite in a non-wrapping flex row, so from ~15 favorites on the strip grew past the page container and forced the dashboard into horizontal scroll; the strip also had no group name | `flex-wrap` + `min-w-0` so it wraps; `role="group"` + `aria-label` names it for assistive tech | S | auto-refine |
| 3 | Keyboard shortcut `/` (focus search) | The shortcuts popover advertises `/` as a global "focus search", but only the analyser's `InputSection` listened — on the dashboard the key was dead and the filter was mouse/Tab-only | The favorites filter registers `/` via the existing `useEventListener` hook (the two inputs are never mounted together) and shows a `kbd` hint in the input's free right slot | S | auto-refine |

## Type of Change

- [x] Bug fix (layout overflow, dead shortcut, per-keystroke storage reads)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (`dashboard.quickJump`, `dashboard.filter.shortcutHint` in both `en` and `de`)
- [x] Tested locally — `format:check` → `typecheck` → `build` all green

## Related Issues

Closes #357


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9bU2iNuz2sXp4Vy2GewQp)_