### PR TITLE
fix(dashboard): remove misleading delete button from hidden videos modal

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -126,7 +126,7 @@
       "hiddenModalTitle": "Ausgeblendete Videos",
       "noHiddenItems": "Keine ausgeblendeten Videos.",
       "unhide": "Einblenden",
-      "delete": "Löschen",
+      "unhideAria": "{{title}} – wieder einblenden",
       "empty": "Noch keine Highlights verfügbar. Highlights erscheinen, sobald deine Favoriten Videos geladen haben."
     },
     "filter": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -126,7 +126,7 @@
       "hiddenModalTitle": "Hidden Videos",
       "noHiddenItems": "No hidden videos.",
       "unhide": "Show",
-      "delete": "Delete",
+      "unhideAria": "{{title}} – show again",
       "empty": "No highlights available yet. Highlights will appear once your favorites have loaded videos."
     },
     "filter": {

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Clock, ExternalLink, Eye, Trash2, X } from "lucide-react";
+import { Clock, ExternalLink, Eye, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { hiddenHighlightsService, type HiddenHighlight } from "@/src/features/dashboard";
 import { getLocale } from "@/src/shared/lib/locale";
@@ -81,13 +81,10 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
     };
   }, [isOpen]);
 
+  // The hidden list *is* the hide state: an entry exists only while the video is
+  // hidden, so removing it is the one and only action this row supports. There is
+  // no separate record left over to "delete" afterwards.
   const handleUnhide = (videoId: string) => {
-    hiddenHighlightsService.show(videoId);
-    setHiddenItems(hiddenHighlightsService.listChronological());
-  };
-
-  const handleDelete = (videoId: string) => {
-    // show() removes the entry from the hidden list (un-hiding it)
     hiddenHighlightsService.show(videoId);
     setHiddenItems(hiddenHighlightsService.listChronological());
   };
@@ -201,18 +198,12 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
                       type="button"
                       onClick={() => handleUnhide(item.videoId)}
                       className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-indigo-500/30 text-indigo-500 dark:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
+                      aria-label={t("dashboard.highlights.unhideAria", {
+                        title: item.videoTitle ?? "",
+                      })}
                     >
-                      <Eye className="w-3 h-3" />
+                      <Eye className="w-3 h-3" aria-hidden="true" />
                       {t("dashboard.highlights.unhide")}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(item.videoId)}
-                      className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-red-500/30 text-red-400 dark:text-red-300 hover:bg-red-500/10 transition-colors"
-                      aria-label={t("dashboard.highlights.delete")}
-                      title={t("dashboard.highlights.delete")}
-                    >
-                      <Trash2 className="w-3 h-3" aria-hidden="true" />
                     </button>
                   </div>
                 </li>


### PR DESCRIPTION
## Problem

Each row in `HiddenHighlightsModal` carried two buttons:

| Button | Styling | Handler |
|---|---|---|
| "Show" (`Eye`) | indigo, neutral | `hiddenHighlightsService.show(videoId)` |
| "Delete" (`Trash2`) | **red, destructive** | `hiddenHighlightsService.show(videoId)` |

Identical call, identical effect. The red trash icon promised a destructive action and instead un-hid the video — the same thing the button next to it already did. Anyone reaching for "Delete" to purge an entry got the opposite of what the affordance signalled.

## Why removal rather than new semantics

The hidden list *is* the hide state. An entry exists only while a video is hidden; `show()` removes it. There is no leftover record for a "delete" to target, so the button has no meaning it could be given without inventing a new storage concept. The honest fix is to drop the duplicate and keep the one correctly labelled action.

## Changes

| File | Change |
|---|---|
| `src/shared/components/ui/HiddenHighlightsModal.tsx` | Removed the `Trash2` button, the duplicate `handleDelete`, and the now-unused `Trash2` import; comment records why one action is all this row can have |
| `src/i18n/locales/{en,de}.json` | Dropped the orphaned `dashboard.highlights.delete` key; added `unhideAria` |

The remaining button gains a per-item `aria-label` (`"{{title}} – show again"` / `"… wieder einblenden"`), so screen reader users hear *which* video they are unhiding — matching the neighbouring YouTube link, which already did this. `Eye` is now `aria-hidden`, since the visible text plus the aria-label carry the name.

Purely subtractive otherwise: no behaviour change to hiding, unhiding, or persistence.

## Verification

`npm ci` → `format:check` ✅ → `typecheck` ✅ → `build` ✅ (432 kB JS, 446 ms). No test runner is configured in this repo; the above is the full gate per `CLAUDE.md`.

Found during the UX refine sweep (#357) and flagged there as out of scope for that run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9bU2iNuz2sXp4Vy2GewQp)_