### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,22 @@ Thank you for your interest in contributing to TubeTrend! This document provides
    ```bash
    npm install
    ```
-4. Copy the environment file:
+4. Copy the environment file — **optional**, and read the caveat below before you do:
+
    ```bash
    cp .env.example .env.local
    ```
+
+   Every variable in `.env.example` is build-time configuration with a working default, so skipping
+   this step is fine. If you do copy it, note that the file ships `VITE_DEFAULT_SEARCH=` (empty), and
+   Vite reads an empty assignment as the empty string `""`, not as unset. The read site uses `??`,
+   which only falls back on `null`/`undefined` — so copying the file verbatim **suppresses** the
+   dev-mode `TEDx` default and starts you with an empty search input. Comment the line out to get it
+   back. Full explanation: [`agent_docs/env-vars.md`](agent_docs/env-vars.md).
+
+   > The YouTube Data API v3 key is **not** in this file and must never be added to it. You paste it
+   > into the app's API-key modal at runtime; it lives only in your browser's `localStorage`.
+
 5. Start the development server:
    ```bash
    npm run dev

--- a/agent_docs/api-reference.md
+++ b/agent_docs/api-reference.md
@@ -66,16 +66,16 @@ All storage access goes through the type-safe `StorageAdapter` in `src/shared/li
 
 ### Search & Preferences
 
-| Key                    | Purpose                                     | Used by             |
-| ---------------------- | ------------------------------------------- | ------------------- |
-| `tt.search.timeframe`  | Search timeframe preference                 | `InputSection.tsx`  |
-| `tt.search.maxResults` | Search max results preference               | `InputSection.tsx`  |
-| `tt.search.query`      | Last search input text (restored on reload) | `InputSection.tsx`  |
-| `tt.search.history`    | Search input history                        | `InputSection.tsx`  |
-| `tt.lang.explicit`     | Explicit language selection                 | `i18n/config.ts`    |
-| `tt.theme`             | Theme preference (light/dark/system)        | `ThemeProvider.tsx` |
-| `tt.activePage`        | Active page (dashboard/analyser)            | `App.tsx`           |
-| `yt_quota_tracking`    | API quota usage tracking & history          | `quotaService.ts`   |
+| Key                    | Purpose                                     | Used by               |
+| ---------------------- | ------------------------------------------- | --------------------- |
+| `tt.search.timeframe`  | Search timeframe preference                 | `InputSection.tsx`    |
+| `tt.search.maxResults` | Search max results preference               | `InputSection.tsx`    |
+| `tt.search.query`      | Last search input text (restored on reload) | `InputSection.tsx`    |
+| `tt.search.history`    | Search input history                        | `InputSection.tsx`    |
+| `tt.lang.explicit`     | Explicit language selection                 | `i18n/config.ts` ⚠    |
+| `tt.theme`             | Theme preference (light/dark/system)        | `ThemeProvider.tsx` ⚠ |
+| `tt.activePage`        | Active page (dashboard/analyser)            | `App.tsx`             |
+| `yt_quota_tracking`    | API quota usage tracking & history          | `quotaService.ts`     |
 
 ### Analyser
 
@@ -89,3 +89,21 @@ All storage access goes through the type-safe `StorageAdapter` in `src/shared/li
 > The tables above mirror `STORAGE_KEYS` in `src/shared/constants/config.ts` — that constant is the
 > single source of truth. Adding a key there means adding a row here; a stale list here is what made
 > the old `.junie/` guidelines drift (see `MEMORY.md`).
+
+### ⚠ Keys whose literal is repeated outside `STORAGE_KEYS`
+
+`STORAGE_KEYS` is the source of truth, but two of its values also exist as **hand-written string
+literals** elsewhere. Nothing imports across those boundaries and there is no test suite to pin them,
+so renaming the constant alone leaves the copies pointing at the old key — a silent behaviour
+regression, not a build error (`typecheck` and `build` both stay green). Change every site listed
+here in the same commit.
+
+| Key                | Canonical declaration                                  | Duplicate literal                                                                               | Why it cannot import                                                                                                                                       |
+| ------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tt.theme`         | `STORAGE_KEYS.THEME` (`shared/constants/config.ts`)    | `index.html` (inline FOUC script) and `chrome-extension/theme-init.js` (same script, extracted) | Both run **before** the React bundle loads, so they cannot import a module. Breaking them re-introduces the dark/light FOUC flash.                         |
+| `tt.lang.explicit` | `STORAGE_KEYS.LANGUAGE` (`shared/constants/config.ts`) | `LANG_STORAGE_KEY` in `src/i18n/config.ts` (own `export const`, same literal)                   | Could import, but does not — `i18n/config.ts` is the i18next bootstrap and keeps its detector key local. Drift silently resets the user's language choice. |
+
+`chrome-extension/theme-init.js` is a byte-for-byte copy of the `index.html` script (extracted for
+Manifest-V3 CSP compliance, see `agent_docs/platform_builds.md → Chrome Extension`), so a change to
+one must be mirrored in the other. Every other key in the tables above is read only through
+`STORAGE_KEYS`.

--- a/agent_docs/key-patterns.md
+++ b/agent_docs/key-patterns.md
@@ -47,6 +47,32 @@ Client-side YouTube Data API v3 usage accounting. Per-endpoint cost: `search` = 
 
 **Location:** `src/features/youtube/services/quotaService.ts`
 
+## Result Filtering & Caps (tunable constants)
+
+Three numeric constants silently shape every result set. They have no UI, no env var and no entry in
+`.env.example` — they are compile-time defaults, and changing one changes user-visible output and
+quota burn. Documented here because a search that "loses" videos is otherwise unexplainable.
+
+| Constant                            | Default | Declared in                      | Effect                                                                                                                                        |
+| ----------------------------------- | ------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SHORTS_DURATION_THRESHOLD_SECONDS` | `180`   | `shared/constants/config.ts`     | Videos **shorter than 3 minutes** are treated as Shorts and dropped from keyword _and_ channel results. Unknown/unparseable duration is kept. |
+| `AUTO_LIMIT_KEYWORD`                | `250`   | `shared/constants/maxResults.ts` | Cap the "Auto" max-results option (`value: -1`) resolves to for a **keyword** search.                                                         |
+| `AUTO_LIMIT_CHANNEL`                | `500`   | `shared/constants/maxResults.ts` | Cap "Auto" resolves to for a **channel** search — higher because `playlistItems` paging costs 1 unit per page, not 100.                       |
+
+Notes that bite:
+
+- **The Shorts filter runs _after_ the API call**, so filtered-out videos are already paid for in
+  quota. `channelService` compensates by over-fetching (`Math.max(effectiveMax, 50)`) and slicing to
+  the requested count only after filtering — otherwise a Shorts-heavy channel returns short.
+- **"No limit" (`value: 0`) is not symmetric.** `searchService` turns it into `5000`;
+  `channelService` turns it into `0`, which means "no cap" there. Read the `effectiveMax` line in
+  each service before assuming a shared meaning.
+- Raising `AUTO_LIMIT_KEYWORD` multiplies `search` calls at **100 units each** — the fastest way to
+  burn the 10,000-unit daily quota.
+
+**Location:** `src/shared/constants/config.ts`, `src/shared/constants/maxResults.ts`,
+`src/features/youtube/services/{searchService,channelService}.ts`
+
 ## Results Presentation (Analyser)
 
 The analyser renders the full result set at once — there is no pagination and no `IntersectionObserver`. Presentation is driven by two persisted preferences:

--- a/chrome-extension/theme-init.js
+++ b/chrome-extension/theme-init.js
@@ -2,6 +2,10 @@
 // Extracted from index.html inline script for Chrome Extension CSP compliance.
 (function () {
   try {
+    // Duplicate of STORAGE_KEYS.THEME (src/shared/constants/config.ts) and of the identical inline
+    // block in index.html. Neither can import the constant — both run before the React bundle.
+    // Keep this file, index.html and the constant in sync; a rename that misses one is invisible to
+    // typecheck and build. Sites are listed in agent_docs/api-reference.md.
     var storageKey = "tt.theme";
     var explicit = localStorage.getItem(storageKey);
     var systemPrefersDark =

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
     <script>
       (function () {
         try {
+          // Duplicate of STORAGE_KEYS.THEME (src/shared/constants/config.ts). This script runs
+          // before the React bundle, so it cannot import the constant. chrome-extension/
+          // theme-init.js is a byte-for-byte copy of this block (Manifest-V3 CSP). Renaming the
+          // constant without updating BOTH copies stays green in typecheck/build and only shows up
+          // as the FOUC flash coming back. Sites are listed in agent_docs/api-reference.md.
           var storageKey = "tt.theme";
           var explicit = localStorage.getItem(storageKey);
           var systemPrefersDark =

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -5,6 +5,11 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import en from "./locales/en.json";
 import de from "./locales/de.json";
 
+// Duplicate of STORAGE_KEYS.LANGUAGE ("tt.lang.explicit", src/shared/constants/config.ts).
+// Declared locally so this i18next bootstrap stays free of app-module imports. Nothing links the
+// two literals and there is no test suite, so a rename over there does NOT fail typecheck or build
+// here — it silently resets every user's saved language. Change both, plus the row in
+// agent_docs/api-reference.md.
 export const LANG_STORAGE_KEY = "tt.lang.explicit";
 
 const resources = {


### PR DESCRIPTION
## Description

Routine quality-maintenance sweep of the repo's configuration and onboarding artefacts. **Documentation and comments only — no runtime config, no secrets, no functional code change.**

ENV parity was already clean: all five code-referenced variables are in `.env.example` with purpose, required/optional, default and example format, and there are no orphans. The gaps were one level deeper — values that live in more than one place with nothing keeping them together, and behavioural defaults that no document mentions.

| #   | Pass                  | Datei(en)                                                            | Befund                                                                                                                                                                                       | Fix                                                                                                       | Aufwand |
| --- | --------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
| 1   | Config-Parität        | `agent_docs/api-reference.md`                                         | Doc calls `STORAGE_KEYS` the single source of truth, but `tt.theme` and `tt.lang.explicit` also exist as hand-written literals elsewhere. The "Used by" column named one consumer each.      | Duplicate-literal table naming every site and why it cannot import; the two rows flagged.                  | M       |
| 2   | Config-Parität        | `index.html`, `chrome-extension/theme-init.js`, `src/i18n/config.ts`  | Same risk at the source: `tt.theme` is hardcoded in the `index.html` FOUC script **and** its extracted extension copy; `tt.lang.explicit` is re-declared as `LANG_STORAGE_KEY`.               | Additive comments naming the canonical constant, the sibling copies and the doc table. Comment-only.       | S       |
| 3   | Defaults & Doku       | `agent_docs/key-patterns.md`                                          | `SHORTS_DURATION_THRESHOLD_SECONDS` (180), `AUTO_LIMIT_KEYWORD` (250), `AUTO_LIMIT_CHANNEL` (500) documented nowhere, yet they decide what a search returns and what it costs in quota.       | Constants table with defaults + declaration sites, the over-fetch headroom, the asymmetric "No limit".     | S       |
| 4   | README-Onboarding     | `CONTRIBUTING.md`                                                     | Step 4 says `cp .env.example .env.local` with no caveat — but that file ships `VITE_DEFAULT_SEARCH=`, Vite reads it as `""`, the `??` fallback never fires, and the dev `TEDx` default dies. | Step marked optional, caveat + fix stated, API-key rule repeated.                                          | S       |

**Why 1 and 2 matter:** both duplications are invisible to the toolchain. `typecheck` and `build` stay green after a rename that misses a copy — the only symptom is the dark/light FOUC flash returning, or every user's saved language silently resetting. With no test suite in the repo, a comment and a doc row are the only guard available.

`BACKLOG.md` needed no work: `## Open` is empty, and the Done/Obsolete tables are dated, well-formed and traceable. Nothing to extract, merge or remove.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no UI text touched
- [x] Tested locally — `npm run typecheck` ✅ · `npm run format:check` ✅ · `npm run build` ✅

## Verification

All three CI gates run locally after `npm ci` (the sandbox started with an empty `node_modules`):

```
npm run typecheck     ✅ exit 0
npm run format:check  ✅ All matched files use Prettier code style!
npm run build         ✅ built in 609ms — tt.theme script intact in dist/index.html
```

Diff shape: **81 insertions, 11 deletions across 6 files.** The three source files (`index.html`, `chrome-extension/theme-init.js`, `src/i18n/config.ts`) are **comment-only** — 14 added lines, 0 removed, verified by filtering every non-comment line out of the diff. Secret scan over the branch diff (`sk-`, `ghp_`, `AIza…`, JWT, hex/base64) came back clean.

## Scope

Only documentation and example/onboarding artefacts were touched — **no runtime configuration, no real `.env*` file, no secrets**. Formatting, linting, tests, dependency bumps and dead-code removal were explicitly out of scope for this sweep.

## Related Issues

Closes #360

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMgGr1Hyn6w6u8F6Tak9tA


---
_Generated by [Claude Code](https://claude.ai/code/session_01CMgGr1Hyn6w6u8F6Tak9tA)_