### PR TITLE
chore(deps-dev): bump prettier to 3.9.6 and reformat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "electron": "^41.6.1",
         "electron-builder": "^26.15.3",
-        "prettier": "3.8.4",
+        "prettier": "3.9.6",
         "tailwindcss": "^4.3.1",
         "typescript": "~6.0.3",
         "vite": "^8.0.16",
@@ -4464,9 +4464,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "electron": "^41.6.1",
     "electron-builder": "^26.15.3",
-    "prettier": "3.8.4",
+    "prettier": "3.9.6",
     "tailwindcss": "^4.3.1",
     "typescript": "~6.0.3",
     "vite": "^8.0.16",

--- a/src/features/dashboard/services/dashboardBackupService.ts
+++ b/src/features/dashboard/services/dashboardBackupService.ts
@@ -19,8 +19,7 @@ export interface DashboardBackupPayload {
 }
 
 export type ParseResult =
-  | { ok: true; payload: DashboardBackupPayload }
-  | { ok: false; payload?: never };
+  { ok: true; payload: DashboardBackupPayload } | { ok: false; payload?: never };
 
 export const dashboardBackupService = {
   createBackup(options: {

--- a/src/features/dashboard/services/hiddenHighlightsService.ts
+++ b/src/features/dashboard/services/hiddenHighlightsService.ts
@@ -45,16 +45,14 @@ export const hiddenHighlightsService = {
           (item.sourceId as string).length > 0 &&
           (item.videoId as string).length > 0,
       )
-      .map(
-        (item): HiddenHighlight => ({
-          sourceId: item.sourceId as string,
-          videoId: item.videoId as string,
-          hiddenAt: typeof item.hiddenAt === "number" ? item.hiddenAt : 0,
-          videoTitle: typeof item.videoTitle === "string" ? item.videoTitle : undefined,
-          thumbnailUrl: typeof item.thumbnailUrl === "string" ? item.thumbnailUrl : undefined,
-          sourceLabel: typeof item.sourceLabel === "string" ? item.sourceLabel : undefined,
-        }),
-      );
+      .map((item): HiddenHighlight => ({
+        sourceId: item.sourceId as string,
+        videoId: item.videoId as string,
+        hiddenAt: typeof item.hiddenAt === "number" ? item.hiddenAt : 0,
+        videoTitle: typeof item.videoTitle === "string" ? item.videoTitle : undefined,
+        thumbnailUrl: typeof item.thumbnailUrl === "string" ? item.thumbnailUrl : undefined,
+        sourceLabel: typeof item.sourceLabel === "string" ? item.sourceLabel : undefined,
+      }));
   },
 
   /**

--- a/src/features/youtube/services/searchService.ts
+++ b/src/features/youtube/services/searchService.ts
@@ -108,16 +108,14 @@ export async function searchVideosByKeyword(
         if (seconds === null) return true;
         return seconds >= SHORTS_DURATION_THRESHOLD_SECONDS;
       })
-      .map(
-        (item): YouTubeVideoItem => ({
-          id: item.id,
-          // Cast through `unknown` to bridge the loose API type (all fields
-          // optional) and the stricter consumer type. Required fields are
-          // guaranteed by the `part=snippet,statistics` request.
-          snippet: item.snippet as unknown as YouTubeVideoItem["snippet"],
-          statistics: item.statistics,
-        }),
-      );
+      .map((item): YouTubeVideoItem => ({
+        id: item.id,
+        // Cast through `unknown` to bridge the loose API type (all fields
+        // optional) and the stricter consumer type. Required fields are
+        // guaranteed by the `part=snippet,statistics` request.
+        snippet: item.snippet as unknown as YouTubeVideoItem["snippet"],
+        statistics: item.statistics,
+      }));
   });
 
   const batchResults = await Promise.all(batchPromises);


### PR DESCRIPTION
## Description

Replaces #341. Dependabot proposed `prettier 3.8.4 → 3.9.6`, but that PR is CI-red: Prettier 3.9 changes how it breaks arrow-function bodies and union types, so three already-committed files no longer match the new formatter's output. Dependabot only bumps the version and cannot carry the reformat, so the bump and the reformat are done together here.

**Reformatted files** (whitespace only — no tokens, logic or comments changed):

- `src/features/dashboard/services/dashboardBackupService.ts` — union type collapsed onto one line
- `src/features/dashboard/services/hiddenHighlightsService.ts` — `.map((item): T => ({ … }))` arrow body hugged
- `src/features/youtube/services/searchService.ts` — same `.map()` arrow-body hugging

`prettier` stays **exactly pinned** (`3.9.6`, no caret), matching its existing notation — it is the only dependency in the manifest without a range prefix. A floating range would let `npm install` pull a reformatting patch and turn CI red unpredictably, which is exactly the failure this PR resolves.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Chore / tooling (dev dependency bump + formatting)

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, no UI text touched
- [x] Tested locally

Local verification against the full gate, all green:

| Step | Result |
| --- | --- |
| `npm run format:check` | pass — "All matched files use Prettier code style!" |
| `npm run typecheck` | pass |
| `npm run build` | pass — built in 2.57s |

## Related Issues

Replaces #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqXocxLmahCG3q3VwJTwPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqXocxLmahCG3q3VwJTwPo)_