### PR TITLE
security: hardening sweep (Vite+React)

### DIFF
--- a/src/features/dashboard/services/dashboardBackupService.ts
+++ b/src/features/dashboard/services/dashboardBackupService.ts
@@ -21,6 +21,39 @@ export interface DashboardBackupPayload {
 export type ParseResult =
   { ok: true; payload: DashboardBackupPayload } | { ok: false; payload?: never };
 
+/** True only for absolute http(s) URLs — the schemes an <a href> may safely navigate to. */
+function isHttpUrl(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A backup file is untrusted input the user picked from disk. Its cached videos are
+ * rendered straight into `<a href={video.url}>` (HighlightVideoCard, VideoCard,
+ * VideoListTable), so without this guard a crafted file can smuggle a `javascript:`
+ * URL into the dashboard and run script in the app origin the moment the user clicks
+ * a highlight — which is where the YouTube API key lives in localStorage.
+ * Genuine exports only ever contain `https://www.youtube.com/watch?v=<id>` (built in
+ * trendAnalysisService), so rejecting anything else is behavior-equivalent for real
+ * backups and fails closed. CWE-79 / OWASP A03.
+ */
+function hasOnlySafeVideoUrls(favoritesCache: Record<string, unknown>): boolean {
+  for (const entry of Object.values(favoritesCache)) {
+    const videos = (entry as { videos?: unknown } | null | undefined)?.videos;
+    if (videos === undefined || videos === null) continue;
+    if (!Array.isArray(videos)) return false;
+    for (const video of videos) {
+      if (!isHttpUrl((video as { url?: unknown } | null | undefined)?.url)) return false;
+    }
+  }
+  return true;
+}
+
 export const dashboardBackupService = {
   createBackup(options: {
     dashboardSortMode: DashboardSortMode;
@@ -75,6 +108,10 @@ export const dashboardBackupService = {
         parsed.data.favoritesCache === null ||
         Array.isArray(parsed.data.favoritesCache)
       ) {
+        return { ok: false };
+      }
+
+      if (!hasOnlySafeVideoUrls(parsed.data.favoritesCache as Record<string, unknown>)) {
         return { ok: false };
       }
 


### PR DESCRIPTION
Autonomous security hardening sweep over the browser-reachable web layer (`src/**`, serving config, build config). Electron, Chrome-extension and Capacitor targets were out of scope.

The repo is already well hardened by earlier sweeps — CSP/HSTS/COOP/CORP headers, `rel="noopener noreferrer"` everywhere, CSV formula-injection neutralization and secret hygiene were all verified in place. One genuine finding remained.

## Findings

| # | Kategorie | Severity | Datei:Zeile | Fix-Klasse | Status |
|---|-----------|----------|-------------|------------|--------|
| 1 | DOM XSS via `javascript:` URL in untrusted import (CWE-79 / OWASP A03) | Medium | `src/features/dashboard/services/dashboardBackupService.ts:53` | safe / S | fixed |

## What was wrong

A dashboard backup is a JSON file the user picks from disk — untrusted input. `parse()` validated only that `favoritesCache` was a plain object, then `handleDashboardImportFile` wrote it verbatim to `localStorage`. `favoritesService.getCache()` returns those entries unvalidated, and they flow through `selectHighlightVideosFromFavorites()` into `HighlightVideoCard` / `VideoCard` / `VideoListTable`, each rendering `<a href={video.url}>`.

A crafted backup could therefore park a `javascript:` URL behind a dashboard highlight link. Clicking it executes script in the app origin — which is where the YouTube API key lives (`localStorage["yt_api_key"]`).

Rated **Medium**, not High: it needs the user to import an attacker-supplied file and confirm the replace dialog, and the Docker/nginx deployment's CSP (`script-src` without `'unsafe-inline'`) already blocks `javascript:` URI execution. The dev server, Electron and Capacitor surfaces do not.

## The fix

Validate the URLs at `dashboardBackupService.parse()` — the single trust boundary the file passes through — and fail closed through the existing `backup.importInvalid` alert. Genuine exports only ever contain `https://www.youtube.com/watch?v=<id>` (built in `trendAnalysisService.ts:75`), so this is behavior-equivalent for real backups. One file, +37 lines, no functionality removed.

## Verification

`npm ci` → `npm run format:check` → `npm run typecheck` → `npm run build` — all green. No test runner is configured in this repo, so the test step does not apply.

> Note: `npx prettier` without `node_modules` resolves a global 3.8.1 and reformats unrelated files; the checks above were re-run against the lockfile-pinned 3.9.6 and the diff is confined to the one file.

## Not fixed here (see the issue)

Flagged for manual follow-up rather than auto-fixed: a render-site URL-scheme allowlist as defense in depth against `localStorage` tampering (effort `L`), the container running nginx as root (breaking — needs a coordinated `Dockerfile` + `nginx.conf` + `docker-compose.yml` change), and 3 high-severity **devDependency** advisories (`npm audit --omit=dev` reports 0 — production runtime is clean).

Refs #295


---
_Generated by [Claude Code](https://claude.ai/code/session_01J6xYL4u3TrB76T4ffHQVgn)_