### PR TITLE
ux: best-practice sweep (Vite + React + TypeScript + Tailwind)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -179,11 +179,13 @@ const App: React.FC = () => {
     }
   }, [t]);
 
-  const downloadTextFile = useCallback((filename: string, text: string) => {
+  /** Returns false when the download was blocked, so the caller never claims success. */
+  const downloadTextFile = useCallback((filename: string, text: string): boolean => {
     try {
       downloadBlob(filename, new Blob([text], { type: "application/json" }));
+      return true;
     } catch {
-      // ignore
+      return false;
     }
   }, []);
 
@@ -198,8 +200,11 @@ const App: React.FC = () => {
       dashboardSortOrder: sortOrder,
     });
     const json = dashboardBackupService.stringify(payload);
-    downloadTextFile(filename, json);
-    showToast(t("backup.exportSuccess"), "success");
+    // The download can be blocked (sandboxed iframe, hardened Electron window).
+    // Reporting "Backup downloaded." regardless left the user believing a file
+    // existed that was never written.
+    const ok = downloadTextFile(filename, json);
+    showToast(ok ? t("backup.exportSuccess") : t("backup.exportFailed"), ok ? "success" : "error");
   }, [sortMode, sortOrder, downloadTextFile, t]);
 
   const handleDashboardImportFile = useCallback(

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -237,6 +237,19 @@ const App: React.FC = () => {
     [loadFavorites, t],
   );
 
+  // Removing a favorite drops its config and its cached videos for good — there
+  // is no undo and no trash. "Clear all" already confirms; the per-row Remove
+  // button sat directly beside Refresh and deleted on the first click, so a
+  // mis-click cost the favorite silently. Same guard, same wording pattern.
+  const handleRemoveFavorite = useCallback(
+    (id: string) => {
+      const label = favorites.find((fav) => fav.id === id)?.query ?? "";
+      if (!window.confirm(t("favorites.removeConfirm", { name: label }))) return;
+      removeFavorite(id);
+    },
+    [favorites, removeFavorite, t],
+  );
+
   const handleClearAllFavorites = useCallback(() => {
     const count = favorites.length;
     if (!window.confirm(t("favorites.clearAllConfirm", { count }))) return;
@@ -329,7 +342,7 @@ const App: React.FC = () => {
             dashboardSortOrder={sortOrder}
             cacheTick={cacheTick}
             hiddenTick={hiddenTick}
-            onRemoveFavorite={removeFavorite}
+            onRemoveFavorite={handleRemoveFavorite}
             onAnalyzeFavorite={handleAnalyzeFavorite}
             onRefreshAll={refreshAll}
             onSortClick={handleSortClick}

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -288,9 +288,15 @@ export function AnalyserPage({
       {/* Results */}
       {sortedVideos.length > 0 && (
         <div className="space-y-12 animate-fade-in">
-          {/* Control Bar */}
-          <div className="flex flex-col sm:flex-row justify-between items-center bg-slate-100/50 dark:bg-slate-900/50 p-4 rounded-xl border border-slate-200 dark:border-slate-800 gap-4 backdrop-blur-sm">
-            <div className="flex items-center gap-2">
+          {/* Control Bar — flex-wrap on both halves and min-w-0 on the bar:
+              from the `sm` breakpoint up the two halves sit side by side, and
+              the right half alone (3 export buttons + the sort-mode label +
+              two toggle groups + Clear) needs ~670px on one unwrapped line.
+              Between ~640px and ~1024px that pushed the bar past the page
+              container and put the whole document into a horizontal scroll.
+              Wrapping keeps every control reachable without one. */}
+          <div className="flex flex-col sm:flex-row flex-wrap justify-between items-center bg-slate-100/50 dark:bg-slate-900/50 p-4 rounded-xl border border-slate-200 dark:border-slate-800 gap-4 backdrop-blur-sm">
+            <div className="flex flex-wrap items-center gap-2 min-w-0">
               {/* h2: the page's <h1> (Header) otherwise skips straight to the
                   <h3> section titles below (WCAG 1.3.1 — no skipped heading levels). */}
               <h2 className="font-semibold text-slate-700 dark:text-slate-200">
@@ -346,7 +352,7 @@ export function AnalyserPage({
               )}
             </div>
 
-            <div className="flex items-center gap-3 text-sm font-medium">
+            <div className="flex flex-wrap items-center justify-end gap-3 text-sm font-medium min-w-0">
               {/* Export & Share actions */}
               <div className="inline-flex items-center rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 p-0.5">
                 <button

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -203,14 +203,18 @@ export function DashboardPage({
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-2">
+            {/* flex-wrap: up to five labelled buttons (Import, Export, Refresh
+                all, Clear all, Hidden) share this row with the count badge. On
+                one unwrapped line they run past the section — and the page
+                container with it — on any viewport narrower than a desktop. */}
+            <div className="flex flex-wrap items-center justify-end gap-2 min-w-0">
               {highlightVideos.length > 0 && (
                 <div className="text-xs font-medium text-slate-500 dark:text-slate-400 mr-1">
                   {t("dashboard.highlights.count", { count: highlightVideos.length })}
                 </div>
               )}
 
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center justify-end gap-2 min-w-0">
                 <button
                   type="button"
                   onClick={handleImportPick}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -106,6 +106,7 @@
     "analyze": "Im Analyser öffnen (nutzt Cache-Daten)",
     "clearAll": "Alle Favoriten löschen",
     "clearAllConfirm": "Alle {{count}} Favoriten entfernen? Das kann nicht rückgängig gemacht werden.",
+    "removeConfirm": "Favorit \"{{name}}\" entfernen? Die zwischengespeicherten Videos werden mit gelöscht. Das kann nicht rückgängig gemacht werden.",
     "noVideosInTimeFrame": "Keine Videos in diesem Zeitraum gefunden."
   },
   "dashboard": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -256,6 +256,7 @@
   },
   "backup": {
     "exportSuccess": "Backup-Datei wurde heruntergeladen.",
+    "exportFailed": "Download fehlgeschlagen. Der Browser hat die Datei blockiert.",
     "importSuccess": "Import abgeschlossen. {{count}} Favoriten wurden wiederhergestellt.",
     "importInvalid": "Ungültige Backup-Datei.",
     "importFailedStorage": "Import fehlgeschlagen (konnte nicht in den Browser-Speicher schreiben)."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -256,6 +256,7 @@
   },
   "backup": {
     "exportSuccess": "Backup downloaded.",
+    "exportFailed": "Download failed. Your browser blocked the file.",
     "importSuccess": "Import completed. {{count}} favorites restored.",
     "importInvalid": "Invalid backup file.",
     "importFailedStorage": "Import failed (could not write to browser storage)."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -106,6 +106,7 @@
     "analyze": "Open in Analyzer (uses cached data)",
     "clearAll": "Clear all favorites",
     "clearAllConfirm": "Remove all {{count}} favorites? This cannot be undone.",
+    "removeConfirm": "Remove the favorite \"{{name}}\"? Its cached videos are deleted too. This cannot be undone.",
     "noVideosInTimeFrame": "No videos found in this time frame."
   },
   "dashboard": {

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -316,13 +316,21 @@ export const ApiQuotaIndicator: React.FC = () => {
   // Show all sources - the container is scrollable (max-h-48 overflow-y-auto)
   const groupedCalls = useMemo(() => groupCallsByContext(history), [history]);
 
-  // Color based on percentage and exhausted state
+  // Color based on percentage and exhausted state.
+  //
+  // `text` is used inside the dropdown panel, which has its own dark surface in
+  // both themes — the 400 shades are the readable choice there. `trigger` is the
+  // same status colour for the indicator button, which sits on the *themed*
+  // header (white in light mode): a 400 shade on white is ~1.7–2.9:1 and fails
+  // WCAG 1.4.3, so the light theme needs a darker shade. Keep the two apart —
+  // collapsing them back into one value breaks whichever surface loses.
   const getColorClasses = () => {
     if (quota.exhausted) {
       return {
         bg: "bg-red-600",
         border: "border-red-500/50",
         text: "text-red-400",
+        trigger: "text-red-700 dark:text-red-400",
         glow: "shadow-red-500/30",
         bar: "bg-red-500",
         stroke: "#f87171",
@@ -333,6 +341,7 @@ export const ApiQuotaIndicator: React.FC = () => {
         bg: "bg-red-500",
         border: "border-red-500/30",
         text: "text-red-400",
+        trigger: "text-red-700 dark:text-red-400",
         glow: "shadow-red-500/20",
         bar: "bg-red-400",
         stroke: "#f87171",
@@ -343,6 +352,7 @@ export const ApiQuotaIndicator: React.FC = () => {
         bg: "bg-amber-500",
         border: "border-amber-500/30",
         text: "text-amber-400",
+        trigger: "text-amber-700 dark:text-amber-400",
         glow: "shadow-amber-500/20",
         bar: "bg-amber-400",
         stroke: "#fbbf24",
@@ -352,6 +362,7 @@ export const ApiQuotaIndicator: React.FC = () => {
       bg: "bg-emerald-500",
       border: "border-emerald-500/30",
       text: "text-emerald-400",
+      trigger: "text-emerald-700 dark:text-emerald-400",
       glow: "shadow-emerald-500/20",
       bar: "bg-emerald-400",
       stroke: "#34d399",
@@ -414,7 +425,7 @@ export const ApiQuotaIndicator: React.FC = () => {
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="group flex items-center gap-1.5 px-2 py-1 rounded hover:bg-slate-700/50 transition-colors cursor-pointer"
+        className="group flex items-center gap-1.5 px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700/50 transition-colors cursor-pointer"
         aria-label={t("quota.historyTitle")}
         aria-expanded={isOpen}
         aria-haspopup="dialog"
@@ -427,14 +438,14 @@ export const ApiQuotaIndicator: React.FC = () => {
       >
         {/* Icon - warning when exhausted, otherwise battery */}
         {quota.exhausted ? (
-          <AlertTriangle className={`w-3 h-3 ${colors.text} animate-pulse`} />
+          <AlertTriangle className={`w-3 h-3 ${colors.trigger} animate-pulse`} aria-hidden="true" />
         ) : (
-          <Zap className={`w-3 h-3 ${colors.text}`} />
+          <Zap className={`w-3 h-3 ${colors.trigger}`} aria-hidden="true" />
         )}
 
         {/* Battery bar container */}
         <div
-          className={`relative w-8 h-2.5 rounded-sm border ${colors.border} bg-slate-800/50 overflow-hidden`}
+          className={`relative w-8 h-2.5 rounded-sm border ${colors.border} bg-slate-200 dark:bg-slate-800/50 overflow-hidden`}
         >
           {/* Fill bar */}
           <div
@@ -445,7 +456,7 @@ export const ApiQuotaIndicator: React.FC = () => {
 
         {/* Percentage text */}
         <span
-          className={`text-[10px] font-mono ${colors.text} opacity-60 group-hover:opacity-100 transition-opacity min-w-[2rem]`}
+          className={`text-[10px] font-mono ${colors.trigger} opacity-100 dark:opacity-60 dark:group-hover:opacity-100 transition-opacity min-w-[2rem]`}
         >
           {quota.percentage}%
         </span>

--- a/src/shared/components/ui/VideoCard.tsx
+++ b/src/shared/components/ui/VideoCard.tsx
@@ -76,12 +76,19 @@ export const VideoCard: React.FC<VideoCardProps> = ({ video }) => {
     );
   };
 
-  // Determine color based on score
+  // Determine color based on score.
+  //
+  // The card surface is white in light mode, so the 400 shades that read well on
+  // the dark card were only ~1.7-2.9:1 there — the score is real content, so it
+  // has to clear the 4.5:1 of WCAG 1.4.3. Darker shades for light, the original
+  // 400s kept for dark. Only the text colour changes; the tinted background and
+  // border stay as they were. Mirrored in VideoListTable.
   const getScoreColor = (score: number) => {
     if (score >= 80)
-      return "text-red-400 bg-red-400/10 border-red-400/20 shadow-[0_0_15px_rgba(248,113,113,0.2)]";
-    if (score >= 50) return "text-amber-400 bg-amber-400/10 border-amber-400/20";
-    return "text-slate-400 bg-slate-400/10 border-slate-400/20";
+      return "text-red-700 dark:text-red-400 bg-red-400/10 border-red-400/20 shadow-[0_0_15px_rgba(248,113,113,0.2)]";
+    if (score >= 50)
+      return "text-amber-700 dark:text-amber-400 bg-amber-400/10 border-amber-400/20";
+    return "text-slate-600 dark:text-slate-400 bg-slate-400/10 border-slate-400/20";
   };
 
   return (

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -139,10 +139,15 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startInd
     );
   }, [sortedVideos, showFilter, normalizedFilter]);
 
+  // Light mode paints this table on a white surface, where the 400 shades were
+  // only ~1.7-2.9:1 — the score is content, so it has to clear the 4.5:1 of WCAG
+  // 1.4.3. Darker shades for light, the original 400s kept for dark; the tinted
+  // background and border are unchanged. Mirrors VideoCard.
   const getScoreColor = (score: number) => {
-    if (score >= 80) return "text-red-400 bg-red-400/10 border-red-400/20";
-    if (score >= 50) return "text-amber-400 bg-amber-400/10 border-amber-400/20";
-    return "text-slate-400 bg-slate-400/10 border-slate-400/20";
+    if (score >= 80) return "text-red-700 dark:text-red-400 bg-red-400/10 border-red-400/20";
+    if (score >= 50)
+      return "text-amber-700 dark:text-amber-400 bg-amber-400/10 border-amber-400/20";
+    return "text-slate-600 dark:text-slate-400 bg-slate-400/10 border-slate-400/20";
   };
 
   return (


### PR DESCRIPTION
## Description

Top-5 UX findings from a best-practice sweep, one commit per finding. Everything here is additive — labels, feedback, confirmation, semantics, contrast — no feature changes and no restyling beyond what each finding calls for.

Prior sweeps already covered the usual first-pass items (`alt` text, icon-button labels, focus rings, reduced motion, modal focus traps, `<html lang>` sync, live regions). What was left clusters around the **light theme**: components written dark-first that never got their `dark:` counterparts.

| # | Datei | Kategorie | Fix | Aufwand | Empfehlung |
|---|---|---|---|---|---|
| 1 | `ApiQuotaIndicator.tsx` | a11y | Quota trigger used dark-only colours on the white header — the percentage readout was ~1.7–2.9:1 (WCAG 1.4.3 wants 4.5:1). Split status colour into `text` (dropdown) / `trigger` (button) and add light variants for hover surface + battery track. | M | auto-fix |
| 2 | `VideoCard.tsx`, `VideoListTable.tsx` | a11y | `getScoreColor()` returned dark-only text colours; the trend score was ~1.7–2.9:1 on the white card/table surface. Paired each with a darker light-mode shade. | S | auto-fix |
| 3 | `App.tsx`, `locales/{en,de}.json` | interaction | Dashboard export toasted "Backup downloaded." even when the download was blocked. `downloadTextFile` now reports failure and the error toast fires instead. | M | auto-fix |
| 4 | `App.tsx`, `locales/{en,de}.json` | interaction | Per-row **Remove** deleted a favorite and its cache on the first click, next to **Refresh**, with no undo — while bulk `Clear all` already confirms. Same `window.confirm` guard, naming the favorite. | M | auto-fix |
| 5 | `AnalyserPage.tsx`, `DashboardPage.tsx` | responsive | Long unwrapped control rows ran past the page container from the `sm` breakpoint up, putting the whole document into a horizontal scroll on tablet-width viewports. Added `flex-wrap` + `min-w-0`. | S | auto-fix |

### Visible changes

- **Light theme only** for #1 and #2: the header quota percentage and the trend-score badges get darker, legible text. Dark mode renders byte-identically — every original value is kept behind `dark:`.
- **Dashboard**: removing a single favorite now opens a confirm dialog; a blocked backup export shows a red toast instead of a green one.
- **Analyser control bar / dashboard highlights row**: wrap onto a second line when they no longer fit. Nothing moves at desktop width.

Deferred findings (dark-only quota dropdown panel, 59 icons missing `aria-hidden`, avatar-initials contrast, the always-faded floating scroll button, and the `HiddenHighlightsModal` Unhide/Delete duplication) are written up in the issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (`backup.exportFailed`, `favorites.removeConfirm` in `en` + `de`)
- [x] Tested locally — `format:check` → `typecheck` → `lint` → `build`, all green (lint: 0 errors, 6 pre-existing `react-refresh` warnings in untouched files). No test runner is configured in this repo.

## Related Issues

Closes #377


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWs88CzVVdFJ3iAi3s64pv)_