### PR TITLE
chore: repo quality maintenance (Vite + React + TypeScript)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,13 +100,14 @@ Formatting is enforced in CI via `npm run format:check`. PRs with formatting dri
 
 ### Verification Before Submitting
 
-Formatting is only the first of three gates. `.github/workflows/pr-checks.yml` runs all of the
+Formatting is only the first of four gates. `.github/workflows/pr-checks.yml` runs all of the
 following on every pull request, so run them locally in this order to catch failures before CI does:
 
 ```bash
 npm run format:check  # 1. Prettier verification (read-only)
 npm run typecheck     # 2. tsc --noEmit — strict mode, noUnusedLocals/noUnusedParameters are ON
-npm run build         # 3. Production build to dist/ — must succeed
+npm run lint          # 3. ESLint 9 flat config — react-hooks rules; errors gate, warnings don't
+npm run build         # 4. Production build to dist/ — must succeed
 ```
 
 Notes:
@@ -114,7 +115,11 @@ Notes:
 - **Run `npm run format` first** if step 1 fails — it rewrites files in place, then re-check.
 - **Unused variables are type errors, not warnings** (`noUnusedLocals` / `noUnusedParameters`), so a
   leftover import fails step 2.
-- **There is no test suite yet.** No test framework is configured, so the three commands above are the
+- **ESLint does not duplicate `tsc`** — `eslint.config.js` disables `no-unused-vars` /
+  `no-explicit-any` and exists for `react-hooks/rules-of-hooks` + `exhaustive-deps`. Step 3 fails on
+  rule **errors** only; `react-refresh/only-export-components` warnings do not block. Use
+  `npm run lint:fix` for the auto-fixable subset.
+- **There is no test suite yet.** No test framework is configured, so the four commands above are the
   complete quality gate. See `agent_docs/testing.md` for the planned Vitest setup and priority targets.
 - CI additionally runs `npm audit --audit-level=high`, but that job is advisory and does not block.
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Open http://localhost:3000
 | `npm run build`        | Production build to `dist/`       |
 | `npm run preview`      | Build + local preview             |
 | `npm run typecheck`    | TypeScript type check (no emit)   |
+| `npm run lint`         | ESLint 9 flat config (CI gate)    |
+| `npm run lint:fix`     | ESLint with `--fix`               |
 | `npm run format`       | Auto-format with Prettier         |
 | `npm run format:check` | Verify formatting (CI-equivalent) |
 
@@ -230,8 +232,9 @@ React 19 | TypeScript | Vite 8 | Tailwind CSS 4 | i18next | Electron | YouTube D
 ## Contributing
 
 Contributions are welcome. [`CONTRIBUTING.md`](CONTRIBUTING.md) covers the development setup, the
-code style guidelines, the i18n rules and the three local checks that mirror CI
-(`npm run format:check` → `npm run typecheck` → `npm run build`) — run them before opening a PR.
+code style guidelines, the i18n rules and the four local checks that mirror CI
+(`npm run format:check` → `npm run typecheck` → `npm run lint` → `npm run build`) — run them before
+opening a PR.
 
 - **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 - **Reporting a vulnerability:** [`SECURITY.md`](SECURITY.md) — please use GitHub's private

--- a/agent_docs/deployment.md
+++ b/agent_docs/deployment.md
@@ -12,7 +12,7 @@ All seven workflow files, with every trigger each one actually declares:
 | `electron-release.yml`  | push to `main`/`master` · tag push `v*` · `workflow_dispatch`        | Builds win/mac/linux + Chromebook `.deb` + Chrome Extension + Android APK, then **creates a GitHub Release** |
 | `android-release.yml`   | push to `main`/`master` · `workflow_dispatch`                        | Standalone APK build, uploaded as a workflow artifact (no release)                                           |
 | `extension-release.yml` | push to `main`/`master` · `workflow_dispatch`                        | Standalone `dist-extension/` zip, uploaded as a workflow artifact (no release)                               |
-| `pr-checks.yml`         | `pull_request` → `main`/`master` (opened / synchronize / reopened)   | `format:check` → `tsc --noEmit` → optional lint → `build`, plus an advisory `npm audit` job                  |
+| `pr-checks.yml`         | `pull_request` → `main`/`master` (opened / synchronize / reopened)   | `format:check` → `tsc --noEmit` → `lint` → `build`, plus an advisory `npm audit` job                         |
 | `docs-format.yml`       | `pull_request` → `main`/`master` · push to `main`, both `**.md` only | Prettier `--check "**/*.md"` via `npx` at the version pinned in `package.json` — no `npm ci`, no build       |
 | `cleanup-ghcr.yml`      | weekly cron (Sun 04:00 UTC) · `workflow_dispatch`                    | Prunes untagged GHCR image versions, keeps the newest 10                                                     |
 

--- a/agent_docs/review_process.md
+++ b/agent_docs/review_process.md
@@ -57,7 +57,7 @@ UI Review (if UI changed)
 
 ## Automated Checks
 
-Canonical command list + order: **CLAUDE.md → Commands** (`format` write first, then `format:check` → `typecheck` → `build`). Run them before the review; `npm ci` first if dependencies are missing. Neither a linter nor a test runner is configured — those three commands are the whole gate.
+Canonical command list + order: **CLAUDE.md → Commands** (`format` write first, then `format:check` → `typecheck` → `lint` → `build`). Run them before the review; `npm ci` first if dependencies are missing. No test runner is configured, so those four commands are the whole gate — but a linter **is** configured: ESLint 9 (`eslint.config.js`, added in #376) runs as a hard step in `pr-checks.yml`. Its rule errors gate; `react-refresh/only-export-components` warnings do not (BACKLOG #14).
 
 ### Test execution constraints (autonomy + zero-cost)
 

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -9,8 +9,12 @@ Offloaded from `CLAUDE.md` (2026-07-26) per `agent_docs/context_budget.md` ladde
 ```bash
 npm run format:check   # Prettier verification (matches CI)
 npm run typecheck      # tsc --noEmit (strict mode)
+npm run lint           # ESLint 9 flat config (matches CI; errors gate, warnings don't)
 npm run build          # production build must succeed
 ```
+
+A **linter** does exist — ESLint 9 landed in #376 and `pr-checks.yml` runs it as a hard step. Only the
+**test runner** is missing; do not read "no test framework" as "no static analysis".
 
 `package.json` has no `test` script. Do not invent one in generated docs or CI until a framework actually lands.
 


### PR DESCRIPTION
## Description

Repo-quality maintenance sweep. ESLint 9 landed in #376 and `.github/workflows/pr-checks.yml` runs `npm run lint` as a hard gate — but five documents were never updated and still describe a three-command, linter-less quality gate. Anyone following them locally skips exactly the step CI enforces; `agent_docs/review_process.md` went further and told agents "Neither a linter nor a test runner is configured".

Documentation only. No functional change, no runtime config, no secrets.

### Merged findings

| #   | Pass | File(s)                                                       | Finding                                                                                                                                                                                    | Fix                                                                                                                 | Effort | Recommendation |
| --- | ---- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------ | -------------- |
| 1   | D    | `README.md`, `CONTRIBUTING.md`                                | Available-scripts table omits `lint` / `lint:fix` (the platform-script exemption note does not cover them). "Three local checks that mirror CI" / "first of three gates" both undercount. | Added both script rows; ESLint inserted as step 3 of "Verification Before Submitting"; counts corrected to four.    | S      | auto-fix       |
| 2   | D    | `agent_docs/testing.md`, `review_process.md`, `deployment.md` | `review_process.md` claimed no linter is configured; `testing.md` listed a three-command gate; `deployment.md` called the `pr-checks.yml` lint step "optional".                            | Added `lint` to both gate listings, separated "no test runner" from "no static analysis", marked the step mandatory. | S      | auto-fix       |

The documented chain is now `format:check` → `typecheck` → `lint` → `build` everywhere, matching `pr-checks.yml`. `CLAUDE.md` already had it right and is unchanged.

### Artefact status

| Artefact          | Present | Complete (code parity) |
| ----------------- | ------- | ---------------------- |
| .env.example      | yes     | yes                    |
| Config example    | n.a.    | n.a.                   |
| README onboarding | yes     | fixed by this PR       |
| Referenced docs   | yes     | yes                    |
| BACKLOG.md        | yes     | tidy                   |

ENV parity is exact — all five code-scanned keys (`VITE_DEFAULT_SEARCH`, `VITE_GIT_COMMIT_HASH`, `VITE_GIT_BRANCH`, `ELECTRON`, `VITE_DEV_SERVER_URL`) are in `.env.example` with purpose, required/optional, default and format; no missing keys, no orphans. All 35 referenced `.md` files exist and none is a stub.

### Backlog review

| Entry (short)                                            | Action | Evidence                                                                                                                                        |
| ---------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| #14 — 6 `react-refresh/only-export-components` warnings | kept   | Still valid: `ThemeProvider.tsx`, `Toast.tsx` and `VideoListSortHeader.tsx` each still export a non-constant next to a component. No merged PR matches. |

0 removed, 0 extracted to issues, 0 consolidated, 1 kept. `BACKLOG.md` is unchanged.

## Type of Change

- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [ ] Added translations for new UI text (if applicable) — n.a., no UI text touched
- [x] Tested locally — `npx prettier@3.9.6 --check "**/*.md"` passes (the `docs-format.yml` gate). `pr-checks.yml` carries `paths-ignore: "**.md"`, so it does not run for this PR; no source, config or lockfile was touched, so its typecheck/lint/build chain is unaffected.

## Related Issues

Closes #379

---
_Generated by [Claude Code](https://claude.ai/code/session_013ShaZt3K9wBHCm5rnVwFAN)_