### PR TITLE
refine: ux sweep (Vite + React + TypeScript)

### DIFF
--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -528,7 +528,15 @@ export function AnalyserPage({
                   {t("results.moreVideos")}
                 </h3>
               </div>
-              <VideoListTable videos={otherVideos} startIndex={topN + 1} />
+              {/* analysisKey identifies the analysis on screen (channel plus the
+                  moment it was produced), so the table can drop a title filter
+                  left over from the previous one. Re-sorting or switching
+                  Top 3/6 keeps the same key and therefore the same filter. */}
+              <VideoListTable
+                videos={otherVideos}
+                startIndex={topN + 1}
+                analysisKey={`${searchState.channelName}|${searchState.resultSavedAt ?? ""}`}
+              />
             </div>
           )}
         </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -128,6 +128,7 @@
       "hiddenModalTitle": "Ausgeblendete Videos",
       "noHiddenItems": "Keine ausgeblendeten Videos.",
       "unhide": "Einblenden",
+      "unhideAria": "\"{{title}}\" wieder einblenden",
       "delete": "Löschen",
       "empty": "Noch keine Highlights verfügbar. Highlights erscheinen, sobald deine Favoriten Videos geladen haben."
     },
@@ -253,6 +254,8 @@
   },
   "confirm": {
     "deleteApiKey": "Möchtest du den API Key wirklich löschen?",
+    "restoreAllHidden_one": "Das {{count}} ausgeblendete Video wieder einblenden?",
+    "restoreAllHidden_other": "Alle {{count}} ausgeblendeten Videos wieder einblenden?",
     "importDashboardReplace": "Import ersetzt deine aktuellen Dashboard-Favoriten und den Cache ({{count}} Favoriten). Fortfahren?"
   },
   "backup": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -306,6 +306,8 @@
     "historyTitle": "API-Nutzung",
     "units": "Einheiten",
     "copySummary": "Kontingent-Übersicht kopieren",
+    "copied": "Kontingent-Übersicht kopiert",
+    "copyFailed": "Zwischenablage nicht verfügbar",
     "calls": "Aufrufe",
     "last24Hours": "Letzte 24 Stunden",
     "lastTimeWindow": "Letzte {{time}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -128,6 +128,7 @@
       "hiddenModalTitle": "Hidden Videos",
       "noHiddenItems": "No hidden videos.",
       "unhide": "Show",
+      "unhideAria": "Show \"{{title}}\" again",
       "delete": "Delete",
       "empty": "No highlights available yet. Highlights will appear once your favorites have loaded videos."
     },
@@ -253,6 +254,8 @@
   },
   "confirm": {
     "deleteApiKey": "Do you really want to delete the API key?",
+    "restoreAllHidden_one": "Show the {{count}} hidden video again?",
+    "restoreAllHidden_other": "Show all {{count}} hidden videos again?",
     "importDashboardReplace": "Import will replace your current dashboard favorites and cache ({{count}} favorites). Continue?"
   },
   "backup": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -306,6 +306,8 @@
     "historyTitle": "API Usage",
     "units": "Units",
     "copySummary": "Copy quota summary",
+    "copied": "Quota summary copied",
+    "copyFailed": "Clipboard unavailable",
     "calls": "Calls",
     "last24Hours": "Last 24 hours",
     "lastTimeWindow": "Last {{time}}",

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Activity,
+  AlertCircle,
   AlertTriangle,
   AtSign,
   Check,
@@ -214,20 +215,38 @@ export const ApiQuotaIndicator: React.FC = () => {
   const [history, setHistory] = useState<QuotaHistoryEntry[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  // A blocked clipboard used to make this button a dead control: it returned
+  // silently, so the user clicked and nothing at all happened. Every other copy
+  // action in the app (VideoCard, VideoListTable, the analyser bulk actions)
+  // flashes a warning icon instead — this one now matches them.
+  const [copyFailed, setCopyFailed] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Clear the copy-feedback timer on unmount to avoid setState after unmount
+  // Clear the copy-feedback timers on unmount to avoid setState after unmount
   useEffect(() => {
     return () => {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      if (copyFailedTimerRef.current) clearTimeout(copyFailedTimerRef.current);
     };
   }, []);
+
+  const flashCopyFailed = () => {
+    setCopyFailed(true);
+    if (copyFailedTimerRef.current) clearTimeout(copyFailedTimerRef.current);
+    copyFailedTimerRef.current = setTimeout(() => setCopyFailed(false), 2500);
+  };
 
   // Copy a plain-text quota summary (used / limit / percentage) to the clipboard.
   const handleCopyQuota = () => {
     // navigator.clipboard is undefined in insecure contexts (HTTP, some iframes).
-    if (!navigator.clipboard) return;
+    // Accessing .writeText on it throws synchronously, which the promise
+    // rejection handler below would not catch — so guard the property first.
+    if (!navigator.clipboard) {
+      flashCopyFailed();
+      return;
+    }
     const summary = `${t("quota.label")}: ${formatNumber(quota.used)} / ${formatNumber(
       quota.limit,
     )} ${t("quota.units")} (${quota.percentage}%)`;
@@ -238,7 +257,8 @@ export const ApiQuotaIndicator: React.FC = () => {
         copyTimerRef.current = setTimeout(() => setCopied(false), 1500);
       },
       () => {
-        // Clipboard API unavailable (HTTP context, iframe restriction, etc.)
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyFailed();
       },
     );
   };
@@ -421,6 +441,11 @@ export const ApiQuotaIndicator: React.FC = () => {
 
   return (
     <div className="relative" ref={dropdownRef}>
+      {/* Polite live region: announce the copy result to assistive tech — the
+          icon swap alone is silent to screen readers (mirrors VideoCard). */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {copyFailed ? t("quota.copyFailed") : copied ? t("quota.copied") : ""}
+      </span>
       {/* Clickable indicator */}
       <button
         type="button"
@@ -497,11 +522,15 @@ export const ApiQuotaIndicator: React.FC = () => {
                 <button
                   type="button"
                   onClick={handleCopyQuota}
-                  className="inline-flex items-center justify-center w-6 h-6 rounded-md bg-slate-800/60 hover:bg-slate-700 text-slate-400 hover:text-slate-200 transition-colors border border-slate-700"
-                  title={t("quota.copySummary")}
-                  aria-label={t("quota.copySummary")}
+                  className={`inline-flex items-center justify-center w-6 h-6 rounded-md bg-slate-800/60 hover:bg-slate-700 transition-colors border border-slate-700 ${
+                    copyFailed ? "text-red-400" : "text-slate-400 hover:text-slate-200"
+                  }`}
+                  title={copyFailed ? t("quota.copyFailed") : t("quota.copySummary")}
+                  aria-label={copyFailed ? t("quota.copyFailed") : t("quota.copySummary")}
                 >
-                  {copied ? (
+                  {copyFailed ? (
+                    <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                  ) : copied ? (
                     <Check className="w-3.5 h-3.5 text-green-500" aria-hidden="true" />
                   ) : (
                     <Copy className="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/shared/components/ui/HiddenHighlightsModal.tsx
+++ b/src/shared/components/ui/HiddenHighlightsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Clock, ExternalLink, Eye, Trash2, X } from "lucide-react";
+import { Clock, ExternalLink, Eye, RotateCcw, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { hiddenHighlightsService, type HiddenHighlight } from "@/src/features/dashboard";
 import { getLocale } from "@/src/shared/lib/locale";
@@ -86,9 +86,14 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
     setHiddenItems(hiddenHighlightsService.listChronological());
   };
 
-  const handleDelete = (videoId: string) => {
-    // show() removes the entry from the hidden list (un-hiding it)
-    hiddenHighlightsService.show(videoId);
+  // Restoring one entry at a time is the only way back out of this list, so a
+  // user who hid a dozen highlights had a dozen clicks ahead of them. clearAll()
+  // already existed on the service and the label was already translated
+  // (dashboard.highlights.clearHidden) — nothing surfaced either. Confirmed
+  // first, matching the app's other bulk actions (clear all favorites, import).
+  const handleRestoreAll = () => {
+    if (!window.confirm(t("confirm.restoreAllHidden", { count: hiddenItems.length }))) return;
+    hiddenHighlightsService.clearAll();
     setHiddenItems(hiddenHighlightsService.listChronological());
   };
 
@@ -126,21 +131,43 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
         className="relative bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[80vh] mx-4 flex flex-col overflow-hidden border border-slate-200 dark:border-slate-700"
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-700">
-          <h2
-            id="hidden-highlights-modal-title"
-            className="text-lg font-bold text-slate-900 dark:text-white"
-          >
-            {t("dashboard.highlights.hiddenModalTitle")}
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400 transition-colors"
-            aria-label={t("modal.close")}
-          >
-            <X className="w-5 h-5" aria-hidden="true" />
-          </button>
+        <div className="flex items-center justify-between gap-3 px-6 py-4 border-b border-slate-200 dark:border-slate-700">
+          <div className="flex items-center gap-2 min-w-0">
+            <h2
+              id="hidden-highlights-modal-title"
+              className="text-lg font-bold text-slate-900 dark:text-white truncate"
+            >
+              {t("dashboard.highlights.hiddenModalTitle")}
+            </h2>
+            {/* How many entries are in here — the list itself scrolls, so the
+                size was only knowable by counting rows. */}
+            {hiddenItems.length > 0 && (
+              <span className="shrink-0 rounded-full border border-slate-300 bg-slate-100 px-2 py-0.5 text-xs text-slate-600 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                {t("dashboard.highlights.hiddenCount", { count: hiddenItems.length })}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            {hiddenItems.length > 0 && (
+              <button
+                type="button"
+                onClick={handleRestoreAll}
+                className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-indigo-500/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
+                title={t("dashboard.highlights.clearHidden")}
+              >
+                <RotateCcw className="w-3 h-3" aria-hidden="true" />
+                <span className="hidden sm:inline">{t("dashboard.highlights.clearHidden")}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 dark:text-slate-400 transition-colors"
+              aria-label={t("modal.close")}
+            >
+              <X className="w-5 h-5" aria-hidden="true" />
+            </button>
+          </div>
         </div>
 
         {/* Content */}
@@ -197,22 +224,21 @@ export function HiddenHighlightsModal({ isOpen, onClose }: HiddenHighlightsModal
                     >
                       <ExternalLink className="w-3 h-3" aria-hidden="true" />
                     </a>
+                    {/* One restore action per row. The red "Delete" button that
+                        used to sit here called the exact same service method
+                        (show() = drop the entry from the hidden list), so the
+                        row offered a destructive-looking second button for an
+                        action that was already available and non-destructive. */}
                     <button
                       type="button"
                       onClick={() => handleUnhide(item.videoId)}
                       className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-indigo-500/30 text-indigo-500 dark:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
+                      aria-label={t("dashboard.highlights.unhideAria", {
+                        title: item.videoTitle ?? "",
+                      })}
                     >
-                      <Eye className="w-3 h-3" />
+                      <Eye className="w-3 h-3" aria-hidden="true" />
                       {t("dashboard.highlights.unhide")}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(item.videoId)}
-                      className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md border border-red-500/30 text-red-400 dark:text-red-300 hover:bg-red-500/10 transition-colors"
-                      aria-label={t("dashboard.highlights.delete")}
-                      title={t("dashboard.highlights.delete")}
-                    >
-                      <Trash2 className="w-3 h-3" aria-hidden="true" />
                     </button>
                   </div>
                 </li>

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -24,11 +24,29 @@ const FILTER_MIN_ROWS = 10;
 interface VideoListTableProps {
   videos: VideoData[];
   startIndex: number;
+  /**
+   * Identity of the analysis these rows belong to. Changing it clears the title
+   * filter — see the effect below. Optional so the table stays usable without it.
+   */
+  analysisKey?: string;
 }
 
-export const VideoListTable: React.FC<VideoListTableProps> = ({ videos, startIndex }) => {
+export const VideoListTable: React.FC<VideoListTableProps> = ({
+  videos,
+  startIndex,
+  analysisKey,
+}) => {
   const { t } = useTranslation();
   const [filter, setFilter] = useState("");
+
+  // The table is not remounted between analyses, so a filter typed for the
+  // previous channel stayed active for the next one: the user ran a new search
+  // and landed on "No video title matches <the word they typed minutes ago>",
+  // or on a silently truncated list. The filter belongs to the result set that
+  // was on screen when it was typed, so a new analysis drops it.
+  useEffect(() => {
+    setFilter("");
+  }, [analysisKey]);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [copiedTitleId, setCopiedTitleId] = useState<string | null>(null);
   // Which row/action last failed, so a blocked clipboard is visible feedback


### PR DESCRIPTION
## Description

Three comfort/UX refinements to existing features. Each is additive and stays inside the component that owns the feature; no new features, no dependencies, no refactoring.

| # | Original feature | UX gap | Improvement | Aufwand | Empfehlung |
|---|---|---|---|---|---|
| 1 | API quota indicator — "Copy quota summary" | The only copy action in the app without failure feedback: a blocked clipboard (insecure context, denied permission, unfocused document) returned silently, so the button looked like a dead control | Guard `navigator.clipboard` before touching it, flash an `AlertCircle` + "clipboard unavailable" label for 2.5 s on both failure paths, and announce the outcome through a polite `sr-only` live region — the same shape VideoCard, VideoListTable and the analyser bulk actions already use | S | auto-refine |
| 2 | Hidden Videos modal (dashboard → "Hidden") | No bulk restore, so undoing a hiding spree cost one click per entry; no size indication on a scrolling list; and every row offered "Show" **plus** a red trash "Delete" that called the identical service method (`show()`) | Confirmed "Show all hidden" header action — `hiddenHighlightsService.clearAll()` and its translation already existed but nothing surfaced them — a count badge reusing the equally unused `hiddenCount` key, and the destructive-looking duplicate replaced by one clearly-labelled restore button with a per-item `aria-label` | S | auto-refine |
| 3 | Analyser results table title filter | The table is not remounted between analyses, so a filter typed for one channel stayed active for the next search: the user could land on "No video title matches &lt;a word they typed minutes ago&gt;" or on a silently truncated list, with nothing pointing at the cause | The table takes an `analysisKey` (channel + the moment the analysis was produced) and clears the filter when it changes; re-sorting columns or switching Top 3/6 keeps the same key, and therefore the filter | S | auto-refine |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — `quota.copied`, `quota.copyFailed`, `confirm.restoreAllHidden`, `dashboard.highlights.unhideAria` in both `en` and `de`
- [x] Tested locally — `format:check` → `typecheck` → `lint` (0 errors, 6 pre-existing `react-refresh` warnings) → `build`, all green. No test runner is configured in this repo.

## Related Issues

Closes #381


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKeba7pWTmW91oo4Vju79g)_