### PR TITLE
security: hardening sweep (Vite + React SPA)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -45,7 +45,7 @@ server {
     #   theme) — the app itself keeps working.
     # - connect-src allows the YouTube Data API; img-src allows YouTube thumbnail CDNs
     #   (i.ytimg.com, *.ggpht.com, *.googleusercontent.com) via the generic https: source.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-jruAVbleMoklzXIdqjOgmlFQ78IckrHmADK/VuUAO/U='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-gWm6I0QtusD49TVJ/zybUBJl1/uavGwHt37pQzBDoC8='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     # Gzip compression for text assets
     gzip on;
@@ -69,6 +69,6 @@ server {
         add_header Strict-Transport-Security "max-age=31536000" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-jruAVbleMoklzXIdqjOgmlFQ78IckrHmADK/VuUAO/U='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-gWm6I0QtusD49TVJ/zybUBJl1/uavGwHt37pQzBDoC8='; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     }
 }

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -41,11 +41,35 @@ interface PersistedAnalyserResult {
   savedAt: number;
 }
 
+/** True only for absolute http(s) URLs — the schemes an `<a href>` may safely navigate to. */
+function isHttpUrl(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The persisted snapshot is rehydrated straight into the analyser view, where every
+ * entry's `url` becomes an `<a href={video.url}>` (VideoCard, VideoListTable). Treat
+ * it like any other on-disk input and reject a snapshot carrying a non-http(s) URL,
+ * so a `javascript:` URL can never reach a link in the app origin — the origin whose
+ * localStorage holds the YouTube API key. dashboardBackupService.parse() applies the
+ * identical guard to the backup-import boundary; this is the second boundary the same
+ * cached-video shape crosses. Genuine snapshots only ever contain
+ * `https://www.youtube.com/watch?v=<id>` (built in trendAnalysisService), so this is
+ * behavior-equivalent for real data and fails closed — a rejected snapshot simply
+ * starts the analyser empty, exactly like an expired one. CWE-79 / OWASP A03.
+ */
 function isPersistedAnalyserResult(value: unknown): value is PersistedAnalyserResult {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
   return (
     Array.isArray(v.data) &&
+    v.data.every((entry) => isHttpUrl((entry as { url?: unknown } | null | undefined)?.url)) &&
     typeof v.channelName === "string" &&
     typeof v.savedAt === "number" &&
     (v.channelId === undefined || typeof v.channelId === "string")


### PR DESCRIPTION
Autonomous security hardening sweep over the **web-app** part (SPA under `src/**` + the nginx serving config that ships it as `ghcr.io/fo0/tubetrend`). Electron / Capacitor / Chrome-extension wrappers are deliberately out of scope.

The codebase was already in good shape — no XSS sinks (`dangerouslySetInnerHTML`, `innerHTML`, `eval` all absent), every `target="_blank"` carries `rel="noopener noreferrer"`, CSV injection is neutralized, the only `fetch()` goes to a fixed `googleapis.com` URL, workflow permissions are least-privilege, and production dependencies report 0 vulnerabilities. Two real defects remained.

## Fixed

| # | Category | Severity | File | Fix |
|---|----------|----------|------|-----|
| 1 | Injection / XSS (CWE-79, A03) | Low (defense-in-depth) | `src/features/search/hooks/useSearch.ts` | Validate persisted video URLs on analyser rehydration |
| 2 | Security Misconfiguration (A05) | Low | `nginx.conf` | Refresh the stale CSP `script-src` hash |

**1 — Analyser snapshot rehydration trusted its stored URLs.**
The last analyser result is persisted to `localStorage` and restored on mount, where each entry's `url` becomes `<a href={video.url}>` (VideoCard, VideoListTable). The type guard only checked `Array.isArray(v.data)`, so a snapshot carrying a `javascript:` URL would place it behind a result link in the app origin — the origin whose `localStorage` holds the YouTube API key. This applies the identical guard `dashboardBackupService.parse()` already enforces on the backup-import boundary (#363), closing the second boundary the same cached-video shape crosses. Genuine snapshots only ever contain `https://www.youtube.com/watch?v=<id>`, so it is behavior-equivalent for real data and fails closed — a rejected snapshot starts the analyser empty, exactly like an expired one.

**2 — The CSP pinned a hash that no longer matched the shipped script.**
`script-src` pins the inline FOUC theme script by sha256 so it can stay free of `'unsafe-inline'` — the property that stops an injected `<script>` from executing in a client-only SPA. The script's content was edited without recomputing the hash. Verified: Vite copies the block verbatim into `dist/index.html`, and recomputing with the command documented in `nginx.conf` yields `sha256-gWm6I0…`, not the pinned `sha256-jruAVb…`. Blocking fails closed, so this was a degradation (theme flash on load) rather than a weakening — but a stale hash invites the wrong repair, `'unsafe-inline'`, which would remove the CSP's main protection. Both occurrences (server block and `/assets/`) updated together.

## Verification

`npm run format` → `format:check` → `typecheck` → `lint` → `build` — all green. No test step: this repo has no test framework configured (per `CLAUDE.md`), and none was added. The CSP hash was re-verified against the final build output.

> Note: `npm run format:check` also flagged three unrelated files mid-run, but that turned out to be an artifact of a non-pinned Prettier resolving before `npm ci`; the lockfile-pinned Prettier 3.9.6 considers `main` clean. No formatting changes are included in this PR.

## Not fixed (reported, not autonomously actionable)

- **Dev-dependency CVEs** — 6 advisories (3 moderate, 3 high) in the Capacitor CLI toolchain (`uuid` → `xcode` → `@capacitor/cli`). Build-time only, never in the shipped web bundle; production deps are clean. Dependabot's territory, and the fix is a breaking major.
- **Actions pinned by tag, not commit SHA** — 11 pins across 7 workflows, all from `actions/*`, `docker/*`, `android-actions/*`. Defense-in-depth only; too broad for a security sweep to change unilaterally.
- **Container runs nginx as root** — moving to a non-root user requires the listen port to change (80 → 8080), which breaks the published image contract and `docker-compose.yml`.
- **`img-src https:` and `style-src 'unsafe-inline'`** — both currently required (YouTube CDN uses many subdomains; Tailwind/React emit inline styles).

Refs #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRGqPtKngEBcaRDJWetrHq)_