### PR TITLE
chore: quality & housekeeping sweep (Vite + React)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Top 5 lookup index — descriptions, event list, error handling: `agent_docs/key
 
 - **Language:** UI text via i18n keys (`t('key')`); comments and docs in English.
 - **Naming:** PascalCase components/types, camelCase functions/variables/hooks, kebab-case CSS classes. Files: PascalCase components, camelCase services/hooks/utils.
-- **Imports:** cross-module via the `@/src/…` alias (~132 sites); relative only inside a module; `import type` for types. `@features|@shared|@providers|@i18n` resolve but are unused — don't start.
+- **Imports:** cross-module via the `@/src/…` alias (~148 sites); relative only inside a module; `import type` for types. `@features|@shared|@providers|@i18n` resolve but are unused — don't start.
 - **Exports:** barrel `index.ts` per feature — never deep-import another feature's internals.
 - **Styling / state:** Tailwind v4 with `dark:` variants; custom hooks + `localStorage`, Context only for theme. No CSS modules, no state library.
 - **Max file length:** ~300 lines (split), ~500 (strongly recommended).
@@ -199,7 +199,7 @@ Toolchain rules, one-build-five-targets: `agent_docs/development_notes.md` · pl
 
 ## Refactoring Notes
 
-Four files sit over the ~500-line bar (largest: `InputSection.tsx` ~768) and there is no test coverage. Current list, split candidates, the resolved list (do not re-open) and the principles: `agent_docs/refactoring_guidelines.md`
+Five files sit over the ~500-line bar (largest: `InputSection.tsx` ~775) and there is no test coverage. Current list, split candidates, the resolved list (do not re-open) and the principles: `agent_docs/refactoring_guidelines.md`
 
 ## Documentation Rules
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Enter your API key in the app when prompted.
 - **Highlights** — Auto-surface top-performing videos
 - **Desktop App** — Portable Electron app for Windows, macOS, and Linux
 - **Chrome Extension** — Install as browser extension, opens in a new tab
-- **Multi-language** — 13 languages with auto-detection
+- **Multi-language** — English and German translations; 11 further locales auto-detect and fall back to English
 - **Dark Mode** — System-aware with manual toggle
 - **Offline-ready** — All CSS and fonts bundled locally (only YouTube API needs internet)
 - **API Quota Tracking** — Monitor YouTube API usage

--- a/agent_docs/refactoring_guidelines.md
+++ b/agent_docs/refactoring_guidelines.md
@@ -22,12 +22,13 @@ Refactoring does NOT happen automatically. Only when:
 
 ## Known Refactoring Targets
 
-Verified against the tree on 2026-07-30. Line counts come from `find src -name '*.ts*' | xargs wc -l | sort -rn`; re-run it before trusting a number here.
+Verified against the tree on 2026-08-16. Line counts come from `find src -name '*.ts*' | xargs wc -l | sort -rn`; re-run it before trusting a number here.
 
-- **`InputSection.tsx` (~768 lines)** — the largest file in `src/`. Search form, autocomplete, search history, timeframe/max-results controls and their `localStorage` persistence in one component. Split candidates: a `useSearchHistory()` hook and a separate autocomplete dropdown component.
-- **`FavoriteRow.tsx` (~715 lines)** — God component handling data fetching, caching, UI menus, state management and event handling, with 11 interdependent `useEffect` hooks plus refs for synchronization. Should be split into sub-components (`FavoriteRowHeader`, `FavoriteRowMenus`, `FavoriteRowVideos`) and a custom `useFavoriteRowData()` hook that absorbs the effect chain.
-- **`ApiQuotaIndicator.tsx` (~686 lines)** — quota badge, history panel and time-window selection in one file. The window/aggregation math is pure and extractable into a service, which would also make it the first easily testable target here.
-- **`AnalyserPage.tsx` (~576 lines)** — page shell plus sort/topN state, export handlers and clipboard handling. Extract the export + copy-all actions.
+- **`InputSection.tsx` (~775 lines)** — the largest file in `src/`. Search form, autocomplete, search history, timeframe/max-results controls and their `localStorage` persistence in one component. Split candidates: a `useSearchHistory()` hook and a separate autocomplete dropdown component.
+- **`FavoriteRow.tsx` (~734 lines)** — God component handling data fetching, caching, UI menus, state management and event handling, with 11 interdependent `useEffect` hooks plus refs for synchronization. Should be split into sub-components (`FavoriteRowHeader`, `FavoriteRowMenus`, `FavoriteRowVideos`) and a custom `useFavoriteRowData()` hook that absorbs the effect chain.
+- **`ApiQuotaIndicator.tsx` (~726 lines)** — quota badge, history panel and time-window selection in one file. The window/aggregation math is pure and extractable into a service, which would also make it the first easily testable target here.
+- **`AnalyserPage.tsx` (~599 lines)** — page shell plus sort/topN state, export handlers and clipboard handling. Extract the export + copy-all actions.
+- **`DashboardPage.tsx` (~519 lines)** — page shell plus favorites filtering, import/export picking, refresh-progress tracking and highlight aggregation. Newly over the 500-line bar. The `useMemo` filter/aggregation chain (`favoriteHaystacks`, `matchingFavoriteIds`, `highlightVideosData`) is the natural extraction into a `useDashboardFilters()` hook.
 - **No test coverage** — no test framework is configured. Critical services (`favoritesService`, `trendAnalysisService`, `quotaService`, `eventBus`, `storage`) would benefit from unit tests; priority order in `agent_docs/testing.md`.
 
 ### Resolved — do not re-open


### PR DESCRIPTION
## Description

Automated quality & housekeeping sweep. **Docs-only** — no code, no dependency changes, **no version bumps included**. One commit per finding.

| #   | Pass   | Datei(en)                                           | Befund → Fix                                                                                                                                                                                        | Aufwand | Empfehlung |
| --- | ------ | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------- |
| 1   | E Docs | `README.md`                                         | Feature-Liste warb mit „13 languages with auto-detection", obwohl nur `en` + `de` Resource-Bundles haben → auf „English and German translations; 11 further locales auto-detect and fall back to English" korrigiert | S       | auto-fix   |
| 2   | E Docs | `CLAUDE.md`, `agent_docs/refactoring_guidelines.md` | Line-Counts seit 2026-07-30 gedriftet, „Four files" über der 500-Zeilen-Grenze sind inzwischen fünf, Alias-Zahl ~132 statt 148 → neu gemessen, `DashboardPage.tsx` (519) ergänzt, Zahlen korrigiert    | S       | auto-fix   |

Finding 1 war die einzige Doku-Stelle, die zu viel versprach: `CONTRIBUTING.md`, `agent_docs/platform_builds.md` und der Kommentar in `src/i18n/config.ts` beschreiben das Fallback-Verhalten bereits korrekt.

Gemessene Werte für Finding 2 (`find src -name '*.ts*' | xargs wc -l | sort -rn`):

| Datei                   | Doku (alt)   | Ist |
| ----------------------- | ------------ | --- |
| `InputSection.tsx`      | ~768         | 775 |
| `FavoriteRow.tsx`       | ~715         | 734 |
| `ApiQuotaIndicator.tsx` | ~686         | 726 |
| `AnalyserPage.tsx`      | ~576         | 599 |
| `DashboardPage.tsx`     | (ungelistet) | 519 |

## Tooling-Status

| Tool                       | Aktiv          | Lief grün |
| -------------------------- | -------------- | --------- |
| Formatter (Prettier 3.9.6) | ja             | ja        |
| Linter (ESLint 9 flat)     | ja             | ja        |
| Typecheck (tsc)            | ja             | ja        |
| Build (vite)               | ja             | ja        |
| Tests                      | nein (bewusst) | —         |

Pass A (Formatting), B (Linting), D (Unused Deps) und F (Outdated/Dead Code) waren sauber — keine Findings.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — n/a, keine UI-Strings geändert
- [x] Tested locally — `npm ci` → `format:check` → `typecheck` → `lint` → `build` alle grün (kein Test-Runner konfiguriert)

## Related Issues

Closes #392

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5vjm8BxS8uu8fQMe8Rhy8)_