### PR TITLE
feat: comfort sweep (Vite + React)

### DIFF
--- a/agent_docs/project_structure.md
+++ b/agent_docs/project_structure.md
@@ -61,7 +61,7 @@ tubetrend/
 
 ## Feature Module Pattern
 
-A `src/features/` module draws from the same four parts, but takes only the ones it needs — no module currently has all four:
+A `src/features/` module draws from the same four parts, but takes only the ones it needs — `youtube` is currently the only one with all four:
 
 - `services/` — pure business logic
 - `hooks/` — React-state composition
@@ -74,6 +74,6 @@ A `src/features/` module draws from the same four parts, but takes only the ones
 | `favorites` | ✅          | —        | ✅         | ✅         |
 | `search`    | —           | ✅       | —          | —          |
 | `videos`    | ✅          | —        | ✅         | ✅         |
-| `youtube`   | ✅          | —        | ✅         | ✅         |
+| `youtube`   | ✅          | ✅       | ✅         | ✅         |
 
 `search` has no barrel, so `App.tsx` and `AnalyserPage.tsx` import `hooks/useSearch` directly. Every other cross-module import goes through the barrel.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import {
   getApiKey as getYoutubeApiKey,
   setApiKey as setYoutubeApiKey,
+  useQuotaWarning,
 } from "@/src/features/youtube";
 import { dashboardBackupService } from "@/src/features/dashboard";
 import { favoritesService } from "@/src/features/favorites";
@@ -64,6 +65,11 @@ const App: React.FC = () => {
     useFavorites();
   const { sortMode, sortOrder, cacheTick, handleSortClick, sortFavorites } = useDashboardSort();
   const { hiddenTick } = useHighlights(favorites);
+
+  // Raise a toast when the daily YouTube quota is nearly spent or gone. Lives at
+  // the root because the quota is app-wide and the header indicator — the only
+  // previous signal — is easy to miss until a search fails.
+  useQuotaWarning();
 
   const onApiKeyInvalid = useCallback(() => {
     setYoutubeApiKey("");

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -204,6 +204,34 @@ export function DashboardPage({
     copyAllFailedTimerRef.current = setTimeout(() => setCopyAllHighlightsFailed(false), 2500);
   };
 
+  // Jump from a highlight card (or an avatar in the quick-jump strip) to the
+  // favorite row it belongs to.
+  const scrollToFavorite = (favoriteId: string) => {
+    document
+      .getElementById(`favorite-${favoriteId}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  // A filtered-out row is rendered with `hidden` (never unmounted, to protect
+  // the API quota), so scrolling to it would land on a zero-height element.
+  // Drop the filter first and let the effect below scroll once the row is back.
+  const [pendingJumpId, setPendingJumpId] = useState<string | null>(null);
+
+  const handleJumpToSource = (sourceId: string) => {
+    if (matchingFavoriteIds && !matchingFavoriteIds.has(sourceId)) {
+      setFavoriteFilter("");
+      setPendingJumpId(sourceId);
+      return;
+    }
+    scrollToFavorite(sourceId);
+  };
+
+  useEffect(() => {
+    if (!pendingJumpId) return;
+    scrollToFavorite(pendingJumpId);
+    setPendingJumpId(null);
+  }, [pendingJumpId]);
+
   const handleCopyAllHighlights = () => {
     if (highlightVideos.length === 0) return;
     // navigator.clipboard is undefined in insecure contexts (HTTP, some
@@ -402,6 +430,7 @@ export function DashboardPage({
                   onHide={(sourceId, videoId, meta) =>
                     hiddenHighlightsService.hide(sourceId, videoId, meta)
                   }
+                  onJumpToSource={handleJumpToSource}
                 />
               ))}
             </div>
@@ -506,13 +535,8 @@ export function DashboardPage({
                     favorite={fav}
                     isRefreshing={refreshingIds.has(fav.id)}
                     size="sm"
-                    onClick={() => {
-                      // Scroll to the favorite section
-                      const element = document.getElementById(`favorite-${fav.id}`);
-                      if (element) {
-                        element.scrollIntoView({ behavior: "smooth", block: "start" });
-                      }
-                    }}
+                    // Same jump the highlight cards use — one implementation.
+                    onClick={() => scrollToFavorite(fav.id)}
                   />
                 ))}
               </div>

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Activity, BarChart3, Download, EyeOff, RefreshCw, Trash2, Upload } from "lucide-react";
+import {
+  Activity,
+  AlertCircle,
+  BarChart3,
+  Check,
+  Copy,
+  Download,
+  EyeOff,
+  RefreshCw,
+  Trash2,
+  Upload,
+} from "lucide-react";
 import { FavoriteRow } from "@/src/shared/components/ui/FavoriteRow";
 import { FavoriteAvatar } from "@/src/shared/components/ui/FavoriteAvatar";
 import { FavoritesFilter } from "@/src/shared/components/ui/FavoritesFilter";
@@ -169,6 +180,53 @@ export function DashboardPage({
   const highlightVideos = highlightVideosData.visible;
   const hiddenHighlightsCount = highlightVideosData.hiddenCount;
 
+  // Bulk copy of every visible highlight URL. The analyser's results bar has
+  // offered this for a while; the dashboard — the surface most users start on —
+  // only had a per-card copy button, so collecting the day's highlights meant
+  // one click per card. Same clipboard guard and transient icon feedback as
+  // VideoCard / HighlightVideoCard, so a blocked clipboard is never a silent
+  // no-op.
+  const [copiedAllHighlights, setCopiedAllHighlights] = useState(false);
+  const [copyAllHighlightsFailed, setCopyAllHighlightsFailed] = useState(false);
+  const copiedAllTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyAllFailedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedAllTimerRef.current) clearTimeout(copiedAllTimerRef.current);
+      if (copyAllFailedTimerRef.current) clearTimeout(copyAllFailedTimerRef.current);
+    };
+  }, []);
+
+  const flashCopyAllFailed = () => {
+    setCopyAllHighlightsFailed(true);
+    if (copyAllFailedTimerRef.current) clearTimeout(copyAllFailedTimerRef.current);
+    copyAllFailedTimerRef.current = setTimeout(() => setCopyAllHighlightsFailed(false), 2500);
+  };
+
+  const handleCopyAllHighlights = () => {
+    if (highlightVideos.length === 0) return;
+    // navigator.clipboard is undefined in insecure contexts (HTTP, some
+    // iframes); reading .writeText off it throws synchronously, which the
+    // rejection handler below would not catch — guard the property first.
+    if (!navigator.clipboard) {
+      flashCopyAllFailed();
+      return;
+    }
+    const urls = highlightVideos.map((item) => item.video.url).join("\n");
+    navigator.clipboard.writeText(urls).then(
+      () => {
+        setCopiedAllHighlights(true);
+        if (copiedAllTimerRef.current) clearTimeout(copiedAllTimerRef.current);
+        copiedAllTimerRef.current = setTimeout(() => setCopiedAllHighlights(false), 1500);
+      },
+      () => {
+        // Clipboard write rejected (permissions / focus) — surface it.
+        flashCopyAllFailed();
+      },
+    );
+  };
+
   return (
     <div className="animate-fade-in">
       {/* Hidden file input for dashboard import */}
@@ -186,6 +244,17 @@ export function DashboardPage({
           });
         }}
       />
+
+      {/* Polite live region: the bulk-copy result is otherwise only conveyed by a
+          transient icon swap, which is silent to assistive tech (mirrors the
+          analyser's bulk actions and the per-card copy buttons). */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {copyAllHighlightsFailed
+          ? t("dashboard.highlights.copyAllFailed")
+          : copiedAllHighlights
+            ? t("dashboard.highlights.copyAllDone")
+            : ""}
+      </p>
 
       {favorites.length > 0 && (
         <section
@@ -215,6 +284,36 @@ export function DashboardPage({
               )}
 
               <div className="flex flex-wrap items-center justify-end gap-2 min-w-0">
+                {highlightVideos.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={handleCopyAllHighlights}
+                    className={`inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                      copyAllHighlightsFailed
+                        ? "border-red-300/60 text-red-600 dark:border-red-700/40 dark:text-red-400"
+                        : "border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                    }`}
+                    title={
+                      copyAllHighlightsFailed
+                        ? t("dashboard.highlights.copyAllFailed")
+                        : t("dashboard.highlights.copyAllUrls")
+                    }
+                    aria-label={
+                      copyAllHighlightsFailed
+                        ? t("dashboard.highlights.copyAllFailed")
+                        : t("dashboard.highlights.copyAllUrls")
+                    }
+                  >
+                    {copyAllHighlightsFailed ? (
+                      <AlertCircle className="w-3 h-3" aria-hidden="true" />
+                    ) : copiedAllHighlights ? (
+                      <Check className="w-3 h-3 text-green-500" aria-hidden="true" />
+                    ) : (
+                      <Copy className="w-3 h-3" aria-hidden="true" />
+                    )}
+                    <span className="whitespace-nowrap">{t("dashboard.highlights.copyAll")}</span>
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={handleImportPick}

--- a/src/features/youtube/hooks/useQuotaWarning.ts
+++ b/src/features/youtube/hooks/useQuotaWarning.ts
@@ -1,0 +1,68 @@
+import { useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useEventBus } from "@/src/shared/lib/eventBus";
+import { showToast } from "@/src/shared/components/feedback";
+import { quotaService } from "../services/quotaService";
+
+/**
+ * Percentage from which the daily YouTube quota counts as nearly spent. Matches
+ * the red band of the header indicator, so the toast and the battery bar never
+ * disagree about what "critical" means.
+ */
+const WARN_THRESHOLD_PERCENT = 90;
+
+/**
+ * Warns once when the daily YouTube API quota is nearly spent, and once when it
+ * is gone.
+ *
+ * The free tier is 10,000 units a day and a single keyword search costs 100, so
+ * a couple of "Refresh all" runs can eat the rest of the budget in seconds.
+ * Until now the only signal was the small colour-coded battery in the header:
+ * unless the user happened to look at it, the first notice was a search failing
+ * with an API error, with the quota already gone for the day.
+ *
+ * Fires at most once per threshold per session, and only on an actual crossing
+ * — the value at mount is recorded as the baseline, so reloading the page while
+ * already deep in the red does not re-announce something the user knows. The
+ * daily reset (handled in quotaService) drops the percentage back down, which
+ * re-arms both warnings.
+ */
+export function useQuotaWarning(): void {
+  const { t } = useTranslation();
+  // Baseline: whatever the quota already was when the app started. Reading it
+  // here rather than on the first event means a call that crosses the threshold
+  // is still recognised as a crossing.
+  const lastPercentageRef = useRef(quotaService.getInfo().percentage);
+  const warnedRef = useRef(false);
+  const exhaustedWarnedRef = useRef(false);
+
+  const handleQuotaUpdate = useCallback(
+    ({ percentage, exhausted }: { percentage: number; exhausted: boolean }) => {
+      const previous = lastPercentageRef.current;
+      lastPercentageRef.current = percentage;
+
+      // A daily reset (or a manual quota reset) re-arms both warnings.
+      if (percentage < WARN_THRESHOLD_PERCENT && !exhausted) {
+        warnedRef.current = false;
+        exhaustedWarnedRef.current = false;
+        return;
+      }
+
+      if (exhausted) {
+        if (exhaustedWarnedRef.current) return;
+        exhaustedWarnedRef.current = true;
+        // Suppress the near-limit toast afterwards — the harder message wins.
+        warnedRef.current = true;
+        showToast(t("quota.exhausted"), "error");
+        return;
+      }
+
+      if (previous >= WARN_THRESHOLD_PERCENT || warnedRef.current) return;
+      warnedRef.current = true;
+      showToast(t("quota.nearLimit", { percentage }), "error");
+    },
+    [t],
+  );
+
+  useEventBus("quota-updated", handleQuotaUpdate);
+}

--- a/src/features/youtube/index.ts
+++ b/src/features/youtube/index.ts
@@ -13,3 +13,6 @@ export {
   getChannelQueryType,
 } from "./services/channelService";
 export { searchVideosByKeyword } from "./services/searchService";
+
+// Hooks
+export { useQuotaWarning } from "./hooks/useQuotaWarning";

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -130,7 +130,11 @@
       "unhide": "Einblenden",
       "unhideAria": "\"{{title}}\" wieder einblenden",
       "delete": "Löschen",
-      "empty": "Noch keine Highlights verfügbar. Highlights erscheinen, sobald deine Favoriten Videos geladen haben."
+      "empty": "Noch keine Highlights verfügbar. Highlights erscheinen, sobald deine Favoriten Videos geladen haben.",
+      "copyAll": "Alle kopieren",
+      "copyAllUrls": "Alle Highlight-URLs kopieren",
+      "copyAllDone": "Alle Highlight-URLs kopiert",
+      "copyAllFailed": "Zwischenablage nicht verfügbar"
     },
     "filter": {
       "placeholder": "Favoriten filtern…",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -311,6 +311,7 @@
     "label": "API-Kontingent",
     "tooltip": "YouTube API: {{used}} / {{limit}} Einheiten ({{percentage}}%)",
     "exhausted": "Kontingent erschöpft! Reset um Mitternacht PT.",
+    "nearLimit": "API-Kontingent bei {{percentage}}% — heute sind nur noch wenige Units übrig. Reset um Mitternacht PT.",
     "historyTitle": "API-Nutzung",
     "units": "Einheiten",
     "copySummary": "Kontingent-Übersicht kopieren",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -131,6 +131,7 @@
       "unhideAria": "\"{{title}}\" wieder einblenden",
       "delete": "Löschen",
       "empty": "Noch keine Highlights verfügbar. Highlights erscheinen, sobald deine Favoriten Videos geladen haben.",
+      "jumpToSource": "Zum Favoriten \"{{source}}\" springen",
       "copyAll": "Alle kopieren",
       "copyAllUrls": "Alle Highlight-URLs kopieren",
       "copyAllDone": "Alle Highlight-URLs kopiert",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -131,6 +131,7 @@
       "unhideAria": "Show \"{{title}}\" again",
       "delete": "Delete",
       "empty": "No highlights available yet. Highlights will appear once your favorites have loaded videos.",
+      "jumpToSource": "Jump to favorite \"{{source}}\"",
       "copyAll": "Copy all",
       "copyAllUrls": "Copy all highlight URLs",
       "copyAllDone": "All highlight URLs copied",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -130,7 +130,11 @@
       "unhide": "Show",
       "unhideAria": "Show \"{{title}}\" again",
       "delete": "Delete",
-      "empty": "No highlights available yet. Highlights will appear once your favorites have loaded videos."
+      "empty": "No highlights available yet. Highlights will appear once your favorites have loaded videos.",
+      "copyAll": "Copy all",
+      "copyAllUrls": "Copy all highlight URLs",
+      "copyAllDone": "All highlight URLs copied",
+      "copyAllFailed": "Clipboard unavailable"
     },
     "filter": {
       "placeholder": "Filter favorites…",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -311,6 +311,7 @@
     "label": "API Quota",
     "tooltip": "YouTube API: {{used}} / {{limit}} units ({{percentage}}%)",
     "exhausted": "Quota exhausted! Resets at midnight PT.",
+    "nearLimit": "API quota at {{percentage}}% — few units left today. Resets at midnight PT.",
     "historyTitle": "API Usage",
     "units": "Units",
     "copySummary": "Copy quota summary",

--- a/src/shared/components/ui/HighlightVideoCard.tsx
+++ b/src/shared/components/ui/HighlightVideoCard.tsx
@@ -12,6 +12,8 @@ interface HighlightVideoCardProps {
   sourceId: string;
   // When true, the card is visually marked as "refreshing"
   isRefreshing?: boolean;
+  /** Jump to the favorite this highlight came from. Omit to keep the label static. */
+  onJumpToSource?: (sourceId: string) => void;
   // Callback to hide the card (with optional metadata for the list)
   onHide?: (
     sourceId: string,
@@ -28,6 +30,7 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
   sourceId,
   isRefreshing = false,
   onHide,
+  onJumpToSource,
 }) => {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
@@ -145,13 +148,31 @@ export const HighlightVideoCard: React.FC<HighlightVideoCardProps> = ({
       {/* Content Area */}
       <div className="p-4 flex flex-col grow">
         <div className="mb-2">
-          <div
-            className="text-xs font-semibold text-slate-500 dark:text-slate-400 truncate"
-            title={`${sourceLabel} • Top ${sourceRank}`}
-          >
-            {sourceLabel} <span className="text-slate-400 dark:text-slate-500">•</span> Top{" "}
-            {sourceRank}
-          </div>
+          {/* Source line. A highlight is the single best video of one favorite,
+              so the obvious next question is "what else has that favorite got?"
+              — until now the only answer was scrolling the dashboard for the
+              row by hand. With a handler the line becomes the shortcut to it;
+              without one it stays the plain label it always was. */}
+          {onJumpToSource ? (
+            <button
+              type="button"
+              onClick={() => onJumpToSource(sourceId)}
+              className="block max-w-full text-left text-xs font-semibold text-slate-500 dark:text-slate-400 truncate hover:text-indigo-500 dark:hover:text-indigo-400 hover:underline underline-offset-2 transition-colors"
+              title={t("dashboard.highlights.jumpToSource", { source: sourceLabel })}
+              aria-label={t("dashboard.highlights.jumpToSource", { source: sourceLabel })}
+            >
+              {sourceLabel} <span className="text-slate-400 dark:text-slate-500">•</span> Top{" "}
+              {sourceRank}
+            </button>
+          ) : (
+            <div
+              className="text-xs font-semibold text-slate-500 dark:text-slate-400 truncate"
+              title={`${sourceLabel} • Top ${sourceRank}`}
+            >
+              {sourceLabel} <span className="text-slate-400 dark:text-slate-500">•</span> Top{" "}
+              {sourceRank}
+            </div>
+          )}
           <h3 className="text-base font-bold leading-snug line-clamp-2 min-h-[2.75rem]">
             <a
               href={video.url}


### PR DESCRIPTION
## Description

Autonomous end-user comfort sweep — three small features, one commit each, plus a one-line docs correction. No new dependencies, no refactors, no dependency bumps.

| # | Bereich/Datei | Kategorie | Feature | Nutzen für User | Aufwand | Empfehlung |
|---|---------------|-----------|---------|-----------------|---------|------------|
| 1 | `src/app/routes/DashboardPage.tsx` | Komfort | "Copy all" for the dashboard highlight URLs | The analyser results bar has had a bulk "Copy all" for a while; the dashboard — the surface most users open first — only had a per-card copy button, so collecting the day's highlights meant one click per card. The new toolbar action copies every visible highlight URL, one per line, hidden entries excluded. | S | auto-build |
| 2 | `src/shared/components/ui/HighlightVideoCard.tsx`, `DashboardPage.tsx` | Komfort | Jump from a highlight card to its favorite row | A highlight is the single best video of one favorite, so the obvious follow-up is "what else does that favorite have?" — the only answer was scrolling the dashboard and finding the row by eye. The source line (`MrBeast • Top 1`) is now the shortcut to it. | M | auto-build |
| 3 | `src/features/youtube/hooks/useQuotaWarning.ts` (new), `App.tsx` | Qualität | Toast when the daily API quota is nearly spent or exhausted | 10,000 units/day, 100 per keyword search — two "Refresh all" runs can eat the rest in seconds. The only signal was the small colour-coded battery in the header; miss it and the first notice is a search failing with an API error. | M | auto-build |

**Notes**

- **#1** reuses the established clipboard pattern: `navigator.clipboard` guarded as a property before use (undefined in insecure contexts — the Docker image over plain HTTP on a LAN address — where reading `.writeText` throws synchronously), transient check / warning icon, polite live region. Button only renders when a highlight is visible.
- **#2** reuses the `#favorite-<id>` anchor and `scroll-mt-20` offset the avatar quick-jump already relies on; both entry points now share one `scrollToFavorite` helper. Filtered-out rows are rendered `hidden` rather than unmounted (unmounting would re-fetch and burn quota), so the handler clears the filter first and defers the scroll to the render in which the row is back. `onJumpToSource` is optional — without it the source line stays static text.
- **#3** listens on the existing typed `quota-updated` bus event; nothing new is polled or stored. 90 % is the same red band the header indicator uses, and the exhausted case reuses the existing `quota.exhausted` string. Fires at most once per threshold per session and only on an actual crossing — the value at mount is the baseline, and the daily reset re-arms both warnings.
- The docs commit records that `youtube` now carries all four parts of the Feature Module Pattern (`agent_docs/project_structure.md`).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — all new strings are i18n keys in **both** `en` and `de`; parity verified (294 keys, 0 missing in either direction)
- [x] Tested locally — `npm ci` → `npm run format:check` → `npm run typecheck` → `npm run lint` → `npm run build`, all green (build: 1884 modules, 2.56 s). No test runner is configured in this repo; that four-step chain is the gate.

## Related Issues

Closes #394

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01G85uLc9WanjC2wc3HTneEU)_