### PR TITLE
refactor: best-practice sweep (Vite + React)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,8 +45,11 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Run Linter
-        # Führt Lint nur aus, wenn das Skript existiert, um Fehler zu vermeiden
-        run: if npm run | grep -q "lint"; then npm run lint; fi
+        # Called directly, like pr-checks.yml. The previous
+        # `if npm run | grep -q "lint"` wrapper turned this gate into a silent
+        # no-op whenever the grep missed (script renamed, `npm run` output
+        # reformatted) — a quality gate that can quietly skip itself is not one.
+        run: npm run lint
 
   build-and-push:
     # Startet erst, wenn check-code erfolgreich war

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,14 @@ on:
     # Trigger auch bei Release-Tags (z.B. v20260214-1530)
   workflow_dispatch:
 
+# Same guard the other four push-triggered workflows already carry. Without it,
+# two pushes to main run two publishes in parallel and both race for the `latest`
+# tag in GHCR — whichever finishes last wins, which is not necessarily the newer
+# commit. Superseded runs are cancelled instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/src/features/dashboard/services/hiddenHighlightsService.ts
+++ b/src/features/dashboard/services/hiddenHighlightsService.ts
@@ -127,21 +127,6 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Checks whether an entry exists for a sourceId (independent of the videoId).
-   */
-  hasEntry(sourceId: string): boolean {
-    return this.list().some((h) => h.sourceId === sourceId);
-  },
-
-  /**
-   * Returns the stored videoId for a sourceId, or null if none exists.
-   */
-  getHiddenVideoId(sourceId: string): string | null {
-    const entry = this.list().find((h) => h.sourceId === sourceId);
-    return entry?.videoId ?? null;
-  },
-
-  /**
    * Removes all hidden highlights.
    */
   clearAll(): void {

--- a/src/features/videos/services/exportResults.ts
+++ b/src/features/videos/services/exportResults.ts
@@ -46,6 +46,24 @@ function escapeCsvField(value: string): string {
 }
 
 /**
+ * Render an epoch timestamp as ISO-8601, or an empty field when it is not a
+ * finite number.
+ *
+ * `VideoData` does not only come fresh out of `analyzeVideoStats()` — it is also
+ * rehydrated from on-disk input: the persisted analyser snapshot
+ * (`tt.analyser.lastResult.v1`) and imported dashboard backups. Both boundaries
+ * validate `url`, neither validates `publishedTimestamp`, and
+ * `analyzeVideoStats()` itself forwards `new Date(...).getTime()` unguarded, so
+ * the value can be `NaN` or `undefined`. `new Date(NaN).toISOString()` throws
+ * `RangeError: Invalid time value`, which aborted the whole export — CSV and
+ * JSON alike — over a single unparseable row. Output is byte-identical for every
+ * finite timestamp, i.e. for all real data.
+ */
+function toIsoTimestamp(timestamp: number): string {
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : "";
+}
+
+/**
  * Build a CSV document (header + one row per video) from analyser results.
  * Order is preserved exactly as passed in (the caller controls sorting).
  */
@@ -60,7 +78,7 @@ export function buildResultsCsv(videos: VideoData[]): string {
       video.viewsPerHour != null ? String(video.viewsPerHour) : "",
       video.engagementRate != null ? String(video.engagementRate) : "",
       String(video.trendingScore),
-      new Date(video.publishedTimestamp).toISOString(),
+      toIsoTimestamp(video.publishedTimestamp),
     ];
     return fields.map((f) => escapeCsvField(f)).join(",");
   });
@@ -146,7 +164,7 @@ export function buildResultsJson(
       viewsPerHour: video.viewsPerHour ?? null,
       engagementRate: video.engagementRate ?? null,
       trendingScore: video.trendingScore,
-      publishedAt: new Date(video.publishedTimestamp).toISOString(),
+      publishedAt: toIsoTimestamp(video.publishedTimestamp),
     })),
   };
   return JSON.stringify(payload, null, 2);

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -32,7 +32,16 @@ const getOptimalTimeWindow = (
   if (history.length === 0) return fullDay;
 
   const now = Date.now();
-  const oldestEntry = Math.min(...history.map((h) => h.timestamp));
+  // Folded instead of `Math.min(...history.map(...))`: quotaService caps the
+  // history at MAX_HISTORY_ENTRIES = 10000, and spreading an array that size
+  // into a call pushes one argument per entry onto the stack — the pattern that
+  // throws "Maximum call stack size exceeded" once the engine's argument limit
+  // is reached (lowest in JavaScriptCore). Same value, no argument explosion,
+  // and one pass instead of an intermediate array.
+  const oldestEntry = history.reduce(
+    (oldest, entry) => (entry.timestamp < oldest ? entry.timestamp : oldest),
+    Infinity,
+  );
   const dataSpan = now - oldestEntry;
 
   // Choose time window based on data span with some buffer

--- a/src/shared/lib/formatters.ts
+++ b/src/shared/lib/formatters.ts
@@ -25,39 +25,6 @@ export function formatCompactNumber(value: number, locale: string = getLocale())
 }
 
 /**
- * Format bytes to human readable size
- */
-export function formatBytes(bytes: number, decimals = 2): string {
-  if (bytes === 0) return "0 Bytes";
-
-  const k = 1024;
-  const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
-}
-
-/**
- * Format duration in milliseconds to human readable string
- */
-export function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`;
-  const minutes = Math.floor(ms / 60000);
-  const seconds = ((ms % 60000) / 1000).toFixed(0);
-  return `${minutes}m ${seconds}s`;
-}
-
-/**
- * Format percentage
- */
-export function formatPercentage(value: number, decimals = 0): string {
-  return `${value.toFixed(decimals)}%`;
-}
-
-/**
  * Format a past timestamp as a localized relative time string.
  * Uses the timeAgo.* i18n keys present in all supported locales.
  *


### PR DESCRIPTION
## Description

Autonomous best-practice sweep. Five findings, one commit each, all behaviour-preserving for real data — no feature changes, no style-only diffs outside the findings.

| #   | Datei                                                                     | Kategorie        | Fix                                                                                                                                        | Aufwand | Empfehlung |
| --- | ------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------- |
| 1   | `src/features/videos/services/exportResults.ts`                           | Correctness      | `toIsoTimestamp()` guard — `new Date(NaN).toISOString()` threw `RangeError`, so one unparseable `publishedTimestamp` aborted the whole CSV/JSON export. `VideoData` also comes from on-disk input (`tt.analyser.lastResult.v1`, imported backups), where only `url` is validated. | S       | auto-fix   |
| 2   | `.github/workflows/docker-publish.yml`                                    | Correctness (CI) | Lint runs unconditionally instead of `if npm run \| grep -q "lint"` — a gate that can silently skip itself is not a gate.                    | S       | auto-fix   |
| 3   | `.github/workflows/docker-publish.yml`                                    | Correctness (CI) | Added the `concurrency` group the other four push-triggered workflows already carry; two pushes to `main` no longer race for `latest`.       | S       | auto-fix   |
| 4   | `src/shared/components/ui/ApiQuotaIndicator.tsx`                          | Performance      | `getOptimalTimeWindow` folds the history minimum instead of spreading up to 10 000 entries into `Math.min`.                                  | S       | auto-fix   |
| 5   | `src/shared/lib/formatters.ts`, `.../services/hiddenHighlightsService.ts` | Maintainability  | Removed five exported helpers with zero references repo-wide (`noUnusedLocals` cannot see unused exports). −48 LoC.                          | M       | auto-fix   |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — no UI strings touched
- [x] Tested locally — `npm ci` → `format:check` → `typecheck` → `lint` → `build`, all green (no test framework configured in this repo)

## Related Issues

Closes #396


---
_Generated by [Claude Code](https://claude.ai/code/session_016vUBtMeaW1mtv3jyYGaKiT)_