### PR TITLE
ux: best-practice sweep (Vite + React + Tailwind v4 + i18next)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -108,6 +108,13 @@ const App: React.FC = () => {
   // - "?" toggles the keyboard-shortcuts help popover
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // Skip while a modal dialog owns the screen. Both dialogs trap Tab, so a
+      // keyboard user lands on one of their buttons — and from there a bare "d",
+      // "a", "t" or "r" fell through to these handlers and switched the page,
+      // cycled the theme or refetched every favorite behind the backdrop, with
+      // no visible cause. Only the focused input was ever protected.
+      if (isApiKeyModalOpen || isHiddenHighlightsModalOpen) return;
+
       // Skip when focus is inside an input, textarea, or contentEditable element,
       // or when a modifier key is held (avoid hijacking browser/OS shortcuts).
       const target = e.target as HTMLElement;
@@ -152,7 +159,15 @@ const App: React.FC = () => {
         refreshAll();
       }
     },
-    [activePage, favorites.length, refreshAll, theme, setTheme],
+    [
+      activePage,
+      favorites.length,
+      refreshAll,
+      theme,
+      setTheme,
+      isApiKeyModalOpen,
+      isHiddenHighlightsModalOpen,
+    ],
   );
   useEventListener("keydown", handleKeyDown, document);
 

--- a/src/shared/components/feedback/Toast.tsx
+++ b/src/shared/components/feedback/Toast.tsx
@@ -57,20 +57,24 @@ export function ToastHost() {
     };
   }, []);
 
-  if (toasts.length === 0) return null;
-
+  // The live region stays mounted even with no toasts. A `role="status"` element
+  // that enters the DOM together with its text is announced unreliably — screen
+  // readers only watch regions that already existed, so the first toast after a
+  // quiet period was regularly swallowed. Empty it renders nothing visible, and
+  // `pointer-events-none` keeps the zero-height container out of the click path
+  // (each toast re-enables pointer events for its own dismiss button).
   return (
     <div
       // Polite live region: the message must reach assistive tech, but never
       // interrupt whatever the user is doing (unlike the alert it replaces).
       role="status"
       aria-live="polite"
-      className="fixed bottom-4 right-4 z-[60] flex w-[min(22rem,calc(100vw-2rem))] flex-col gap-2"
+      className="pointer-events-none fixed bottom-4 right-4 z-[60] flex w-[min(22rem,calc(100vw-2rem))] flex-col gap-2"
     >
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className={`flex items-start gap-2 rounded-xl border p-3 text-sm shadow-xl backdrop-blur-sm animate-fade-in ${
+          className={`pointer-events-auto flex items-start gap-2 rounded-xl border p-3 text-sm shadow-xl backdrop-blur-sm animate-fade-in ${
             toast.tone === "error"
               ? "border-red-500/30 bg-red-50/95 text-red-700 dark:border-red-500/30 dark:bg-red-950/90 dark:text-red-200"
               : "border-emerald-500/30 bg-emerald-50/95 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-950/90 dark:text-emerald-200"

--- a/src/shared/components/ui/ApiKeyModal.tsx
+++ b/src/shared/components/ui/ApiKeyModal.tsx
@@ -123,7 +123,10 @@ export const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
                   aria-label={showKey ? t("modal.apiKey.hideKey") : t("modal.apiKey.showKey")}
                   aria-pressed={showKey}
                   title={showKey ? t("modal.apiKey.hideKey") : t("modal.apiKey.showKey")}
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                  // slate-400 on the slate-50 field is 2.5:1 — under the 3:1 WCAG
+                  // 1.4.11 asks of a control's own graphic. The 400 shade stays
+                  // for dark mode, where the field is slate-950.
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-500 dark:text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
                 >
                   {showKey ? (
                     <EyeOff className="w-4 h-4" aria-hidden="true" />

--- a/src/shared/components/ui/ApiQuotaIndicator.tsx
+++ b/src/shared/components/ui/ApiQuotaIndicator.tsx
@@ -569,7 +569,11 @@ export const ApiQuotaIndicator: React.FC = () => {
 
           {/* Timeline line chart - pure line chart showing usage over time */}
           <div className="px-3 py-3 border-b border-slate-700/50">
-            <div className="text-[10px] text-slate-500 mb-2">
+            {/* slate-400, not 500/600: this panel is dark in BOTH themes, and on
+                slate-900 the 500 shade is 3.8:1 and the 600 shade 2.4:1 — under
+                the 4.5:1 WCAG 1.4.3 asks of body text, which these 9–10px labels
+                are. slate-400 clears it at ~7:1. */}
+            <div className="text-[10px] text-slate-400 mb-2">
               {t("quota.lastTimeWindow", { time: t(timeWindow.labelKey) })}
             </div>
             <div className="relative h-16">
@@ -675,7 +679,7 @@ export const ApiQuotaIndicator: React.FC = () => {
               </div>
             </div>
             {/* Time labels - dynamic based on time window */}
-            <div className="flex justify-between mt-1 text-[9px] text-slate-600">
+            <div className="flex justify-between mt-1 text-[9px] text-slate-400">
               <span>-{t(timeWindow.labelKey)}</span>
               <span>-{t(timeWindow.halfLabelKey)}</span>
               <span>{t("quota.now")}</span>
@@ -684,9 +688,9 @@ export const ApiQuotaIndicator: React.FC = () => {
 
           {/* Grouped calls by source/context */}
           <div className="px-3 py-2 max-h-48 overflow-y-auto">
-            <div className="text-[10px] text-slate-500 mb-1.5">{t("quota.usageBySource")}</div>
+            <div className="text-[10px] text-slate-400 mb-1.5">{t("quota.usageBySource")}</div>
             {groupedCalls.length === 0 ? (
-              <div className="text-xs text-slate-500 italic py-2">{t("quota.noCalls")}</div>
+              <div className="text-xs text-slate-400 italic py-2">{t("quota.noCalls")}</div>
             ) : (
               <div className="space-y-1.5">
                 {groupedCalls.map((group, index) => (
@@ -715,7 +719,7 @@ export const ApiQuotaIndicator: React.FC = () => {
                       <div className="text-slate-300 font-medium">
                         {formatNumber(group.totalUnits)} {t("quota.units")}
                       </div>
-                      <div className="text-slate-600 text-[9px]">
+                      <div className="text-slate-400 text-[9px]">
                         {group.callCount}x ·{" "}
                         {(() => {
                           const { key, count } = getRelativeTimeParts(group.lastTimestamp);

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -639,7 +639,10 @@ export const InputSection: React.FC<InputSectionProps> = ({
                           e.stopPropagation();
                           removeHistoryItem(item);
                         }}
-                        className="px-3 flex items-center text-slate-400 hover:text-red-500 dark:hover:text-red-400 opacity-0 group-hover/item:opacity-100 focus:opacity-100 transition-opacity"
+                        // slate-400 on the white dropdown is 2.6:1 — under the 3:1
+                        // WCAG 1.4.11 asks of a control's own graphic. The 400
+                        // shade is kept for dark mode, where it sits on slate-900.
+                        className="px-3 flex items-center text-slate-500 dark:text-slate-400 hover:text-red-500 dark:hover:text-red-400 opacity-0 group-hover/item:opacity-100 focus:opacity-100 transition-opacity"
                         title={t("history.remove")}
                         aria-label={t("history.removeAria", { item })}
                       >

--- a/src/shared/components/ui/VideoListTable.tsx
+++ b/src/shared/components/ui/VideoListTable.tsx
@@ -254,9 +254,15 @@ export const VideoListTable: React.FC<VideoListTableProps> = ({
                   key={video.id}
                   className="hover:bg-slate-100/40 dark:hover:bg-slate-800/40 transition-colors group"
                 >
-                  <td className="p-4 text-center text-slate-500 font-mono font-medium" scope="row">
+                  {/* <th scope="row">, not <td scope="row">: `scope` is only
+                      valid on a header cell, so on a <td> it was inert markup and
+                      the rank never became the row's header — screen readers read
+                      each following cell without saying which video it belongs to.
+                      font-medium + text-center keep the <th> default bold/centering
+                      overridden, so the cell renders exactly as before. */}
+                  <th scope="row" className="p-4 text-center text-slate-500 font-mono font-medium">
                     {rank}
-                  </td>
+                  </th>
                   <td className="p-4">
                     <div className="flex items-center gap-4">
                       <a


### PR DESCRIPTION
Autonomous UX best-practice sweep. Five additive fixes, one commit each — no feature changes, no redesign, no restyling beyond the findings. No new user-facing strings, so both i18n bundles are untouched.

| # | Datei | Kategorie | Befund | Fix |
|---|-------|-----------|--------|-----|
| 1 | `src/shared/components/feedback/Toast.tsx` | a11y | The `role="status"` live region entered the DOM together with its first message, so screen readers regularly swallowed the first toast after a quiet period. | Keep the region mounted permanently, render only the toast items conditionally; `pointer-events-none` on the container and `pointer-events-auto` per toast keep the now-always-present container out of the click path. |
| 2 | `src/shared/components/ui/ApiQuotaIndicator.tsx` | a11y | The history panel is dark in both themes; `text-slate-500` (~3.8:1) and `text-slate-600` (~2.4:1) on `slate-900` are under the 4.5:1 of WCAG 1.4.3 for these 9–10px labels. | Five labels moved to `text-slate-400` (~7:1). Decorative SVG grid lines untouched. |
| 3 | `src/shared/components/ui/VideoListTable.tsx` | a11y | `scope="row"` sat on a `<td>`, where the attribute is inert — the results table had no row header (WCAG 1.3.1). | Promote the rank cell to `<th scope="row">`; `text-center` + `font-medium` already override the `<th>` UA defaults, so rendering is unchanged. |
| 4 | `src/shared/components/ui/InputSection.tsx`, `src/shared/components/ui/ApiKeyModal.tsx` | a11y | Two icon-only controls at `text-slate-400` with no light variant: history "remove entry" ✕ (2.6:1 on white) and the show/hide-key eye (2.5:1 on `slate-50`) — below the 3:1 of WCAG 1.4.11. | `text-slate-500 dark:text-slate-400`; the 400 shade stays for dark mode. |
| 5 | `src/app/App.tsx` | interaction | Global hotkeys (`d`/`a`/`t`/`r`/`?`) only skipped inside `INPUT`/`TEXTAREA`. Both modals trap Tab onto their own buttons, so a bare keypress there switched the page, cycled the theme or refetched every favorite behind the backdrop — `r` spending real YouTube API quota. | Bail out while `isApiKeyModalOpen` or `isHiddenHighlightsModalOpen` is set. |

**Betroffene Screens:** Analyser (results table, search input + history dropdown, toasts), Dashboard (toasts, hotkeys), Header (quota history panel), API key modal, hidden-highlights modal.

**Verifikation:** `npm ci` → `npm run format` → `format:check` → `typecheck` → `lint` → `build` — all green. The repo has no test framework, so no test step exists.

Closes #398

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J5v3Gqr1tNrLwTqt2s8oZG)_