### PR TITLE
refine: ux sweep (Vite + React + TypeScript)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2,7 +2,9 @@
   "appTitle": "TubeTrend",
   "language": {
     "label": "Sprache:",
-    "system": "System"
+    "system": "System",
+    "groupTranslated": "Übersetzt",
+    "groupFallback": "Fällt auf Englisch zurück"
   },
   "actions": {
     "search": "Suchen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2,7 +2,9 @@
   "appTitle": "TubeTrend",
   "language": {
     "label": "Language:",
-    "system": "System"
+    "system": "System",
+    "groupTranslated": "Translated",
+    "groupFallback": "Falls back to English"
   },
   "actions": {
     "search": "Search",

--- a/src/shared/components/layout/Footer.tsx
+++ b/src/shared/components/layout/Footer.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Info, Calendar, GitBranch, GitCommitHorizontal } from "lucide-react";
 import { Github } from "@/src/shared/components/ui/BrandIcons";
 import { useTranslation } from "react-i18next";
+import { getLocale } from "@/src/shared/lib/locale";
 
 const buildInfo = __BUILD_INFO__;
 
@@ -9,13 +10,19 @@ export function Footer() {
   const { t } = useTranslation();
   const [showDetails, setShowDetails] = useState(false);
 
+  // getLocale(), not `undefined`: passing undefined formats in the *browser's*
+  // locale, so a German UI on an English-language browser showed "Aug 18, 2026"
+  // right next to German labels — and switching the language in-app left the
+  // date untouched. The rest of the app routes date formatting through this
+  // helper (AnalyserPage, HiddenHighlightsModal); the build-info panel did not.
+  const locale = getLocale();
   const buildDate = new Date(buildInfo.buildDate);
-  const formattedDate = buildDate.toLocaleDateString(undefined, {
+  const formattedDate = buildDate.toLocaleDateString(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
   });
-  const formattedTime = buildDate.toLocaleTimeString(undefined, {
+  const formattedTime = buildDate.toLocaleTimeString(locale, {
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -11,6 +11,7 @@ import {
   getChannelQueryType,
   getVideosFromChannel,
   searchVideosByKeyword,
+  YouTubeApiError,
 } from "@/src/features/youtube";
 import { VideoCard } from "./VideoCard";
 import {
@@ -295,7 +296,20 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
         });
       } catch (e: unknown) {
         if (!cancelled) {
-          const message = e instanceof Error ? e.message : "";
+          // Services carry an i18n descriptor instead of a ready-made sentence
+          // (YouTubeApiError.i18n) — resolve it here so the row speaks the user's
+          // language. Without this the dashboard rendered the raw developer text
+          // ("YouTube API error: ...", "HTTP error: 503") for exactly the failures
+          // the analyser already reports translated: useSearch runs the same
+          // lookup, so one and the same outage read German on one page and
+          // English on the other. The plain message stays the fallback for errors
+          // from outside our own service layer.
+          const message =
+            e instanceof YouTubeApiError && e.i18n
+              ? t(e.i18n.key, e.i18n.params)
+              : e instanceof Error
+                ? e.message
+                : "";
           setError(message || t("errors.favoriteLoad"));
         }
       } finally {

--- a/src/shared/components/ui/FavoriteRow.tsx
+++ b/src/shared/components/ui/FavoriteRow.tsx
@@ -29,6 +29,7 @@ import { MAX_RESULTS_OPTIONS, TIME_FRAMES } from "@/src/shared/constants";
 import { useTranslation } from "react-i18next";
 import { dispatchEvent, eventBus } from "@/src/shared/lib/eventBus";
 import { formatTimeAgo } from "@/src/shared/lib/formatters";
+import { getLocale } from "@/src/shared/lib/locale";
 
 interface FavoriteRowProps {
   favorite: FavoriteConfig;
@@ -623,7 +624,13 @@ export const FavoriteRow: React.FC<FavoriteRowProps> = ({
             )}
             <span
               className="px-2 py-0.5 rounded-full bg-slate-100/70 dark:bg-slate-800/70 border border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400"
-              title={lastFetchedAt ? new Date(lastFetchedAt).toLocaleString() : undefined}
+              // getLocale(), not the browser default: the badge next to it
+              // ("as of 5 min ago") follows the chosen UI language, so an exact
+              // timestamp in a different locale is a jarring mismatch. Same
+              // helper AnalyserPage and HiddenHighlightsModal already use.
+              title={
+                lastFetchedAt ? new Date(lastFetchedAt).toLocaleString(getLocale()) : undefined
+              }
             >
               {loading
                 ? t("favorites.status.refreshing")

--- a/src/shared/components/ui/LanguageSwitcher.tsx
+++ b/src/shared/components/ui/LanguageSwitcher.tsx
@@ -24,6 +24,20 @@ type ExplicitLang = (typeof LANGS)[number]["code"];
 
 const SUPPORTED = LANGS.map((l) => l.code) as unknown as ExplicitLang[];
 
+/**
+ * The languages that actually ship a resource bundle (`src/i18n/locales/`).
+ * The other eleven entries above are in i18next's `supportedLngs` so the
+ * detector accepts them, but they have no bundle — picking one renders English
+ * through `fallbackLng` (see the comment in `src/i18n/config.ts`).
+ *
+ * The picker used to be one flat list, so choosing "Français" left a control
+ * confidently reading "Français" above an untouched English UI, with nothing to
+ * tell the user whether they had mis-clicked or the app was broken. Splitting
+ * the options into two labelled groups states the outcome before the click.
+ * Keep this list in sync with the `resources` map in `src/i18n/config.ts`.
+ */
+const TRANSLATED_LANGS: readonly ExplicitLang[] = ["en", "de"];
+
 function normalizeLangCode(lng: string): string {
   return (lng || "en").split("-")[0].toLowerCase();
 }
@@ -120,11 +134,20 @@ export const LanguageSwitcher: React.FC = () => {
           title={`${t("language.label")} ${title}`}
         >
           <option value="system">{t("language.system")}</option>
-          {LANGS.map((lng) => (
-            <option key={lng.code} value={lng.code}>
-              {lng.label}
-            </option>
-          ))}
+          <optgroup label={t("language.groupTranslated")}>
+            {LANGS.filter((lng) => TRANSLATED_LANGS.includes(lng.code)).map((lng) => (
+              <option key={lng.code} value={lng.code}>
+                {lng.label}
+              </option>
+            ))}
+          </optgroup>
+          <optgroup label={t("language.groupFallback")}>
+            {LANGS.filter((lng) => !TRANSLATED_LANGS.includes(lng.code)).map((lng) => (
+              <option key={lng.code} value={lng.code}>
+                {lng.label}
+              </option>
+            ))}
+          </optgroup>
         </select>
       </div>
     </div>


### PR DESCRIPTION
Three small, additive refinements to existing features — no new features, no new dependencies, no architecture change.

| # | Feature | UX gap | Improvement | Effort | Recommendation |
|---|---|---|---|---|---|
| 1 | Dashboard favorite rows | A failing favorite rendered the raw developer text from the service layer (`YouTube API error: …`, `HTTP error: 503`) even though every `YouTubeApiError` carries an i18n descriptor — so one and the same outage read German on the analyser and English on the dashboard | Resolve `err.i18n` through `t()` exactly as `useSearch` already does; plain `Error.message` stays the fallback for errors from outside our own service layer | S | auto-refine |
| 2 | Build-info footer + favorite "as of" badge | Two timestamps bypassed `getLocale()`: the footer passed `undefined` (= the *browser's* locale, unaffected by the in-app language switch), the favorite row used a bare `toLocaleString()` — both sitting directly next to locale-aware labels | Route both through `getLocale()`, the helper `AnalyserPage` and `HiddenHighlightsModal` already use | S | auto-refine |
| 3 | Language switcher | All 13 `supportedLngs` entries were one flat list, but only `en` and `de` ship a resource bundle. Picking "Français" left the control reading "Français" above an unchanged English UI, with no hint whether the click missed or the app broke | Split the options into two labelled `<optgroup>`s — "Translated" (en, de) and "Falls back to English" (the other eleven). Values and selection semantics unchanged, only the grouping is new | S | auto-refine |

Two new i18n keys (`language.groupTranslated`, `language.groupFallback`), added to **both** bundles. Refinements 1 and 2 need no new strings — all `errors.api.*` keys already ship in `en` and `de`.

**Verification:** `format:check` → `typecheck` → `lint` → `build` all green. No test runner is configured in this repo, so there is no test step to run.

Six further ideas and two deferred items are recorded in the issue rather than implemented here.

Closes #400


---
_Generated by [Claude Code](https://claude.ai/code/session_01BenEKKds2fB1NWe7UvHPnw)_