### PR TITLE
security: hardening sweep (Vite + React)

### DIFF
--- a/src/features/favorites/services/favoritesService.ts
+++ b/src/features/favorites/services/favoritesService.ts
@@ -14,6 +14,40 @@ const makeId = (
   return `${query.trim().toLowerCase()}|${timeFrame}|${maxResults}|${searchType}`;
 };
 
+/** True only for absolute http(s) URLs — the schemes an `<a href>` may safely navigate to. */
+function isHttpUrl(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The favorites cache is localStorage content, i.e. untrusted on-disk input, and
+ * `getCache()` is the single read boundary every consumer goes through
+ * (FavoriteRow, FavoriteAvatar, DashboardPage, useDashboard, dashboardTopVideos).
+ * Its videos are rendered straight into `<a href={video.url}>` (VideoCard,
+ * VideoListTable, HighlightVideoCard), so a tampered entry carrying a
+ * `javascript:` URL would put script execution one click away in the app origin —
+ * the origin whose localStorage holds the YouTube API key. Dropping non-http(s)
+ * entries here closes the third and last boundary this cached-video shape crosses;
+ * the backup-import boundary (dashboardBackupService.parse) and the persisted
+ * analyser snapshot (useSearch) already apply the identical guard.
+ * Genuine entries only ever contain `https://www.youtube.com/watch?v=<id>` (built
+ * in trendAnalysisService), so this is behavior-equivalent for real data and fails
+ * closed. The original object is returned untouched when nothing is filtered, which
+ * keeps referential identity for the memo/cache-buster call sites. CWE-79 / OWASP A03.
+ */
+function withSafeVideoUrls<T extends FavoriteCacheEntry>(entry: T): T {
+  const videos = entry?.videos;
+  if (!Array.isArray(videos)) return entry;
+  const safe = videos.filter((video) => isHttpUrl(video?.url));
+  return safe.length === videos.length ? entry : { ...entry, videos: safe };
+}
+
 export const favoritesService = {
   list(): FavoriteConfig[] {
     const raw = safeRead<unknown[]>(STORAGE_KEYS.FAVORITES, []);
@@ -202,7 +236,8 @@ export const favoritesService = {
       STORAGE_KEYS.FAVORITES_CACHE,
       {},
     );
-    return cache[id] ?? null;
+    const entry = cache[id];
+    return entry ? withSafeVideoUrls(entry) : null;
   },
 
   setCache(


### PR DESCRIPTION
Autonomous security hardening sweep of the web-app layer (client-only Vite + React SPA + the nginx serving layer). Continuation of the standing sweep issue — no new issue opened.

## Fixed

| # | Category | Severity | File:Line | Fix |
|---|----------|----------|-----------|-----|
| 1 | Injection/XSS via `javascript:` URL (CWE-79 / OWASP A03) | Low (defense-in-depth) | `src/features/favorites/services/favoritesService.ts:200` (`getCache`) | Reject non-http(s) `video.url` at the favorites-cache read boundary |

The favorites cache is `localStorage` content, i.e. untrusted on-disk input, and its videos are rendered straight into `<a href={video.url}>` (`VideoCard`, `VideoListTable`, `HighlightVideoCard`). A tampered entry carrying a `javascript:` URL therefore put script execution one click away in the app origin — the origin whose `localStorage` holds the YouTube API key.

`getCache()` turned out to be the **single** read boundary every consumer goes through (`FavoriteRow`, `FavoriteAvatar`, `DashboardPage`, `useDashboard`, `dashboardTopVideos`), so one guard there covers every render path in one file. This closes the third and last boundary the cached-video shape crosses — the backup-import boundary (`dashboardBackupService.parse`, #363) and the persisted analyser snapshot (`useSearch`, #386) already carry the identical guard.

Genuine entries only ever contain `https://www.youtube.com/watch?v=<id>` (built in `trendAnalysisService`), so the change is behavior-equivalent for real data and fails closed. When nothing is filtered the original object is returned untouched, preserving referential identity for the memo / cache-buster call sites.

## Not changed (flagged on the issue)

Dependency CVEs (devDependencies only — `npm audit --omit=dev` reports 0), the API-key query-parameter transport (needs a deliberate CORS-preflight decision), and the i18n `escapeValue: false` default (no HTML sinks exist). CSP `img-src`/`style-src` tightening, non-root nginx, workflow SHA-pinning and the Vite dev-server bind stay deferred.

## Verification

`npm ci` → `format:check` → `typecheck` → `lint` → `build` — all green. This repo has no test framework configured, so no test step ran and none was added.

Refs #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYJ8ELApy4VBMdyMkRsH1B)_