### PR TITLE
chore: quality & housekeeping sweep (Vite+React)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,9 @@ Review findings not immediately fixed. **Only work on these upon explicit reques
 
 ## Open
 
-_No open findings._
+| #   | Date       | Category | Sev | Location                | Finding                                                                                                                                                                                                   | Status   | Source                                           |
+| --- | ---------- | -------- | --- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------ |
+| 15  | 2026-08-23 | Testing  | P2  | package.json -> scripts | No test framework configured — the gate is `format:check` → `typecheck` → `lint` → `build` only, so no behavioural regression is caught. Vitest recommended; priority targets in `agent_docs/testing.md`. | Deferred | Routine: quality & housekeeping sweep 2026-08-23 |
 
 ## Done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Three schedulers, different lifetimes: **Routines** (cloud, durable, ≥1 h, sur
 
 ## Tech Stack
 
-TypeScript ~6.0.3 (strict) · React ^19.2 + Vite ^8.0 · Tailwind CSS v4 (`@tailwindcss/vite`) · i18next ^26 · Lucide React ^1.18 · Node.js 22+ · npm (lockfile v3) · Prettier ^3 · ESLint 9 flat config. **No test framework configured.**
+TypeScript ~6.0.3 (strict) · React ^19.2 + Vite ^8.2 · Tailwind CSS v4 (`@tailwindcss/vite`) · i18next ^26 · Lucide React ^1.31 · Node.js 22+ · npm (lockfile v3) · Prettier ^3 · ESLint 9 flat config. **No test framework configured.**
 
 Full version table + the Electron / Capacitor / Chrome-extension / Docker wrappers around the same `dist/`: `agent_docs/platform_builds.md`
 

--- a/agent_docs/platform_builds.md
+++ b/agent_docs/platform_builds.md
@@ -10,10 +10,10 @@ TubeTrend ships one web build (`dist/`) that every other target wraps. Nothing u
 | --------------- | ---------------------------------- | --------- |
 | Language        | TypeScript (strict)                | ~6.0.3    |
 | UI Framework    | React                              | ^19.2.7   |
-| Build Tool      | Vite (+ `@vitejs/plugin-react`)    | ^8.0.16   |
+| Build Tool      | Vite (+ `@vitejs/plugin-react`)    | ^8.2.1    |
 | Styling         | Tailwind CSS (`@tailwindcss/vite`) | ^4.3.1    |
 | i18n            | i18next + react-i18next            | ^26 / ^17 |
-| Icons           | Lucide React                       | ^1.18.0   |
+| Icons           | Lucide React                       | ^1.31.0   |
 | Runtime         | Node.js                            | 22+       |
 | Package Manager | npm (lockfile v3)                  | —         |
 | Formatter       | Prettier                           | ^3        |

--- a/agent_docs/refactoring_guidelines.md
+++ b/agent_docs/refactoring_guidelines.md
@@ -22,13 +22,13 @@ Refactoring does NOT happen automatically. Only when:
 
 ## Known Refactoring Targets
 
-Verified against the tree on 2026-08-16. Line counts come from `find src -name '*.ts*' | xargs wc -l | sort -rn`; re-run it before trusting a number here.
+Verified against the tree on 2026-08-23. Line counts come from `find src -name '*.ts*' | xargs wc -l | sort -rn`; re-run it before trusting a number here.
 
-- **`InputSection.tsx` (~775 lines)** — the largest file in `src/`. Search form, autocomplete, search history, timeframe/max-results controls and their `localStorage` persistence in one component. Split candidates: a `useSearchHistory()` hook and a separate autocomplete dropdown component.
-- **`FavoriteRow.tsx` (~734 lines)** — God component handling data fetching, caching, UI menus, state management and event handling, with 11 interdependent `useEffect` hooks plus refs for synchronization. Should be split into sub-components (`FavoriteRowHeader`, `FavoriteRowMenus`, `FavoriteRowVideos`) and a custom `useFavoriteRowData()` hook that absorbs the effect chain.
-- **`ApiQuotaIndicator.tsx` (~726 lines)** — quota badge, history panel and time-window selection in one file. The window/aggregation math is pure and extractable into a service, which would also make it the first easily testable target here.
+- **`InputSection.tsx` (~778 lines)** — the largest file in `src/`. Search form, autocomplete, search history, timeframe/max-results controls and their `localStorage` persistence in one component. Split candidates: a `useSearchHistory()` hook and a separate autocomplete dropdown component.
+- **`FavoriteRow.tsx` (~755 lines)** — God component handling data fetching, caching, UI menus, state management and event handling, with 11 interdependent `useEffect` hooks plus refs for synchronization. Should be split into sub-components (`FavoriteRowHeader`, `FavoriteRowMenus`, `FavoriteRowVideos`) and a custom `useFavoriteRowData()` hook that absorbs the effect chain.
+- **`ApiQuotaIndicator.tsx` (~739 lines)** — quota badge, history panel and time-window selection in one file. The window/aggregation math is pure and extractable into a service, which would also make it the first easily testable target here.
 - **`AnalyserPage.tsx` (~599 lines)** — page shell plus sort/topN state, export handlers and clipboard handling. Extract the export + copy-all actions.
-- **`DashboardPage.tsx` (~519 lines)** — page shell plus favorites filtering, import/export picking, refresh-progress tracking and highlight aggregation. Newly over the 500-line bar. The `useMemo` filter/aggregation chain (`favoriteHaystacks`, `matchingFavoriteIds`, `highlightVideosData`) is the natural extraction into a `useDashboardFilters()` hook.
+- **`DashboardPage.tsx` (~642 lines)** — page shell plus favorites filtering, import/export picking, refresh-progress tracking and highlight aggregation. Newly over the 500-line bar. The `useMemo` filter/aggregation chain (`favoriteHaystacks`, `matchingFavoriteIds`, `highlightVideosData`) is the natural extraction into a `useDashboardFilters()` hook.
 - **No test coverage** — no test framework is configured. Critical services (`favoritesService`, `trendAnalysisService`, `quotaService`, `eventBus`, `storage`) would benefit from unit tests; priority order in `agent_docs/testing.md`.
 
 ### Resolved — do not re-open


### PR DESCRIPTION
## Description

Automated quality & housekeeping sweep (2026-08-23). Documentation-only changes — three commits, no source file and no dependency touched.

## Type of Change

- [x] Documentation update

## Merged findings

| # | Pass | Datei(en) | Befund | Fix | Aufwand | Empfehlung | Status |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | E (Docs) | `agent_docs/platform_builds.md`, `CLAUDE.md` | Stack tables listed Vite `^8.0.16` and Lucide React `^1.18.0`; `package.json` declares `^8.2.1` and `^1.31.0` | Corrected both version cells / the CLAUDE.md stack line | S | auto-fix | in this PR |
| 2 | E (Docs) | `agent_docs/refactoring_guidelines.md` | Refactoring-target line counts stale; `DashboardPage.tsx` listed at ~519 lines, actually 642 | Re-measured with `wc -l`, refreshed all four numbers + the verification date | S | auto-fix | in this PR |
| 3 | C (Tests) | `package.json` → `scripts` | No test framework configured | none — recorded as `BACKLOG.md` #15 | L | defer Backlog | deferred |

Passes A (formatting), B (linting), D (unused deps) and F (stale TODO / dead code) produced no findings: `prettier --check` reports no drift, `eslint .` is clean, no `TODO`/`FIXME`/`HACK`/`XXX` marker and no commented-out block >10 lines exists under `src/`, `electron/`, `scripts/` or `chrome-extension/`, and the grep heuristic found no removable declared dependency.

## Tooling status

| Tool | Aktiv | Lief grün |
| --- | --- | --- |
| Prettier 3.9.6 (`format:check`) | yes | yes (exit 0) |
| ESLint 9 flat (`lint`) | yes | yes (exit 0) |
| TypeScript (`typecheck`) | yes | yes (exit 0) |
| Vite build (`build`) | yes | yes (exit 0, 753 ms) |
| Test runner | no | n/a — no framework configured |

Verification chain run after all commits: `npm ci` → `format:check` → `lint` → `typecheck` → `build`. All green.

## Scope note

**No version bumps are included.** No version string in `package.json` was changed and `package-lock.json` is byte-identical to `main`. Dependency updates and the 8 open Dependabot PRs are out of scope for this routine.

## Related Issues

Closes #406


---
_Generated by [Claude Code](https://claude.ai/code/session_01584qP9vt4y4BBTEVmuBs4Q)_