### PR TITLE
feat: comfort sweep (React 19 + Vite 8 + TypeScript 6 + Tailwind 4)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -26,6 +26,8 @@ Session-spanning project knowledge. **Read at session start, update during work.
 
 - **ESLint suppressions need a reason, and `exhaustive-deps` is not always right (2026-08-11)** — this codebase leans on cache-buster dependencies (`cacheTick`, `hiddenTick`, `i18n.resolvedLanguage`, refresh tokens): counters listed in a dep array but never read in the body, because the memo/effect reads `localStorage` imperatively. `exhaustive-deps` calls those "unnecessary" — removing them freezes stale data on screen. Every such site carries an `// eslint-disable-next-line react-hooks/exhaustive-deps` with the reason above it. Never strip one without checking what the imperative read is. (2026-08-11)
 
+- **`InputSection.handleFocus` reopens a dropdown on _any_ focus, programmatic ones included (2026-08-24)** — the input's `onFocus` opens the history list (empty input) or the channel suggestions (≥2 chars), so a bare `searchInputRef.current.focus()` immediately reopens the dropdown the caller just closed. `refocusSearchInput()` exists for that: it raises `suppressFocusOpenRef` around the `.focus()` call, which `handleFocus` checks first. Native `focus()` dispatches `focusin` synchronously, so the flag is still up when React's handler runs. Never call `.focus()` on that input directly.
+
 - **TypeScript 6 defaults changed (2026-04)** — TS 6 changes many defaults (types=[], esModuleInterop=true, noUncheckedSideEffectImports=true). Our tsconfig explicitly sets most values so impact was minimal. `baseUrl` is deprecated in TS 6 — removed it since paths already use `"./"` prefixes. (2026-04-06)
 
 ## Working Context

--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ Enter your API key in the app when prompted.
 ## Features
 
 - **Dashboard** — Track favorite channels and keywords with cached video data
-- **Analyser** — Search and analyze videos with trend scoring
+- **Analyser** — Search and analyze videos with trend scoring; a failed search can be retried
+  straight from the error banner
 - **Highlights** — Auto-surface top-performing videos, copy their URLs or export them as CSV
 - **Desktop App** — Portable Electron app for Windows, macOS, and Linux
 - **Chrome Extension** — Install as browser extension, opens in a new tab

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Enter your API key in the app when prompted.
 
 - **Dashboard** — Track favorite channels and keywords with cached video data
 - **Analyser** — Search and analyze videos with trend scoring
-- **Highlights** — Auto-surface top-performing videos
+- **Highlights** — Auto-surface top-performing videos, copy their URLs or export them as CSV
 - **Desktop App** — Portable Electron app for Windows, macOS, and Linux
 - **Chrome Extension** — Install as browser extension, opens in a new tab
 - **Multi-language** — English and German translations; 11 further locales auto-detect and fall back to English

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -78,7 +78,7 @@ const App: React.FC = () => {
   }, []);
 
   const searchOptions = useMemo(() => ({ onApiKeyInvalid }), [onApiKeyInvalid]);
-  const { searchState, handleSearch, setSearchResult, resetSearch } = useSearch(
+  const { searchState, handleSearch, setSearchResult, resetSearch, retrySearch } = useSearch(
     apiKey,
     searchOptions,
   );
@@ -380,6 +380,7 @@ const App: React.FC = () => {
             onSearch={handleSearch}
             onPickExample={handlePickExample}
             onClearResults={resetSearch}
+            onRetrySearch={retrySearch}
           />
         )}
       </main>

--- a/src/app/routes/AnalyserPage.tsx
+++ b/src/app/routes/AnalyserPage.tsx
@@ -8,6 +8,7 @@ import {
   FileJson,
   List,
   Loader2,
+  RefreshCw,
   RotateCcw,
   Trophy,
 } from "lucide-react";
@@ -50,6 +51,8 @@ interface AnalyserPageProps {
   onPickExample?: (query: string, searchType: SearchType) => void;
   /** Clear the current analysis (and its persisted snapshot), returning to the welcome screen. */
   onClearResults?: () => void;
+  /** Run the failed search again with the arguments it used. */
+  onRetrySearch?: () => void;
 }
 
 export function AnalyserPage({
@@ -58,6 +61,7 @@ export function AnalyserPage({
   onSearch,
   onPickExample,
   onClearResults,
+  onRetrySearch,
 }: AnalyserPageProps) {
   const { t } = useTranslation();
 
@@ -278,10 +282,27 @@ export function AnalyserPage({
       {searchState.error && (
         <div
           role="alert"
-          className="mb-8 bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-center gap-3 text-red-500 dark:text-red-200 animate-fade-in shadow-lg shadow-red-900/10"
+          className="mb-8 bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex flex-wrap items-center gap-3 text-red-500 dark:text-red-200 animate-fade-in shadow-lg shadow-red-900/10"
         >
           <AlertCircle className="w-5 h-5 shrink-0" aria-hidden="true" />
-          <p>{searchState.error}</p>
+          <p className="min-w-0 grow">{searchState.error}</p>
+          {/* One-click recovery for the transient half of these errors (dropped
+              connection, HTTP 5xx, an empty video list from a channel that does
+              have uploads). Without it the only way back was scrolling up to the
+              search box and pressing Search again. No disabled state is needed:
+              a retry clears `error` before its first await, so this whole banner
+              is gone by the time a second click could land. */}
+          {onRetrySearch && (
+            <button
+              type="button"
+              onClick={onRetrySearch}
+              className="inline-flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-red-500/30 text-sm font-medium transition-colors hover:bg-red-500/10"
+              title={t("results.retryTitle")}
+            >
+              <RefreshCw className="w-4 h-4" aria-hidden="true" />
+              <span>{t("results.retry")}</span>
+            </button>
+          )}
         </div>
       )}
 

--- a/src/app/routes/DashboardPage.tsx
+++ b/src/app/routes/DashboardPage.tsx
@@ -25,6 +25,8 @@ import {
   hiddenHighlightsService,
   selectHighlightVideosFromFavorites,
 } from "@/src/features/dashboard";
+import { buildResultsCsv, buildResultsCsvFilename } from "@/src/features/videos";
+import { downloadBlob } from "@/src/shared/lib/download";
 import { getLocale } from "@/src/shared/lib/locale";
 import type { DashboardSortMode } from "@/src/shared/types";
 
@@ -232,6 +234,27 @@ export function DashboardPage({
     setPendingJumpId(null);
   }, [pendingJumpId]);
 
+  // Export every visible highlight as CSV. The analyser has offered CSV/JSON for
+  // its result list for a while; the dashboard could only copy bare URLs, so
+  // getting the day's highlights into a sheet meant pasting links and refilling
+  // views, velocity and score by hand. Same builder as the analyser export, so
+  // both files share one column layout and one CSV-injection guard.
+  const handleExportHighlightsCsv = () => {
+    if (highlightVideos.length === 0) return;
+    try {
+      const csv = buildResultsCsv(highlightVideos.map((item) => item.video));
+      downloadBlob(
+        buildResultsCsvFilename("highlights"),
+        new Blob([csv], { type: "text/csv;charset=utf-8;" }),
+      );
+      showToast(t("dashboard.highlights.exportDone"), "success");
+    } catch {
+      // The download can be blocked (sandboxed iframe, hardened Electron
+      // window) — never report a file the browser refused to write.
+      showToast(t("dashboard.highlights.exportFailed"), "error");
+    }
+  };
+
   const handleCopyAllHighlights = () => {
     if (highlightVideos.length === 0) return;
     // navigator.clipboard is undefined in insecure contexts (HTTP, some
@@ -340,6 +363,20 @@ export function DashboardPage({
                       <Copy className="w-3 h-3" aria-hidden="true" />
                     )}
                     <span className="whitespace-nowrap">{t("dashboard.highlights.copyAll")}</span>
+                  </button>
+                )}
+                {highlightVideos.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={handleExportHighlightsCsv}
+                    className="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-md border transition-colors
+                             border-slate-300 text-slate-700 hover:bg-slate-100
+                             dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                    title={t("dashboard.highlights.exportCsvTitle")}
+                    aria-label={t("dashboard.highlights.exportCsvTitle")}
+                  >
+                    <Download className="w-3 h-3" aria-hidden="true" />
+                    <span className="whitespace-nowrap">{t("dashboard.highlights.exportCsv")}</span>
                   </button>
                 )}
                 <button

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -111,6 +111,14 @@ interface UseSearchOptions {
   onApiKeyInvalid?: () => void;
 }
 
+/** The arguments of the most recent analyser run, kept so it can be repeated. */
+interface LastSearchArgs {
+  query: string;
+  timeFrame: TimeFrame;
+  maxResults: number;
+  searchType: SearchType;
+}
+
 export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
   const { t } = useTranslation();
   const [searchState, setSearchState] = useState<SearchState>(restoreInitialSearchState);
@@ -121,6 +129,11 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
   // results and persists a stale snapshot that survives the next reload. Same
   // pattern InputSection already uses for its autocomplete lookups.
   const searchRequestRef = useRef(0);
+  // Arguments of the last run, so a failed search can be repeated verbatim.
+  // A ref (not state) because nothing renders from it directly — `retrySearch`
+  // reads it at click time, and storing it in state would re-render the whole
+  // analyser on every search for no visible change.
+  const lastSearchArgsRef = useRef<LastSearchArgs | null>(null);
 
   const handleSearch = useCallback(
     async (
@@ -136,6 +149,7 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
 
       const requestId = ++searchRequestRef.current;
       const isStale = () => requestId !== searchRequestRef.current;
+      lastSearchArgsRef.current = { query, timeFrame, maxResults, searchType };
 
       setSearchState((prev) => ({
         ...prev,
@@ -255,10 +269,28 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
     [],
   );
 
+  /**
+   * Run the last search again with the exact arguments it used.
+   *
+   * Most analyser errors are transient — a dropped connection, an HTTP 5xx from
+   * YouTube, a channel lookup that returned no video list. The banner stated the
+   * problem but offered no way out: the search box sits above the fold-height
+   * results area, so recovering meant scrolling back up and pressing Search
+   * again. Nothing is retried automatically; the user decides when.
+   */
+  const retrySearch = useCallback(() => {
+    const args = lastSearchArgsRef.current;
+    if (!args) return;
+    void handleSearch(args.query, args.timeFrame, args.maxResults, args.searchType);
+  }, [handleSearch]);
+
   const resetSearch = useCallback(() => {
     // Clearing supersedes any run still in flight, otherwise its late response
     // would repopulate the view the user just emptied.
     searchRequestRef.current += 1;
+    // The cleared view has no search behind it any more — a Retry offered after
+    // this would silently resurrect a query the user just dismissed.
+    lastSearchArgsRef.current = null;
     clearPersistedResult();
     setSearchState(initialSearchState);
   }, []);
@@ -268,5 +300,6 @@ export function useSearch(apiKey: string | null, options?: UseSearchOptions) {
     handleSearch,
     setSearchResult,
     resetSearch,
+    retrySearch,
   };
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -137,7 +137,11 @@
       "copyAll": "Alle kopieren",
       "copyAllUrls": "Alle Highlight-URLs kopieren",
       "copyAllDone": "Alle Highlight-URLs kopiert",
-      "copyAllFailed": "Zwischenablage nicht verfügbar"
+      "copyAllFailed": "Zwischenablage nicht verfügbar",
+      "exportCsv": "CSV",
+      "exportCsvTitle": "Alle Highlights als CSV exportieren",
+      "exportDone": "Highlights als CSV exportiert.",
+      "exportFailed": "Export fehlgeschlagen. Dein Browser hat die Datei blockiert."
     },
     "filter": {
       "placeholder": "Favoriten filtern…",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -217,6 +217,8 @@
     "exportFailed": "Export fehlgeschlagen",
     "clear": "Zurücksetzen",
     "clearTitle": "Ergebnisse zurücksetzen",
+    "retry": "Erneut versuchen",
+    "retryTitle": "Die letzte Suche erneut ausführen",
     "analyzedAgo": "Analysiert {{time}}",
     "announceLoading": "Ergebnisse werden geladen…",
     "announceResults_one": "{{count}} Video für {{channel}} gefunden.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -137,7 +137,11 @@
       "copyAll": "Copy all",
       "copyAllUrls": "Copy all highlight URLs",
       "copyAllDone": "All highlight URLs copied",
-      "copyAllFailed": "Clipboard unavailable"
+      "copyAllFailed": "Clipboard unavailable",
+      "exportCsv": "CSV",
+      "exportCsvTitle": "Export all highlights as CSV",
+      "exportDone": "Highlights exported as CSV.",
+      "exportFailed": "Export failed. Your browser blocked the file."
     },
     "filter": {
       "placeholder": "Filter favorites…",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -217,6 +217,8 @@
     "exportFailed": "Export failed",
     "clear": "Clear",
     "clearTitle": "Clear results",
+    "retry": "Retry",
+    "retryTitle": "Run the last search again",
     "analyzedAgo": "Analyzed {{time}}",
     "announceLoading": "Loading results…",
     "announceResults_one": "{{count}} video found for {{channel}}.",

--- a/src/shared/components/ui/InputSection.tsx
+++ b/src/shared/components/ui/InputSection.tsx
@@ -94,6 +94,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  // Set while focus is being returned to the input programmatically, so the
+  // focus handler below does not immediately reopen the dropdown we just closed.
+  const suppressFocusOpenRef = useRef(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Generation counter for suggestion lookups: bumped whenever the input
   // changes or is cleared so pending timers / in-flight responses for an
@@ -108,6 +111,21 @@ export const InputSection: React.FC<InputSectionProps> = ({
     suggestionRequestRef.current += 1;
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     setIsSearchingSuggestions(false);
+  };
+
+  /**
+   * Return focus to the search input after a dropdown entry was picked.
+   *
+   * Picking an entry unmounts the button that was clicked, so focus fell back to
+   * `<body>`: the query was filled in, but Enter did nothing and a keyboard user
+   * had to tab back into the form to run the search they had just chosen.
+   * The suppress flag keeps `handleFocus` from reopening the dropdown that the
+   * selection just closed — it would otherwise fire on this very focus call.
+   */
+  const refocusSearchInput = () => {
+    suppressFocusOpenRef.current = true;
+    searchInputRef.current?.focus();
+    suppressFocusOpenRef.current = false;
   };
 
   // Clear timers on unmount to avoid state updates on unmounted component
@@ -300,6 +318,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
     setSuggestions([]);
     setShowSuggestions(false);
     setShowHistory(false);
+    refocusSearchInput();
   };
 
   const clearInput = () => {
@@ -348,6 +367,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
   };
 
   const handleFocus = () => {
+    // Focus was handed back after picking an entry — the dropdown closed on
+    // purpose, so leave it closed.
+    if (suppressFocusOpenRef.current) return;
     // Show history only when input is empty and there is history
     if (inputValue.length === 0 && history.length > 0) {
       setShowHistory(true);
@@ -366,7 +388,9 @@ export const InputSection: React.FC<InputSectionProps> = ({
   const selectHistoryItem = (val: string) => {
     setInputValue(val);
     setShowHistory(false);
-    // Do not trigger search automatically; user can submit
+    // Do not trigger search automatically; user can submit — but hand focus back
+    // so submitting is a single Enter instead of a hunt for the Search button.
+    refocusSearchInput();
   };
 
   const removeHistoryItem = (val: string) => {


### PR DESCRIPTION
## Description

Three self-contained comfort/quality features, one commit each. No new dependency, no architectural change — everything reuses the established patterns (typed event bus, `showToast`, the videos-feature export builders, i18n keys in both `en` and `de`).

| # | Bereich/Datei | Kategorie | Feature | Nutzen | Aufwand |
|---|---------------|-----------|---------|--------|---------|
| 1 | `InputSection.tsx` | Komfort | Refocus the search input after picking a suggestion or history entry | Picking an entry unmounted the clicked button, so focus fell back to `<body>`: the query was filled in but Enter did nothing and the user had to hunt for the Search button. Now one Enter runs the search that was just chosen. | S |
| 2 | `DashboardPage.tsx` | Komfort | Export dashboard highlights as CSV | The analyser has offered CSV/JSON for its result list for a while; the dashboard could only copy bare URLs, so getting the day's highlights into a sheet meant pasting links and refilling views, velocity and score by hand. | S |
| 3 | `useSearch.ts`, `AnalyserPage.tsx` | Qualität | Retry a failed search straight from the error banner | Most analyser errors are transient (dropped connection, HTTP 5xx, a channel that resolves but returns no video list). The banner named the problem and stopped there; recovering meant scrolling back up to the search box. | M |

### Notes on the implementation

- **(1)** `refocusSearchInput()` raises a suppress flag around the `.focus()` call, because `handleFocus` reopens a dropdown on *any* focus event — programmatic ones included — and would otherwise reopen the list the selection just closed. Native `focus()` dispatches `focusin` synchronously, so the flag is still up when React's handler runs. Recorded in `MEMORY.md` as a gotcha. Neither selection triggers a search automatically; that behaviour is unchanged.
- **(2)** Reuses `buildResultsCsv` / `buildResultsCsvFilename`, so both exports share one column layout and one CSV-injection guard. A blocked download raises an error toast rather than claiming success — same contract as the dashboard backup export.
- **(3)** The last run's arguments live in a ref, not state: `retrySearch` reads them at click time, and keeping them in state would re-render the analyser on every search for no visible change. Nothing retries automatically, and `resetSearch()` drops the remembered arguments so a cleared view cannot resurrect a dismissed query.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update (README feature list, `MEMORY.md` gotcha)

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code (one finding fixed before commit: a dead `disabled`/spinner on the Retry button whose comment claimed a double-click guard the unmounting banner already provides)
- [x] Added translations for new UI text — 6 new keys in both `en.json` and `de.json`
- [x] Tested locally: `format:check` → `typecheck` → `lint` → `build`, all green. No test framework is configured in this repo, so no suite was run.

## Related Issues

Closes #409

<!-- screenshot: optional -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb9QmXMRvpZJK5uEsGedav)_