### PR TITLE
refactor: best-practice sweep (Vite 8 + React 19 + TS 6)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      # Format first, in the same order pr-checks.yml uses. This job guards the
+      # only workflow that publishes on its own (push to main ->
+      # ghcr.io/fo0/tubetrend:latest), so it must not be weaker than the PR
+      # gate: a commit that reaches main without passing pr-checks — a direct
+      # push, an admin merge, or a PR whose paths-ignore skipped it — would
+      # otherwise publish an image built from a tree the PR gate rejects.
+      - name: Check Prettier formatting
+        run: npm run format:check
+
       # Diese Skripte sollten in der package.json vorhanden sein
       # (Vite Standard-Templates haben 'lint' und 'tsc' meist integriert)
       - name: Run Type Check

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -3,12 +3,7 @@
  */
 
 // Services
-export {
-  hiddenHighlightsService,
-  type HiddenHighlight,
-  type HiddenHighlightEntry,
-  type HiddenHighlightMeta,
-} from "./services/hiddenHighlightsService";
+export { hiddenHighlightsService, type HiddenHighlight } from "./services/hiddenHighlightsService";
 export {
   dashboardBackupService,
   type DashboardBackupPayload,

--- a/src/features/dashboard/services/hiddenHighlightsService.ts
+++ b/src/features/dashboard/services/hiddenHighlightsService.ts
@@ -20,14 +20,6 @@ export interface HiddenHighlight {
   sourceLabel?: string; // Channel/favorite name for display in the list
 }
 
-// Keep old type names for backwards compatibility
-export type HiddenHighlightEntry = HiddenHighlight;
-export interface HiddenHighlightMeta {
-  readonly title?: string;
-  readonly thumbnailUrl?: string;
-  readonly channelTitle?: string;
-}
-
 export const hiddenHighlightsService = {
   /**
    * Returns all hidden highlights.
@@ -105,48 +97,10 @@ export const hiddenHighlightsService = {
   },
 
   /**
-   * Alias for show() - for API compatibility
-   */
-  unhide(videoId: string): void {
-    this.show(videoId);
-  },
-
-  /**
-   * Alias for show() - for API compatibility
-   */
-  remove(videoId: string): void {
-    this.show(videoId);
-  },
-
-  /**
-   * Checks whether a video is hidden (by its unique videoId).
-   * Once hidden, a video stays hidden permanently.
-   */
-  isHidden(videoId: string): boolean {
-    return this.list().some((h) => h.videoId === videoId);
-  },
-
-  /**
    * Removes all hidden highlights.
    */
   clearAll(): void {
     safeWrite(HIDDEN_HIGHLIGHTS_KEY, []);
     dispatchEvent("hidden-highlights-changed");
-  },
-
-  /**
-   * Returns the count of hidden highlights.
-   */
-  count(): number {
-    return this.list().length;
-  },
-
-  /**
-   * Cleans up stale entries for sourceIds that no longer exist in favorites.
-   */
-  cleanup(validSourceIds: string[]): void {
-    const validSet = new Set(validSourceIds);
-    const list = this.list().filter((h) => validSet.has(h.sourceId));
-    safeWrite(HIDDEN_HIGHLIGHTS_KEY, list);
   },
 };

--- a/src/shared/lib/eventBus.ts
+++ b/src/shared/lib/eventBus.ts
@@ -45,17 +45,17 @@ class EventBus {
     event: K,
     ...args: EventPayload<K> extends undefined ? [] : [EventPayload<K>]
   ): void {
+    // The bus is the only delivery channel. A mirrored `window.dispatchEvent`
+    // used to run alongside this loop for consumers still written as raw
+    // `window.addEventListener`; all of those were migrated to `eventBus.on()`
+    // / `useEventBus()`, leaving the mirror with no subscriber — it only
+    // allocated a CustomEvent per emit on hot paths (`quota-updated` fires on
+    // every API call, `favorites-cache-updated` on every favorite refresh) and
+    // published internal names, `toast` among them, into the global DOM event
+    // namespace where anything sharing the window can observe or forge them.
+    // Do not reintroduce it: a new subscriber belongs on `eventBus.on()`,
+    // which is the typed path.
     this.listeners.get(event)?.forEach((cb) => cb(args[0]));
-
-    // Also dispatch a DOM event for backward compatibility
-    if (typeof window !== "undefined") {
-      try {
-        const detail = args[0] ?? undefined;
-        window.dispatchEvent(new CustomEvent(event, { detail }));
-      } catch {
-        // Ignore
-      }
-    }
   }
 }
 
@@ -71,7 +71,9 @@ export function useEventBus<K extends EventKey>(event: K, callback: EventCallbac
 }
 
 /**
- * Backward-compatible emit function that uses both eventBus and window events
+ * Emit a bus event from outside a component (services, plain callbacks).
+ * Thin alias for `eventBus.emit` — kept because it reads better at the call
+ * sites that raise events from non-React code.
  */
 export function dispatchEvent<K extends EventKey>(
   event: K,

--- a/src/shared/lib/locale.ts
+++ b/src/shared/lib/locale.ts
@@ -1,11 +1,22 @@
 import i18n from "@/src/i18n/config";
 
 /**
- * Returns the active i18n language tag (e.g. 'en', 'de').
+ * Returns the language tag the UI is actually rendered in (e.g. 'en', 'de').
  * Used by sort/format helpers in non-React modules so locale-sensitive
  * behaviour follows the user's chosen UI language instead of being
  * hardcoded to one locale.
+ *
+ * `resolvedLanguage`, not `language`: `i18n.language` is the *requested*
+ * language, and `supportedLngs` in i18n/config.ts lists 13 of them while only
+ * `en` and `de` ship resource bundles. A browser set to French therefore leaves
+ * `i18n.language === "fr"` while every string on screen comes from the `en`
+ * fallback — and `Intl.NumberFormat("fr")` then rendered French separators
+ * ("1 234 567", "24/08/2026") next to English text, in a document that same
+ * config tags `lang="en"` for exactly this reason. `resolvedLanguage` is the
+ * first language in the fallback chain that has translations, i.e. the one the
+ * user really sees. For `en` and `de` the two values are identical, so nothing
+ * changes for a user who has a bundle.
  */
 export function getLocale(): string {
-  return i18n.language || "en";
+  return i18n.resolvedLanguage || i18n.language || "en";
 }


### PR DESCRIPTION
## Description

Automated best-practice sweep. Four findings, one commit each, no feature changes and no style-only churn outside them.

| #   | File                                                                          | Category           | Finding                                                                                                                                | Fix                                                                       | Effort | Recommendation |
| --- | ----------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------ | -------------- |
| 1   | `src/shared/lib/locale.ts`                                                    | Correctness (i18n) | `getLocale()` returned `i18n.language` — the _requested_ language. Only `en` and `de` ship bundles while `supportedLngs` lists 13.      | Return `i18n.resolvedLanguage` first.                                     | S      | auto-fix       |
| 2   | `.github/workflows/docker-publish.yml`                                        | Correctness (CI)   | The gate before the automatic GHCR publish ran typecheck and lint but not `format:check` — weaker than `pr-checks.yml`.                 | Add the missing step, format-first.                                       | S      | auto-fix       |
| 3   | `src/shared/lib/eventBus.ts`                                                  | Performance        | `emit()` mirrored every event as a `window` `CustomEvent` for raw-listener consumers that no longer exist.                              | Remove the mirror.                                                        | S      | auto-fix       |
| 4   | `src/features/dashboard/services/hiddenHighlightsService.ts` + feature barrel | Maintainability    | `unhide`, `remove`, `isHidden`, `count`, `cleanup` and two legacy type aliases had zero callers.                                        | Delete them.                                                              | M      | auto-fix       |

**Finding 1** is the only user-visible one: a browser set to one of the eleven listed-but-unbundled languages (fr, es, it, pt, nl, pl, tr, ru, ja, zh, ko) rendered English text with that language's number and date formatting, inside a document `i18n/config.ts` deliberately tags `lang="en"` for the very same reason. For `en` and `de` the two values are identical, so nothing changes for a user who has a bundle.

**Finding 3** removes work, not behavior: no `addEventListener` in `src/` targets an `EventMap` key, and neither the Chrome extension nor the Electron shell listens for one. It also takes internal event names — `toast` among them — back out of the global DOM event namespace.

**Finding 4** is removal only, proven by `tsc --noEmit`. `cleanup()` was the one place that pruned hidden entries for deleted favorites and it was never wired up; that housekeeping gap is filed in the issue rather than lost with the code.

### Not in this PR

The German comment block in `FavoriteRow.tsx`, the 15 cross-feature deep imports, the TTL-less `yt_channel_cache`, the never-rendered `VideoData.reasoning`, the unused `AbortSignal` parameter and the `npm audit` advisories are all recorded as deferred findings on the issue with the reason each was left alone.

An early `format:check` in this run flagged three files; that run had resolved a stray Prettier via `npx` while `node_modules` was absent. Under the pinned Prettier 3.9.6, `main` is fully format-clean — no formatting change is included.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Refactor / correctness — behavior-preserving except for the deliberate i18n locale correction in finding 1.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed my code
- [x] Added translations for new UI text (if applicable) — no new UI text
- [x] Tested locally — `format:check` → `lint` → `typecheck` → `build` all exit 0; the repo has no test runner

## Verification

```
npm install        exit 0  (package-lock.json unchanged)
npm run format:check exit 0
npm run lint         exit 0
npm run typecheck    exit 0
npm run build        exit 0  (built in 1.33s)
```

No test stage exists in this project — that is configuration, not a skipped check.

## Related Issues

Closes #411


---
_Generated by [Claude Code](https://claude.ai/code/session_018SxQLaDCH4YfF4dSdbLFuF)_